### PR TITLE
add vertical centering option

### DIFF
--- a/doc/man/zathurarc.5.rst
+++ b/doc/man/zathurarc.5.rst
@@ -943,6 +943,13 @@ En/Disables horizontally centered zooming.
 * Value type: Boolean
 * Default value: false
 
+vertical-center
+^^^^^^^^^^^
+Center the screen at the vertical midpoint of the page by default.
+
+* Value type: Boolean
+* Default value: false
+
 zoom-max
 ^^^^^^^^
 Defines the maximum percentage that the zoom level can be.

--- a/zathura/config.c
+++ b/zathura/config.c
@@ -198,6 +198,8 @@ config_load_default(zathura_t* zathura)
   girara_setting_add(gsession, "advance-pages-per-row",  &bool_value,  BOOLEAN, false, _("Advance number of pages per row"), NULL, NULL);
   bool_value = false;
   girara_setting_add(gsession, "zoom-center",            &bool_value,  BOOLEAN, false, _("Horizontally centered zoom"), NULL, NULL);
+  bool_value = false;
+  girara_setting_add(gsession, "vertical-center",        &bool_value,  BOOLEAN, false, _("Vertically center pages"), NULL, NULL);
   bool_value = true;
   girara_setting_add(gsession, "link-hadjust",           &bool_value,  BOOLEAN, false, _("Align link target to the left"), NULL, NULL);
   bool_value = true;

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -1382,9 +1382,17 @@ position_set(zathura_t* zathura, double position_x, double position_y)
   double comppos_x, comppos_y;
   unsigned int page_id = zathura_document_get_current_page_number(zathura->document);
 
+  bool vertical_center = false;
+  girara_setting_get(zathura->ui.session, "vertical-center", &vertical_center);
+
   /* xalign = 0.5: center horizontally (with the page, not the document) */
-  /* yalign = 0.0: align page an viewport edges at the top               */
-  page_number_to_position(zathura->document, page_id, 0.5, 0.0, &comppos_x, &comppos_y);
+  if (vertical_center) {
+    /* yalign = 0.0: align page an viewport edges at the top               */
+    page_number_to_position(zathura->document, page_id, 0.5, 0.0, &comppos_x, &comppos_y);
+  } else {
+    /* yalign = 0.5: center vertically */
+    page_number_to_position(zathura->document, page_id, 0.5, 0.5, &comppos_x, &comppos_y);
+  }
 
   /* automatic horizontal adjustment */
   zathura_adjust_mode_t adjust_mode = zathura_document_get_adjust_mode(zathura->document);


### PR DESCRIPTION
This is a pretty simple change – basically, when I'm TeXing something I want to be able to scroll page by page while staying slightly zoomed in so I don't have to waste screen space on the margins.