### PR TITLE
Do not assume WITH_SYNCTEX is defined if GDK_WINDOWING_X11 is defined

### DIFF
--- a/zathura/main.c
+++ b/zathura/main.c
@@ -84,11 +84,19 @@ run_synctex_forward(const char* synctex_fwd, const char* filename,
 
 static zathura_t*
 init_zathura(const char* config_dir, const char* data_dir,
-    const char* cache_dir, const char* plugin_path, char** argv,
-#ifdef GDK_WINDOWING_X11
-    char* synctex_editor, Window embed)
+    const char* cache_dir, const char* plugin_path,
+#ifdef WITH_SYNCTEX
+#  ifdef GDK_WINDOWING_X11
+    char** argv, char* synctex_editor, Window embed)
+#  else
+    char** argv, char* synctex_editor)
+#  endif
 #else
-    char* synctex_editor)
+#  ifdef GDK_WINDOWING_X11
+    char** argv, Window embed)
+#else
+    char** argv)
+#  endif
 #endif
 {
   /* create zathura session */
@@ -250,10 +258,19 @@ main(int argc, char* argv[])
 
   /* Create zathura session */
   zathura_t* zathura = init_zathura(config_dir, data_dir, cache_dir,
-#ifdef GDK_WINDOWING_X11
-      plugin_path, argv, synctex_editor, embed);
+      plugin_path,
+#ifdef WITH_SYNCTEX
+#  ifdef GDK_WINDOWING_X11
+    argv, synctex_editor, embed);
+#  else
+    argv, synctex_editor);
+#  endif
 #else
-      plugin_path, argv, synctex_editor);
+#  ifdef GDK_WINDOWING_X11
+    argv, embed);
+#  else
+    argv);
+#  endif
 #endif
   if (zathura == NULL) {
     girara_error("Could not initialize zathura.");


### PR DESCRIPTION
Compiling with `WITH_SYNCTEX=0` fails:

    zathura/main.c: In function ‘init_zathura’:
    zathura/main.c:89:11: warning: unused parameter ‘synctex_editor’ [-Wunused-parameter]
    zathura/main.c: In function ‘main’:
    zathura/main.c:254:26: error: ‘synctex_editor’ undeclared (first use in this function)
    zathura/main.c:254:26: note: each undeclared identifier is reported only once for each function it appears in
    make: *** [build/release/zathura/main.o] Error 1

since it's wrongfully assumed that if `GDK_WINDOWING_X11` is defined then `WITH_SYNCTEX` is defined too.