### PR TITLE
Feature: Shortcut for exiting the program in index mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,12 +24,9 @@ zathura-*.tar.gz
 # build dirs
 .depend
 .tx
+build/
 gcov/
 doc/_build
-
-# binaries
-zathura
-zathura-debug
 
 # version file
 version.h

--- a/zathura/config.c
+++ b/zathura/config.c
@@ -381,6 +381,7 @@ config_load_default(zathura_t* zathura)
   girara_shortcut_add(gsession, 0,              GDK_KEY_Right,     NULL, sc_navigate_index,      INDEX,        EXPAND,       NULL);
   girara_shortcut_add(gsession, 0,              GDK_KEY_space,     NULL, sc_navigate_index,      INDEX,        SELECT,       NULL);
   girara_shortcut_add(gsession, 0,              GDK_KEY_Return,    NULL, sc_navigate_index,      INDEX,        SELECT,       NULL);
+  girara_shortcut_add(gsession, 0,              GDK_KEY_q,         NULL, sc_quit,                INDEX,        0,            NULL);
   girara_shortcut_add(gsession, 0,              0,                 "gg", sc_navigate_index,      INDEX,        TOP,          NULL);
   girara_shortcut_add(gsession, 0,              0,                 "G", sc_navigate_index,       INDEX,        BOTTOM,       NULL);
 


### PR DESCRIPTION
Simply defines the key 'q' as a shortcut for exiting zathura in index mode.
As a prerequisite I had to fix .gitignore, as git wouldn't let me stage anything in the "zathura"-folder.