### PR TITLE
replaced deprecated gdk_cursor_new()

### DIFF
--- a/zathura/callbacks.c
+++ b/zathura/callbacks.c
@@ -622,7 +622,7 @@ cb_page_widget_link(ZathuraPage* page, void* data)
   bool enter = (bool) data;
 
   GdkWindow* window = gtk_widget_get_parent_window(GTK_WIDGET(page));
-  GdkCursor* cursor = gdk_cursor_new(enter == true ? GDK_HAND1 : GDK_LEFT_PTR);
+  GdkCursor* cursor = gdk_cursor_new_for_display(gdk_display_get_default(), enter == true ? GDK_HAND1 : GDK_LEFT_PTR);
   gdk_window_set_cursor(window, cursor);
   g_object_unref(cursor);
 }


### PR DESCRIPTION
While compiling zathura from git i noticed a deprecation warning for the [gdk_cursor_new()](https://developer.gnome.org/gdk3/stable/gdk3-Cursors.html#gdk-cursor-new) function so i replaced it with [gdk_cursor_new_for_display()](https://developer.gnome.org/gdk3/stable/gdk3-Cursors.html#gdk-cursor-new-for-display).
