### PR TITLE
Build even without SyncTeX

### DIFF
--- a/zathura/main.c
+++ b/zathura/main.c
@@ -135,10 +135,8 @@ main(int argc, char* argv[])
   gchar* plugin_path    = NULL;
   gchar* loglevel       = NULL;
   gchar* password       = NULL;
-#ifdef WITH_SYNCTEX
   gchar* synctex_editor = NULL;
   gchar* synctex_fwd    = NULL;
-#endif
   gchar* mode           = NULL;
   bool forkback         = false;
   bool print_version    = false;


### PR DESCRIPTION
synctex_editor is used no matter whether we're building WITH_SYNCTEX or
not.  This fixes a build failure when WITH_SYNCTEX isn't defined.

Signed-off-by: Petr Šabata <contyk@redhat.com>