### PR TITLE
Make page mode toggling predictable + clicking a page set the current page number

### DIFF
--- a/zathura/callbacks.c
+++ b/zathura/callbacks.c
@@ -634,11 +634,19 @@ void
 cb_page_widget_scaled_button_release(ZathuraPage* page_widget, GdkEventButton* event,
     void* data)
 {
+  zathura_t* zathura = data;
+
+  zathura_page_t* page = zathura_page_widget_get_page(page_widget);
+
+  /* set page number (but don't scroll there. it was clicked on, so it's visible) */
+  if (event->button == 1) {
+    zathura_document_set_current_page_number(zathura->document, zathura_page_get_index(page));
+    refresh_view(zathura);
+  }
+
   if (event->button != 1 || !(event->state & GDK_CONTROL_MASK)) {
     return;
   }
-
-  zathura_t* zathura = data;
 
   bool synctex = false;
   girara_setting_get(zathura->ui.session, "synctex", &synctex);
@@ -646,8 +654,6 @@ cb_page_widget_scaled_button_release(ZathuraPage* page_widget, GdkEventButton* e
   if (synctex == false) {
     return;
   }
-
-  zathura_page_t* page = zathura_page_widget_get_page(page_widget);
 
   if (zathura->dbus != NULL) {
     zathura_dbus_edit(zathura->dbus, zathura_page_get_index(page), event->x, event->y);

--- a/zathura/shortcuts.c
+++ b/zathura/shortcuts.c
@@ -1224,6 +1224,8 @@ sc_toggle_page_mode(girara_session_t* session, girara_argument_t*
     return false;
   }
 
+  unsigned int page_id = zathura_document_get_current_page_number(zathura->document);
+
   int pages_per_row = 1;
   girara_setting_get(zathura->ui.session, "pages-per-row", &pages_per_row);
 
@@ -1236,6 +1238,10 @@ sc_toggle_page_mode(girara_session_t* session, girara_argument_t*
 
   girara_setting_set(zathura->ui.session, "pages-per-row", &value);
   adjust_view(zathura);
+
+  page_set(zathura, page_id);
+  render_all(zathura);
+  refresh_view(zathura);
 
   return true;
 }


### PR DESCRIPTION
Previously, toggling page mode would jump to near page, but usually not the one your were looking at before. Now it's more predictable.

Making clicking a page set the current page number allows fast visual navigation through the 'd'ouble page shortcut in combination with a high pages-per-row setting. Very, very handy when writing a masters thesis.

(The previous pull request was retracted because it was against master, not develop. My mistake.)
