### PR TITLE
Add feature to show ~ instead of $HOME in title

### DIFF
--- a/doc/man/zathurarc.5.rst
+++ b/doc/man/zathurarc.5.rst
@@ -980,7 +980,6 @@ Define the background color of the selected element in index mode.
 * Default value: #9FBC00
 
 
-
 SEE ALSO
 ========
 

--- a/doc/man/zathurarc.5.rst
+++ b/doc/man/zathurarc.5.rst
@@ -965,6 +965,14 @@ Define the background color of the selected element in index mode.
 * Value type: String
 * Default value: #9FBC00
 
+window-title-home-tilde
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Display a short version of the file path, which replaces $HOME with ~, in the window title.
+
+* Value type: Boolean
+* Default value: false
+
 
 SEE ALSO
 ========

--- a/doc/man/zathurarc.5.rst
+++ b/doc/man/zathurarc.5.rst
@@ -863,6 +863,13 @@ Use basename of the file in the window title.
 * Value type: Boolean
 * Default value: false
 
+window-title-home-tilde
+^^^^^^^^^^^^^^^^^^^^^^^
+Display a short version of the file path, which replaces $HOME with ~, in the window title.
+
+* Value type: Boolean
+* Default value: false
+
 window-title-page
 ^^^^^^^^^^^^^^^^^
 Display the page number in the window title.
@@ -873,6 +880,13 @@ Display the page number in the window title.
 statusbar-basename
 ^^^^^^^^^^^^^^^^^^
 Use basename of the file in the statusbar.
+
+* Value type: Boolean
+* Default value: false
+
+statusbar-home-tilde
+^^^^^^^^^^^^^^^^^^^^
+Display a short version of the file path, which replaces $HOME with ~, in the statusbar.
 
 * Value type: Boolean
 * Default value: false
@@ -965,13 +979,6 @@ Define the background color of the selected element in index mode.
 * Value type: String
 * Default value: #9FBC00
 
-window-title-home-tilde
-^^^^^^^^^^^^^^^^^^^^^^^
-
-Display a short version of the file path, which replaces $HOME with ~, in the window title.
-
-* Value type: Boolean
-* Default value: false
 
 
 SEE ALSO

--- a/zathura/config.c
+++ b/zathura/config.c
@@ -224,6 +224,8 @@ config_load_default(zathura_t* zathura)
   bool_value = false;
   girara_setting_add(gsession, "window-title-basename",  &bool_value,  BOOLEAN, false, _("Use basename of the file in the window title"), NULL, NULL);
   bool_value = false;
+  girara_setting_add(gsession, "window-title-home-tilde",  &bool_value,  BOOLEAN, false, _("Use ~ instead of $HOME in the filename in the window title"), NULL, NULL);
+  bool_value = false;
   girara_setting_add(gsession, "window-title-page",      &bool_value,  BOOLEAN, false, _("Display the page number in the window title"), NULL, NULL);
   bool_value = false;
   girara_setting_add(gsession, "statusbar-basename",     &bool_value,  BOOLEAN, false, _("Use basename of the file in the statusbar"), NULL, NULL);

--- a/zathura/config.c
+++ b/zathura/config.c
@@ -229,6 +229,8 @@ config_load_default(zathura_t* zathura)
   girara_setting_add(gsession, "window-title-page",      &bool_value,  BOOLEAN, false, _("Display the page number in the window title"), NULL, NULL);
   bool_value = false;
   girara_setting_add(gsession, "statusbar-basename",     &bool_value,  BOOLEAN, false, _("Use basename of the file in the statusbar"), NULL, NULL);
