### PR TITLE
Feature/toggle page mode improvement

### DIFF
--- a/doc/man/zathurarc.5.rst
+++ b/doc/man/zathurarc.5.rst
@@ -731,9 +731,12 @@ Defines the number of pages that are rendered next to each other in a row.
 first-page-column
 ^^^^^^^^^^^^^^^^^
 Defines the column in which the first page will be displayed.
+This setting is stored separately for every value of pages-per-row according to
+the following pattern <1 page per row>:[<2 pages per row>[: ...]]. Per default,
+the first column is set to 2 for double-page layout.
 
-* Value type: Integer
-* Default value: 1
+* Value type: String
+* Default value: 1:2
 
 recolor
 ^^^^^^^

--- a/zathura/callbacks.c
+++ b/zathura/callbacks.c
@@ -243,8 +243,13 @@ cb_page_layout_value_changed(girara_session_t* session, const char* name, girara
   unsigned int pages_per_row = 1;
   girara_setting_get(session, "pages-per-row", &pages_per_row);
 
-  unsigned int first_page_column = 1;
-  girara_setting_get(session, "first-page-column", &first_page_column);
+  /* get list of first_page_column settings */
+  char* first_page_column_list = NULL;
+  girara_setting_get(session, "first-page-column", &first_page_column_list);
+
+  /* find value for first_page_column */
+  unsigned int first_page_column = find_first_page_column(first_page_column_list, pages_per_row);
+  g_free(first_page_column_list);
 
   unsigned int page_padding = 1;
   girara_setting_get(zathura->ui.session, "page-padding", &page_padding);

--- a/zathura/config.c
+++ b/zathura/config.c
@@ -149,7 +149,7 @@ config_load_default(zathura_t* zathura)
   int_value = 1;
   girara_setting_add(gsession, "pages-per-row",         &int_value,   INT,    false, _("Number of pages per row"),  cb_page_layout_value_changed, NULL);
   int_value = 1;
-  girara_setting_add(gsession, "first-page-column",     &int_value,   INT,    false, _("Column of the first page"), cb_page_layout_value_changed, NULL);
+  girara_setting_add(gsession, "first-page-column",     "1:2",        STRING, false, _("Column of the first page"), cb_page_layout_value_changed, NULL);
   float_value = 40;
   girara_setting_add(gsession, "scroll-step",           &float_value, FLOAT,  false, _("Scroll step"),              NULL, NULL);
   float_value = 40;

--- a/zathura/database-plain.c
+++ b/zathura/database-plain.c
@@ -559,7 +559,7 @@ plain_set_fileinfo(zathura_database_t* db, const char* file, zathura_fileinfo_t*
   g_key_file_set_double (priv->history, name, KEY_SCALE,             file_info->scale);
   g_key_file_set_integer(priv->history, name, KEY_ROTATE,            file_info->rotation);
   g_key_file_set_integer(priv->history, name, KEY_PAGES_PER_ROW,     file_info->pages_per_row);
-  g_key_file_set_integer(priv->history, name, KEY_FIRST_PAGE_COLUMN, file_info->first_page_column);
+  g_key_file_set_string(priv->history, name, KEY_FIRST_PAGE_COLUMN,  file_info->first_page_column_list);
   g_key_file_set_double (priv->history, name, KEY_POSITION_X,        file_info->position_x);
   g_key_file_set_double (priv->history, name, KEY_POSITION_Y,        file_info->position_y);
   g_key_file_set_integer(priv->history, name, KEY_TIME,              time(NULL));
@@ -600,7 +600,7 @@ plain_get_fileinfo(zathura_database_t* db, const char* file, zathura_fileinfo_t*
     file_info->pages_per_row     = g_key_file_get_integer(priv->history, name, KEY_PAGES_PER_ROW, NULL);
   }
   if (g_key_file_has_key(priv->history, name, KEY_FIRST_PAGE_COLUMN, NULL) == TRUE) {
-    file_info->first_page_column = g_key_file_get_integer(priv->history, name, KEY_FIRST_PAGE_COLUMN, NULL);
+    file_info->first_page_column_list = g_key_file_get_string(priv->history, name, KEY_FIRST_PAGE_COLUMN, NULL);
   }
   if (g_key_file_has_key(priv->history, name, KEY_POSITION_X, NULL) == TRUE) {
     file_info->position_x        = g_key_file_get_double(priv->history, name, KEY_POSITION_X, NULL);

--- a/zathura/database.h
+++ b/zathura/database.h
@@ -15,7 +15,7 @@ typedef struct zathura_fileinfo_s {
   double scale;
   unsigned int rotation;
   unsigned int pages_per_row;
-  unsigned int first_page_column;
+  char* first_page_column_list;
   double position_x;
   double position_y;
 } zathura_fileinfo_t;

--- a/zathura/shortcuts.c
+++ b/zathura/shortcuts.c
@@ -1308,7 +1308,7 @@ sc_toggle_presentation(girara_session_t* session, girara_argument_t*
     render_all(zathura);
     refresh_view(zathura);
 
-    /* setm ode */
+    /* set mode */
     girara_mode_set(session, zathura->modes.normal);
   } else if (old_mode == zathura->modes.normal) {
     /* backup pages per row */
@@ -1336,7 +1336,7 @@ sc_toggle_presentation(girara_session_t* session, girara_argument_t*
     gtk_window_fullscreen(GTK_WINDOW(session->gtk.window));
     refresh_view(zathura);
 
-    /* setm ode */
+    /* set mode */
     girara_mode_set(session, zathura->modes.presentation);
   }
 

--- a/zathura/shortcuts.c
+++ b/zathura/shortcuts.c
@@ -1286,7 +1286,7 @@ sc_toggle_presentation(girara_session_t* session, girara_argument_t*
   }
 
   static int pages_per_row = 1;
-  static int first_page_column = 1;
+  static char* first_page_column_list = "1:2";
   static double zoom = 1.0;
 
   const girara_mode_t old_mode = girara_mode_get(session);
@@ -1295,7 +1295,7 @@ sc_toggle_presentation(girara_session_t* session, girara_argument_t*
     girara_setting_set(session, "pages-per-row", &pages_per_row);
 
     /* reset first page column */
-    girara_setting_set(session, "first-page-column", &first_page_column);
+    girara_setting_set(session, "first-page-column", first_page_column_list);
 
     /* show status bar */
     gtk_widget_show(GTK_WIDGET(session->gtk.statusbar));
@@ -1315,7 +1315,8 @@ sc_toggle_presentation(girara_session_t* session, girara_argument_t*
     girara_setting_get(session, "pages-per-row", &pages_per_row);
 
     /* backup first page column */
-    girara_setting_get(session, "first-page-column", &first_page_column);
+    g_free(first_page_column_list);
+    girara_setting_get(session, "first-page-column", &first_page_column_list);
 
     /* set single view */
     int int_value = 1;

--- a/zathura/utils.c
+++ b/zathura/utils.c
@@ -253,3 +253,33 @@ get_selection(zathura_t* zathura)
 
   return selection;
 }
+
+unsigned int
+find_first_page_column(const char* first_page_column_list,
+                       const unsigned int pages_per_row)
+{
+  /* sanity checks */
+  unsigned int first_page_column = 1;
+  g_return_val_if_fail(first_page_column_list != NULL,     first_page_column);
+  g_return_val_if_fail(strcmp(first_page_column_list, ""), first_page_column);
+  g_return_val_if_fail(pages_per_row > 0,                  first_page_column);
+
+  /* split settings list */
+  char** settings = g_strsplit(first_page_column_list, ":", pages_per_row+1);
+
+  size_t settings_size = 0;
+  while (settings[settings_size] != NULL) {
+    ++settings_size;
+  }
+
+  /* read setting value corresponding to the specified pages per row */
+  unsigned int index = pages_per_row - 1;
+  if (settings_size > index && strcmp(settings[index], "")) {
+    first_page_column = atoi(settings[index]);
+  }
+
+  /* free buffers */
+  g_strfreev(settings);
+
+  return first_page_column;
+}

--- a/zathura/utils.h
+++ b/zathura/utils.h
@@ -107,4 +107,17 @@ GdkAtom* get_selection(zathura_t* zathura);
 double zathura_correct_scale_value(girara_session_t* session, const double
     scale);
 
+
+/**
+ * Extracts the column the first page should be rendered in from the specified
+ * list of settings corresponding to the specified pages per row
+ *
+ * @param[in] first_page_column_list The settings list
+ * @param[in] pages_per_row The current pages per row
+ *
+ * @return The column the first page should be rendered in
+ */
+unsigned int find_first_page_column(const char* first_page_column_list,
+                                    const unsigned int pages_per_row);
+
 #endif // UTILS_H

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -857,7 +857,6 @@ document_open(zathura_t* zathura, const char* path, const char* password,
 
   /* view mode */
   unsigned int pages_per_row = 1;
-  unsigned int first_page_column = 1;
   char* first_page_column_list = first_page_column_list_default;
   unsigned int page_padding = 1;
 
@@ -873,11 +872,15 @@ document_open(zathura_t* zathura, const char* path, const char* password,
   if (strcmp(file_info.first_page_column_list, "")) {
     first_page_column_list = file_info.first_page_column_list;
   } else {
-    girara_setting_get(zathura->ui.session, "first-page-column", &first_page_column);
+    girara_setting_get(zathura->ui.session, "first-page-column", &first_page_column_list);
   }
 
+  /* find value for first_page_column */
+  unsigned int first_page_column = find_first_page_column(first_page_column_list, pages_per_row);
+
   girara_setting_set(zathura->ui.session, "pages-per-row", &pages_per_row);
-  girara_setting_set(zathura->ui.session, "first-page-column", &first_page_column);
+  girara_setting_set(zathura->ui.session, "first-page-column", first_page_column_list);
+  g_free(first_page_column_list);
 
   page_widget_set_mode(zathura, page_padding, pages_per_row, first_page_column);
   zathura_document_set_page_layout(zathura->document, page_padding, pages_per_row, first_page_column);
@@ -1096,6 +1099,9 @@ document_close(zathura_t* zathura, bool keep_monitor)
     /* save jumplist */
     zathura_db_save_jumplist(zathura->database, path, zathura->jumplist.list);
   }
+
+  /* free buffers */
+  g_free(file_info.first_page_column_list);
 
   girara_list_iterator_free(zathura->jumplist.cur);
   zathura->jumplist.cur = NULL;

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <math.h>
+#include <string.h>
 
 #include <girara/datastructures.h>
 #include <girara/utils.h>
@@ -651,13 +652,14 @@ document_open(zathura_t* zathura, const char* path, const char* password,
   }
 
   /* read history file */
+  char first_page_column_list_default[] = "1:2";
   zathura_fileinfo_t file_info = {
     .current_page = 0,
     .page_offset = 0,
     .scale = 1,
     .rotation = 0,
     .pages_per_row = 0,
-    .first_page_column = 0,
+    .first_page_column_list = first_page_column_list_default,
     .position_x = 0,
     .position_y = 0
   };
@@ -856,6 +858,7 @@ document_open(zathura_t* zathura, const char* path, const char* password,
   /* view mode */
   unsigned int pages_per_row = 1;
   unsigned int first_page_column = 1;
+  char* first_page_column_list = first_page_column_list_default;
   unsigned int page_padding = 1;
 
   girara_setting_get(zathura->ui.session, "page-padding", &page_padding);
@@ -866,8 +869,9 @@ document_open(zathura_t* zathura, const char* path, const char* password,
     girara_setting_get(zathura->ui.session, "pages-per-row", &pages_per_row);
   }
 
-  if (file_info.first_page_column > 0) {
-    first_page_column = file_info.first_page_column;
+  /* read first_page_column list */
+  if (strcmp(file_info.first_page_column_list, "")) {
+    first_page_column_list = file_info.first_page_column_list;
   } else {
     girara_setting_get(zathura->ui.session, "first-page-column", &first_page_column);
   }
@@ -1072,14 +1076,14 @@ document_close(zathura_t* zathura, bool keep_monitor)
   /* store file information */
   const char* path = zathura_document_get_path(zathura->document);
 
-  zathura_fileinfo_t file_info = { 0, 0, 1, 0, 1, 1, 0, 0 };
+  zathura_fileinfo_t file_info = { 0, 0, 1, 0, 1, "1:2", 0, 0 };
   file_info.current_page = zathura_document_get_current_page_number(zathura->document);
   file_info.page_offset  = zathura_document_get_page_offset(zathura->document);
   file_info.scale        = zathura_document_get_scale(zathura->document);
   file_info.rotation     = zathura_document_get_rotation(zathura->document);
 
   girara_setting_get(zathura->ui.session, "pages-per-row", &(file_info.pages_per_row));
-  girara_setting_get(zathura->ui.session, "first-page-column", &(file_info.first_page_column));
+  girara_setting_get(zathura->ui.session, "first-page-column", &(file_info.first_page_column_list));
 
   /* get position */
   file_info.position_x = zathura_document_get_position_x(zathura->document);


### PR DESCRIPTION
Extends `first-page-column` to a string containing a list of first page column values:
```
<single page layout>:<double page layout>[: ...]
```
The default value for the list is `1:2`, so in double-page layout the renderer places the first page in the second column.