### PR TITLE
Fix dual page render breakge of adjust_window

### DIFF
--- a/zathura/shortcuts.c
+++ b/zathura/shortcuts.c
@@ -1240,6 +1240,7 @@ sc_toggle_page_mode(girara_session_t* session, girara_argument_t*
   }
 
   girara_setting_set(zathura->ui.session, "pages-per-row", &value);
+  adjust_view(zathura);
 
   return true;
 }


### PR DESCRIPTION
When the page is set to adjust width to the window, toggling dual page mode would break rendering because
sc_toggle_page_mode() did not update dimensions.

To reproduce,
1. Open a file
2. Press "s", switch to fit-to-width mode
3. Press "d", switch to dual page mode
4. Broken pages are shown.

This patch resolves https://bugs.pwmt.org/issue446.