+  bool_value = false;
+  girara_setting_add(gsession, "statusbar-home-tilde",  &bool_value,  BOOLEAN, false, _("Use ~ instead of $HOME in the filename in the statusbar"), NULL, NULL);
   bool_value = true;
   girara_setting_add(gsession, "synctex",                &bool_value,  BOOLEAN, false, _("Enable synctex support"), NULL, NULL);
   string_value = "";

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -1125,9 +1125,7 @@ statusbar_page_number_update(zathura_t* zathura)
       bool basename_only = false;
       girara_setting_get(zathura->ui.session, "window-title-basename", &basename_only);
       char* title = g_strdup_printf("%s %s",
-        (basename_only == true)
-          ? zathura_document_get_basename(zathura->document)
-          : zathura_document_get_path(zathura->document),
+        get_window_title_filename(zathura, zathura_document_get_path(zathura->document)),
         page_number_text);
       girara_set_window_title(zathura->ui.session, title);
       g_free(title);

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -580,20 +580,14 @@ get_formatted_filename(zathura_t* zathura, const char* file_path, bool statusbar
         tdir[tlen - 1] = '\0';
         return tdir;
       } else {
-        char* path = g_try_malloc(sizeof(char) * strlen(file_path));
-        strncpy(path, file_path, file_path_len);
-        return path;
+        return g_strdup(file_path);
       }
     } else {
-      char* path = g_try_malloc(sizeof(char) * strlen(file_path));
-      strncpy(path, file_path, file_path_len);
-      return path;
+      return g_strdup(file_path);
     }
   } else {
     const char* basename = zathura_document_get_basename(zathura->document);
-    char* basename_copy = g_try_malloc(sizeof(char) * strlen(basename));
-    strncpy(basename_copy, basename, strlen(basename));
-    return basename_copy;
+    return g_strdup(basename);
   }
 }
 

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -1122,8 +1122,6 @@ statusbar_page_number_update(zathura_t* zathura)
     girara_setting_get(zathura->ui.session, "window-title-page", &page_number_in_window_title);
 
     if (page_number_in_window_title == true) {
-      bool basename_only = false;
-      girara_setting_get(zathura->ui.session, "window-title-basename", &basename_only);
       char* title = g_strdup_printf("%s %s",
         get_window_title_filename(zathura, zathura_document_get_path(zathura->document)),
         page_number_text);

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -571,14 +571,18 @@ get_formatted_filename(zathura_t* zathura, const char* file_path, bool statusbar
       char *home = girara_get_home_directory(NULL);
       size_t home_len = home ? strlen(home) : 0;
 
-      if (home_len > 1 && strncmp(home, file_path, home_len) == 0 && (!file_path[home_len] || file_path[home_len] == '/')) {
-        // Length should be total length of path - length of $HOME + 1 for '~' + 1 for '\0'
-        int tlen = file_path_len - home_len + 2;
-        char *tdir = g_try_malloc(sizeof(char) * tlen);
-        strncpy(tdir + 1, file_path + home_len, tlen);
-        tdir[0] = '~';
-        tdir[tlen - 1] = '\0';
-        return tdir;
+      if (home_len > 1
+          && file_path_len >= home_len
+          && g_str_has_prefix(file_path, home)
+          && (!file_path[home_len] || file_path[home_len] == '/')) {
+
+        size_t remaining_len = file_path_len - home_len;
+
+        GString* remaining_path = g_string_new_len(&file_path[home_len], remaining_len);
+        char* tilde_path = g_strdup_printf("~%s", remaining_path->str);
+        g_string_free(remaining_path, true);
+
+        return tilde_path;
       } else {
         return g_strdup(file_path);
       }

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -556,13 +556,13 @@ get_window_title_filename(zathura_t* zathura, const char* file_path)
     girara_setting_get(zathura->ui.session, "window-title-home-tilde", &home_tilde);
     if (home_tilde) {
       char *home = getenv("HOME");
-      int home_len = home ? strlen(home) : 0;
-      int file_path_len = file_path ? strlen(file_path) : 0;
+      size_t home_len = home ? strlen(home) : 0;
+      size_t file_path_len = file_path ? strlen(file_path) : 0;
 
       if (home_len > 1 && strncmp(home, file_path, home_len) == 0 && (!file_path[home_len] || file_path[home_len] == '/')) {
         // Length should be total length of path - length of $HOME + 1 for '~' + 1 for '\0'
         int tlen = file_path_len - home_len + 2;
-        char *tdir = malloc(sizeof(char) * tlen);
+        char *tdir = g_try_malloc(sizeof(char) * tlen);
         strncpy(tdir + 1, file_path + home_len, tlen);
         tdir[0] = '~';
         tdir[tlen - 1] = '\0';

--- a/zathura/zathura.h
+++ b/zathura/zathura.h
@@ -278,7 +278,15 @@ void zathura_set_plugin_dir(zathura_t* zathura, const char* dir);
  */
 void zathura_set_argv(zathura_t* zathura, char** argv);
 
-const char* get_window_title_filename(zathura_t* zathura, const char* file_path);
+/**
+ * Returns the filename formatted according to the user config.
+ * Takes into account the basename setting and the home-tilde setting.
+ *
+ * @param zatura The zathura session
+ * @param file_path The filename to be formatted
+ * @param statusbar True if for statusbar, false if for window title
+ */
+const char* get_formatted_filename(zathura_t* zathura, const char* file_path, bool statusbar);
 
 /**
  * Opens a file

--- a/zathura/zathura.h
+++ b/zathura/zathura.h
@@ -286,7 +286,7 @@ void zathura_set_argv(zathura_t* zathura, char** argv);
  * @param file_path The filename to be formatted
  * @param statusbar True if for statusbar, false if for window title
  */
-const char* get_formatted_filename(zathura_t* zathura, const char* file_path, bool statusbar);
+char* get_formatted_filename(zathura_t* zathura, const char* file_path, bool statusbar);
 
 /**
  * Opens a file

--- a/zathura/zathura.h
+++ b/zathura/zathura.h
@@ -278,6 +278,8 @@ void zathura_set_plugin_dir(zathura_t* zathura, const char* dir);
  */
 void zathura_set_argv(zathura_t* zathura, char** argv);
 
+const char* get_window_title_filename(zathura_t* zathura, const char* file_path);
+
 /**
  * Opens a file
  *


### PR DESCRIPTION
This allows users to add "set window-title-home-tilde true" to their zathurarc so that, in the window title, $HOME is replaced with a "~".

Please let me know if I should rename functions or fix my style anywhere, or if you have a suggestion for a better name for this feature.