### PR TITLE
Removing "Failed to loads bookmarks"

### DIFF
--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -828,7 +828,7 @@ document_open(zathura_t* zathura, const char* path, const char* password,
   /* bookmarks */
   if (zathura->database != NULL) {
     if (zathura_bookmarks_load(zathura, file_path) == false) {
-      girara_warning("Failed to loads bookmarks.");
+      girara_debug("Failed to load bookmarks.");
     }
 
     /* jumplist */


### PR DESCRIPTION
This warning in Zathura is a nuisance for a number of reasons:
* Warning appears under perfectly normal conditions as you may not have made any bookmarks or may not use them
* Using Zathura as a PDF viewer with vim-latex can cause text to be written over the terminal when it shows this unnecessary warning as it repeatedly appears whenever the PDF is recompiled
* There are other warning and error messages for when the bookmarks file really can't be read
* `Failed to loads bookmarks` has an annoying typo