### PR TITLE
add continuous history save

### DIFF
--- a/doc/man/zathurarc.5.rst
+++ b/doc/man/zathurarc.5.rst
@@ -652,6 +652,14 @@ Defines if the number of pages per row should be honored when advancing a page.
 * Value type: Boolean
 * Default value: false
 
+continuous-hist-save
+^^^^^^^^^^^^^^^^^^^^
+Tells zathura whether to save document history at each page change or only when
+closing a document.
+
+* Value type: Boolean
+* Default value: false
+
 database
 ^^^^^^^^
 Defines the database backend to use for bookmarks and input history. Possible

--- a/zathura/config.c
+++ b/zathura/config.c
@@ -242,6 +242,8 @@ config_load_default(zathura_t* zathura)
   girara_setting_add(gsession, "synctex-editor-command", string_value, STRING,  false, _("Synctex editor command"), NULL, NULL);
   bool_value = true;
   girara_setting_add(gsession, "dbus-service",           &bool_value,  BOOLEAN, false, _("Enable D-Bus service"), NULL, NULL);
+  bool_value = false;
+  girara_setting_add(gsession, "continuous-hist-save",   &bool_value,  BOOLEAN, false, _("Save history at each page change"), NULL, NULL);
   string_value = "primary";
   girara_setting_add(gsession, "selection-clipboard",    string_value, STRING,  false, _("The clipboard into which mouse-selected data will be written"), NULL, NULL);
   bool_value = true;

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -1281,6 +1281,12 @@ page_set(zathura_t* zathura, unsigned int page_id)
 
   zathura_document_set_current_page_number(zathura->document, page_id);
 
+  bool continuous_hist_save = false;
+  girara_setting_get(zathura->ui.session, "continuous-hist-save", &continuous_hist_save);
+  if (continuous_hist_save) {
+    save_fileinfo_to_db(zathura);
+  }
+
   /* negative position means auto */
   return position_set(zathura, -1, -1);
 


### PR DESCRIPTION
Some of my zathura sessions are pretty long-running, e.g. when I have a textbook open, often more likely to close because of something crashing or because I run out of battery than because I intentionally close them, which means I lose my page. This fixes that problem, and hopefully other people will find this option useful as well.