### PR TITLE
Cases for vertical_center were swapped

### DIFF
--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -1387,11 +1387,11 @@ position_set(zathura_t* zathura, double position_x, double position_y)
 
   /* xalign = 0.5: center horizontally (with the page, not the document) */
   if (vertical_center == true) {
-    /* yalign = 0.0: align page an viewport edges at the top               */
-    page_number_to_position(zathura->document, page_id, 0.5, 0.0, &comppos_x, &comppos_y);
-  } else {
     /* yalign = 0.5: center vertically */
     page_number_to_position(zathura->document, page_id, 0.5, 0.5, &comppos_x, &comppos_y);
+  } else {
+    /* yalign = 0.0: align page an viewport edges at the top               */
+    page_number_to_position(zathura->document, page_id, 0.5, 0.0, &comppos_x, &comppos_y);
   }
 
   /* automatic horizontal adjustment */


### PR DESCRIPTION
Setting vertical-center = false (the default) actually produced vertical centering, and vice versa. I just swapped the cases.