### PR TITLE
Fix scroll down and up in double-page mode.

### DIFF
--- a/shortcuts.c
+++ b/shortcuts.c
@@ -385,8 +385,12 @@ sc_navigate(girara_session_t* session, girara_argument_t* argument,
     }
   }
 
-  if ((new_page < 0 || new_page >= number_of_pages) && !scroll_wrap) {
-    return false;
+  if (!scroll_wrap) {
+    if (new_page <= 0) {
+      new_page = 0;
+    } else if (new_page >= number_of_pages) {
+      new_page = number_of_pages - 1;
+    }
   }
 
   page_set(zathura, new_page);


### PR DESCRIPTION
This commit fixes the bug described here: http://bugs.pwmt.org/issue414

When you are in double-page (or more), and push page-down, the current page increase by 2. For instance, you are at page 8, it goes to 10. However, if there are 9 pages and this page is alone on its row, it won't work.

This fixes it by simply considering that a negative number is page 0 and a number greater or equal to the number of page is the last page.
