### PR TITLE
reformat the rest pages used to create man pages

### DIFF
--- a/doc/man/zathura.1.rst
+++ b/doc/man/zathura.1.rst
@@ -16,11 +16,6 @@ Options
 
 .. include:: _options.txt
 
-Environment variables
----------------------
-
-.. include:: _env.txt
-
 Mouse and key bindings
 ----------------------
 
@@ -40,6 +35,11 @@ Synctex support
 ---------------
 
 .. include:: _synctex.txt
+
+Environment variables
+---------------------
+
+.. include:: _env.txt
 
 Known bugs
 ----------

--- a/doc/man/zathurarc.5.rst
+++ b/doc/man/zathurarc.5.rst
@@ -1,6 +1,6 @@
-=========
+*********
 zathurarc
-=========
+*********
 
 SYNOPSIS
 ========
@@ -88,61 +88,57 @@ the *zathurarc* file to make those changes permanent:
 
     map [mode] <binding> <shortcut function> <argument>
 
-Mode
-^^^^
-The ``map`` command expects several arguments where only the ``binding`` as well as
-the ``shortcut-function`` argument is required. Since zathura uses several modes
-it is possible to map bindings only for a specific mode by passing the ``mode``
-argument which can take one of the following values:
+*Mode*
+  The ``map`` command expects several arguments where only the ``binding`` as well as
+  the ``shortcut-function`` argument is required. Since zathura uses several modes
+  it is possible to map bindings only for a specific mode by passing the ``mode``
+  argument which can take one of the following values:
 
-* normal (default)
-* fullscreen
-* presentation
-* index
+  * normal (default)
+  * fullscreen
+  * presentation
+  * index
 
-The brackets around the value are mandatory.
+  The brackets around the value are mandatory.
 
-Single key binding
-^^^^^^^^^^^^^^^^^^
-The (possible) second argument defines the used key binding that should be
-mapped to the shortcut function and is structured like the following. On the one
-hand it is possible to just assign single letters, numbers or signs to it:
+*Single key binding*
+  The (possible) second argument defines the used key binding that should be
+  mapped to the shortcut function and is structured like the following. On the one
+  hand it is possible to just assign single letters, numbers or signs to it:
 
-::
+  ::
 
-    map a shortcut_function optional_argument
-    map b shortcut_function optional_argument
-    map c shortcut_function optional_argument
-    map 1 shortcut_function optional_argument
-    map 2 shortcut_function optional_argument
-    map 3 shortcut_function optional_argument
-    map ! shortcut_function optional_argument
-    map ? shortcut_function optional_argument
+      map a shortcut_function optional_argument
+      map b shortcut_function optional_argument
+      map c shortcut_function optional_argument
+      map 1 shortcut_function optional_argument
+      map 2 shortcut_function optional_argument
+      map 3 shortcut_function optional_argument
+      map ! shortcut_function optional_argument
+      map ? shortcut_function optional_argument
 
-Using modifiers
-^^^^^^^^^^^^^^^
-It is also possible to use modifiers like the Control or Alt button on the
-keyboard. It is possible to use the following modifiers:
+*Using modifiers*
+  It is also possible to use modifiers like the Control or Alt button on the
+  keyboard. It is possible to use the following modifiers:
 
-* A - Alt
-* C - Control
-* S - Shift
+  * A - Alt
+  * C - Control
+  * S - Shift
 
-If any of the modifiers should be used for a binding, it is required to define
-the ``binding`` with the following structure:
+  If any of the modifiers should be used for a binding, it is required to define
+  the ``binding`` with the following structure:
 
-::
+  ::
 
-    map <A-a> shortcut_function
-    map <C-a> shortcut_function
+      map <A-a> shortcut_function
+      map <C-a> shortcut_function
 
-Special keys
-^^^^^^^^^^^^
-zathura allows it also to assign keys like the space bar or the tab button which
-also have to be written in between angle brackets. The following special keys
-are currently available:
+*Special keys*
+  zathura allows it also to assign keys like the space bar or the tab button which
+  also have to be written in between angle brackets. The following special keys
+  are currently available:
 
-::
+  ::
 
     Identifier Description
 
@@ -173,20 +169,19 @@ are currently available:
     Tab        Tab
     Print      Print key
 
-Of course it is possible to combine those special keys with a modifier. The
-usage of those keys should be explained by the following examples:
+  Of course it is possible to combine those special keys with a modifier. The
+  usage of those keys should be explained by the following examples:
 
-::
+  ::
 
     map <Space> shortcut_function
     map <C-Space> shortcut_function
 
-Mouse buttons
-^^^^^^^^^^^^^
-It is also possible to map mouse buttons to shortcuts by using the following
-special keys:
+*Mouse buttons*
+  It is also possible to map mouse buttons to shortcuts by using the following
+  special keys:
 
-::
+  ::
 
     Identifier Description
 
@@ -203,180 +198,177 @@ They can also be combined with modifiers:
     map <Button1> shortcut_function
     map <C-Button1> shortcut_function
 
-Buffer commands
-^^^^^^^^^^^^^^^
-If a mapping does not match one of the previous definition but is still a valid
-mapping it will be mapped as a buffer command:
+*Buffer commands*
+  If a mapping does not match one of the previous definition but is still a valid
+  mapping it will be mapped as a buffer command:
 
-::
+  ::
 
     map abc quit
     map test quit
 
-Shortcut functions
-^^^^^^^^^^^^^^^^^^
-The following shortcut functions can be mapped:
+*Shortcut functions*
+  The following shortcut functions can be mapped:
 
-* ``abort``
+  * ``abort``
 
-  Switch back to normal mode.
+    Switch back to normal mode.
 
-* ``adjust_window``
+  * ``adjust_window``
 
-  Adjust page width. Possible arguments are ``best-fit`` and ``width``.
+    Adjust page width. Possible arguments are ``best-fit`` and ``width``.
 
-* ``change_mode``
+  * ``change_mode``
 
-  Change current mode. Pass the desired mode as argument.
+    Change current mode. Pass the desired mode as argument.
 
-* ``display_link``:
+  * ``display_link``:
 
-  Display link target.
+    Display link target.
 
-* ``exec``:
+  * ``exec``:
 
-  Execute an external command.
+    Execute an external command.
 
-* ``focus_inputbar``
+  * ``focus_inputbar``
 
-  Focus inputbar.
+    Focus inputbar.
 
-* ``follow``
+  * ``follow``
 
-  Follow a link.
+    Follow a link.
 
-* ``goto``
+  * ``goto``
 
-  Go to a certain page.
+    Go to a certain page.
 
-* ``jumplist``
+  * ``jumplist``
 
-  Move forwards/backwards in the jumplist. Pass ``forward`` as argument to
-  move to the next entry and ``backward`` to move to the previous one.
+    Move forwards/backwards in the jumplist. Pass ``forward`` as argument to
+    move to the next entry and ``backward`` to move to the previous one.
 
-* ``navigate``
+  * ``navigate``
 
-  Navigate to the next/previous page.
+    Navigate to the next/previous page.
 
-* ``navigate_index``
+  * ``navigate_index``
 
-  Navigate through the index.
+    Navigate through the index.
 
-* ``print``
+  * ``print``
 
-  Show the print dialog.
+    Show the print dialog.
 
-* ``quit``
+  * ``quit``
 
-  Quit zathura.
+    Quit zathura.
 
-* ``recolor``
+  * ``recolor``
 
-  Recolor pages.
+    Recolor pages.
 
-* ``reload``
+  * ``reload``
 
-  Reload the document.
+    Reload the document.
 
-* ``rotate``
+  * ``rotate``
 
-  Rotate the page. Pass ``rotate-ccw`` as argument for counterclockwise rotation
-  and ``rotate-cw`` for clockwise rotation.
+    Rotate the page. Pass ``rotate-ccw`` as argument for counterclockwise rotation
+    and ``rotate-cw`` for clockwise rotation.
 
-* ``scroll``
+  * ``scroll``
 
-  Scroll.
+    Scroll.
 
-* ``search``
+  * ``search``
 
-  Search next/previous item. Pass ``forward`` as argument to search for the next
-  hit and ``backward`` to search for the previous hit.
+    Search next/previous item. Pass ``forward`` as argument to search for the next
+    hit and ``backward`` to search for the previous hit.
 
-* ``set``
+  * ``set``
 
-  Set an option.
+    Set an option.
 
-* ``toggle_fullscreen``
+  * ``toggle_fullscreen``
 
-  Toggle fullscreen.
+    Toggle fullscreen.
 
-* ``toggle_index``
+  * ``toggle_index``
 
-  Show or hide index.
+    Show or hide index.
 
-* ``toggle_inputbar``
+  * ``toggle_inputbar``
 
-  Show or hide inputbar.
+    Show or hide inputbar.
 
-* ``toggle_page_mode``
+  * ``toggle_page_mode``
 
-  Toggle between one and multiple pages per row.
+    Toggle between one and multiple pages per row.
 
-* ``toggle_statusbar``
+  * ``toggle_statusbar``
 
-  Show or hide statusbar.
+    Show or hide statusbar.
 
-* ``zoom``
+  * ``zoom``
 
-  Zoom in or out.
+    Zoom in or out.
 
-* ``mark_add``
+  * ``mark_add``
 
-  Set a quickmark.
+    Set a quickmark.
 
-* ``mark_evaluate``
+  * ``mark_evaluate``
 
-  Go to a quickmark.
+    Go to a quickmark.
 
-* ``feedkeys``
+  * ``feedkeys``
 
-  Simulate key presses. Note that all keys will be interpreted as if pressing a
-  key on the keyboard. To input uppercase letters, follow the same convention as
-  for key bindings, i.e. for ``X``, use ``<S-X>``.
+    Simulate key presses. Note that all keys will be interpreted as if pressing a
+    key on the keyboard. To input uppercase letters, follow the same convention as
+    for key bindings, i.e. for ``X``, use ``<S-X>``.
 
 
-Pass arguments
-^^^^^^^^^^^^^^
-Some shortcut function require or have optional arguments which influence the
-behaviour of them. Those can be passed as the last argument:
+*Pass arguments*
+  Some shortcut function require or have optional arguments which influence the
+  behaviour of them. Those can be passed as the last argument:
 
-::
+  ::
 
     map <C-i> zoom in
     map <C-o> zoom out
 
-Possible arguments are:
+  Possible arguments are:
 
-* best-fit
-* bottom
-* backward
-* collapse
-* collapse-all
-* default
-* down
-* expand
-* expand-all
-* forward
-* full-down
-* full-up
-* half-down
-* half-up
-* in
-* left
-* next
-* out
-* page-bottom
-* page-top
-* previous
-* right
-* rotate-ccw
-* rotate-cw
-* select
-* specific
-* toggle
-* top
-* up
-* width
+  * best-fit
+  * bottom
+  * backward
+  * collapse
+  * collapse-all
+  * default
+  * down
+  * expand
+  * expand-all
+  * forward
+  * full-down
+  * full-up
+  * half-down
+  * half-up
+  * in
+  * left
+  * next
+  * out
+  * page-bottom
+  * page-top
+  * previous
+  * right
+  * rotate-ccw
+  * rotate-cw
+  * select
+  * specific
+  * toggle
+  * top
+  * up
+  * width
 
 unmap - Removing a shortcut
 ---------------------------
@@ -393,711 +385,622 @@ section of this document
 OPTIONS
 =======
 
-girara
-------
 This section describes settings concerning the behaviour of girara and
 zathura. The settings described here can be changed with ``set``.
 
-n-completion-items
-^^^^^^^^^^^^^^^^^^
-Defines the maximum number of displayed completion entries.
+girara
+------
 
-* Value type: Integer
-* Default value: 15
+*n-completion-items*
+  Defines the maximum number of displayed completion entries.
 
-completion-bg
-^^^^^^^^^^^^^
-Defines the background color that is used for command line completion
-entries
+  * Value type: Integer
+  * Default value: 15
 
-* Value type: String
-* Default value: #232323
+*completion-bg*
+  Defines the background color that is used for command line completion
+  entries
 
-completion-fg
-^^^^^^^^^^^^^
-Defines the foreground color that is used for command line completion
-entries
+  * Value type: String
+  * Default value: #232323
 
-* Value type: String
-* Default value: #DDDDDD
+*completion-fg*
+  Defines the foreground color that is used for command line completion
+  entries
 
-completion-group-bg
-^^^^^^^^^^^^^^^^^^^
-Defines the background color that is used for command line completion
-group elements
+  * Value type: String
+  * Default value: #DDDDDD
 
-* Value type: String
-* Default value: #000000
+*completion-group-bg*
+  Defines the background color that is used for command line completion
+  group elements
 
-completion-group-fg
-^^^^^^^^^^^^^^^^^^^
-Defines the foreground color that is used for command line completion
-group elements
+  * Value type: String
+  * Default value: #000000
 
-* Value type: String
-* Default value: #DEDEDE
+*completion-group-fg*
+  Defines the foreground color that is used for command line completion
+  group elements
 
-completion-highlight-bg
-^^^^^^^^^^^^^^^^^^^^^^^
-Defines the background color that is used for the current command line
-completion element
+  * Value type: String
+  * Default value: #DEDEDE
 
-* Value type: String
-* Default value: #9FBC00
+*completion-highlight-bg*
+  Defines the background color that is used for the current command line
+  completion element
 
-completion-highlight-fg
-^^^^^^^^^^^^^^^^^^^^^^^
-Defines the foreground color that is used for the current command line
-completion element
+  * Value type: String
+  * Default value: #9FBC00
 
-* Value type: String
-* Default value: #232323
+*completion-highlight-fg*
+  Defines the foreground color that is used for the current command line
+  completion element
 
-default-fg
-^^^^^^^^^^
-Defines the default foreground color
+  * Value type: String
+  * Default value: #232323
 
-* Value type: String
-* Default value: #DDDDDD
+*default-fg*
+  Defines the default foreground color
 
-default-bg
-^^^^^^^^^^
-Defines the default background color
+  * Value type: String
+  * Default value: #DDDDDD
 
-* Value type: String
-* Default value: #000000
+*default-bg*
+  Defines the default background color
 
-exec-command
-^^^^^^^^^^^^
-Defines a command the should be prepended to any command run with exec.
+  * Value type: String
+  * Default value: #000000
 
-* Value type: String
-* Default value:
+*exec-command*
+  Defines a command the should be prepended to any command run with exec.
 
-font
-^^^^
-Defines the font that will be used
+  * Value type: String
+  * Default value:
 
-* Value type: String
-* Default value: monospace normal 9
+*font*
+  Defines the font that will be used
 
-guioptions
-^^^^^^^^^^
-Shows or hides GUI elements.
-If it contains 'c', the command line is displayed.
-If it contains 's', the statusbar is displayed.
-If it contains 'h', the horizontal scrollbar is displayed.
-If it contains 'v', the vertical scrollbar is displayed.
+  * Value type: String
+  * Default value: monospace normal 9
 
-* Value type: String
-* Default value: s
+*guioptions*
+  Shows or hides GUI elements.
+  If it contains 'c', the command line is displayed.
+  If it contains 's', the statusbar is displayed.
+  If it contains 'h', the horizontal scrollbar is displayed.
+  If it contains 'v', the vertical scrollbar is displayed.
 
-inputbar-bg
-^^^^^^^^^^^
-Defines the background color for the inputbar
+  * Value type: String
+  * Default value: s
 
-* Value type: String
-* Default value: #131313
+*inputbar-bg*
+  Defines the background color for the inputbar
 
-inputbar-fg
-^^^^^^^^^^^
-Defines the foreground color for the inputbar
+  * Value type: String
+  * Default value: #131313
 
-* Value type: String
-* Default value: #9FBC00
+*inputbar-fg*
+  Defines the foreground color for the inputbar
 
-notification-bg
-^^^^^^^^^^^^^^^^^^^^^
-Defines the background color for a notification
+  * Value type: String
+  * Default value: #9FBC00
 
-* Value type: String
-* Default value: #FFFFFF
+*notification-bg*
+  Defines the background color for a notification
 
-notification-fg
-^^^^^^^^^^^^^^^^^^^^^
-Defines the foreground color for a notification
+  * Value type: String
+  * Default value: #FFFFFF
 
-* Value type: String
-* Default value: #000000
+*notification-fg*
+  Defines the foreground color for a notification
 
-notification-error-bg
-^^^^^^^^^^^^^^^^^^^^^
-Defines the background color for an error notification
+  * Value type: String
+  * Default value: #000000
 
-* Value type: String
-* Default value: #FFFFFF
+*notification-error-bg*
+  Defines the background color for an error notification
 
-notification-error-fg
-^^^^^^^^^^^^^^^^^^^^^
-Defines the foreground color for an error notification
+  * Value type: String
+  * Default value: #FFFFFF
 
-* Value type: String
-* Default value: #FF1212
+*notification-error-fg*
+  Defines the foreground color for an error notification
 
-notification-warning-bg
-^^^^^^^^^^^^^^^^^^^^^^^
-Defines the background color for a warning notification
+  * Value type: String
+  * Default value: #FF1212
 
-* Value type: String
-* Default value: #FFFFFF
+*notification-warning-bg*
+  Defines the background color for a warning notification
 
-notification-warning-fg
-^^^^^^^^^^^^^^^^^^^^^^^
-Defines the foreground color for a warning notification
+  * Value type: String
+  * Default value: #FFFFFF
 
-* Value type: String
-* Default value: #FFF712
+*notification-warning-fg*
+  Defines the foreground color for a warning notification
 
-tabbar-fg
-^^^^^^^^^
-Defines the foreground color for a tab
+  * Value type: String
+  * Default value: #FFF712
 
-* Value type: String
-* Default value: #FFFFFF
+*tabbar-fg*
+  Defines the foreground color for a tab
 
-tabbar-bg
-^^^^^^^^^
-Defines the background color for a tab
+  * Value type: String
+  * Default value: #FFFFFF
 
-* Value type: String
-* Default value: #000000
+*tabbar-bg*
+  Defines the background color for a tab
 
-tabbar-focus-fg
-^^^^^^^^^^^^^^^
-Defines the foreground color for the focused tab
+  * Value type: String
+  * Default value: #000000
 
-* Value type: String
-* Default value: #9FBC00
+*tabbar-focus-fg*
+  Defines the foreground color for the focused tab
 
-tabbar-focus-bg
-^^^^^^^^^^^^^^^
-Defines the background color for the focused tab
+  * Value type: String
+  * Default value: #9FBC00
 
-* Value type: String
-* Default value: #000000
+*tabbar-focus-bg*
+  Defines the background color for the focused tab
 
-show-scrollbars
-^^^^^^^^^^^^^^^
-Defines if both the horizontal and vertical scrollbars should be shown or not.
-Deprecated, use 'guioptions' instead.
+  * Value type: String
+  * Default value: #000000
 
-* Value type: Boolean
-* Default value: false
+*show-scrollbars*
+  Defines if both the horizontal and vertical scrollbars should be shown or not.
+  Deprecated, use 'guioptions' instead.
 
-show-h-scrollbar
-^^^^^^^^^^^^^^^^
-Defines whether to show/hide the horizontal scrollbar. Deprecated, use
-'guioptions' instead.
+  * Value type: Boolean
+  * Default value: false
 
-* Value type: Boolean
-* Default value: false
+*show-h-scrollbar*
+  Defines whether to show/hide the horizontal scrollbar. Deprecated, use
+  'guioptions' instead.
 
-show-v-scrollbar
-^^^^^^^^^^^^^^^^
-Defines whether to show/hide the vertical scrollbar. Deprecated, use
-'guioptions' instead.
+  * Value type: Boolean
+  * Default value: false
 
-* Value type: Boolean
-* Default value: false
+*show-v-scrollbar*
+  Defines whether to show/hide the vertical scrollbar. Deprecated, use
+  'guioptions' instead.
 
-statusbar-bg
-^^^^^^^^^^^^
-Defines the background color of the statusbar
+  * Value type: Boolean
+  * Default value: false
 
-* Value type: String
-* Default value: #000000
+*statusbar-bg*
+  Defines the background color of the statusbar
 
-statusbar-fg
-^^^^^^^^^^^^
-Defines the foreground color of the statusbar
+  * Value type: String
+  * Default value: #000000
 
-* Value type: String
-* Default value: #FFFFFF
+*statusbar-fg*
+  Defines the foreground color of the statusbar
 
-statusbar-h-padding
-^^^^^^^^^^^^^^^^^^^
-Defines the horizontal padding of the statusbar and notificationbar
+  * Value type: String
+  * Default value: #FFFFFF
 
-* Value type: Integer
-* Default value: 8
+*statusbar-h-padding*
+  Defines the horizontal padding of the statusbar and notificationbar
 
-statusbar-v-padding
-^^^^^^^^^^^^^^^^^^^
-Defines the vertical padding of the statusbar and notificationbar
+  * Value type: Integer
+  * Default value: 8
 
-* Value type: Integer
-* Default value: 2
+*statusbar-v-padding*
+  Defines the vertical padding of the statusbar and notificationbar
 
-window-icon
-^^^^^^^^^^^
-Defines the path for a icon to be used as window icon.
+  * Value type: Integer
+  * Default value: 2
 
-* Value type: String
-* Default value:
+*window-icon*
+  Defines the path for a icon to be used as window icon.
 
-window-height
-^^^^^^^^^^^^^
-Defines the window height on startup
+  * Value type: String
+  * Default value:
 
-* Value type: Integer
-* Default value: 600
+*window-height*
+  Defines the window height on startup
 
-window-width
-^^^^^^^^^^^^
-Defines the window width on startup
+  * Value type: Integer
+  * Default value: 600
 
-* Value type: Integer
-* Default value: 800
+*window-width*
+  Defines the window width on startup
+
+  * Value type: Integer
+  * Default value: 800
 
 zathura
 -------
 
-This section describes settings concerning the behaviour of zathura.
-
-abort-clear-search
-^^^^^^^^^^^^^^^^^^
-Defines if the search results should be cleared on abort.
-
-* Value type: Boolean
-* Default value: true
+  This section describes settings concerning the behaviour of zathura.
 
-adjust-open
-^^^^^^^^^^^
-Defines which auto adjustment mode should be used if a document is loaded.
-Possible options are "best-fit" and "width".
-
-* Value type: String
-* Default value: best-fit
-
-advance-pages-per-row
-^^^^^^^^^^^^^^^^^^^^^
-Defines if the number of pages per row should be honored when advancing a page.
-
-* Value type: Boolean
-* Default value: false
-
-continuous-hist-save
-^^^^^^^^^^^^^^^^^^^^
-Tells zathura whether to save document history at each page change or only when
-closing a document.
-
-* Value type: Boolean
-* Default value: false
-
-database
-^^^^^^^^
-Defines the database backend to use for bookmarks and input history. Possible
-values are "plain", "sqlite" (if built with sqlite support) and "null". If
-"null" is used, bookmarks and input history will not be stored.
-
-* Value type: String
-* Default value: plain
-
-dbus-service
-^^^^^^^^^^^^
-En/Disables the D-Bus service. If the services is disabled, SyncTeX forward
-synchronization is not available.
-
-* Value type: Boolean
-* Default value: true
-
-filemonitor
-^^^^^^^^^^^
-Defines the file monitor backend used to check for changes in files. Possible
-values are "glib", "signal" (if signal handling is supported), and "noop". The
-"noop" file monitor does not trigger reloads.
-
-* Value type: String
-* Default value: glib
-
-incremental-search
-^^^^^^^^^^^^^^^^^^
-En/Disables incremental search (search while typing).
-
-* Value type: Boolean
-* Default value: true
-
-highlight-color
-^^^^^^^^^^^^^^^
-Defines the color that is used for highlighting parts of the document (e.g.:
-show search results)
-
-* Value type: String
-* Default value: #9FBC00
-
-highlight-active-color
-^^^^^^^^^^^^^^^^^^^^^^
-Defines the color that is used to show the current selected highlighted element
-(e.g: current search result)
-
-* Value type: String
-* Default value: #00BC00
+*abort-clear-search*
+  Defines if the search results should be cleared on abort.
 
-highlight-transparency
-^^^^^^^^^^^^^^^^^^^^^^
-Defines the opacity of a highlighted element
+  * Value type: Boolean
+  * Default value: true
 
-* Value type: Float
-* Default value: 0.5
+*adjust-open*
+  Defines which auto adjustment mode should be used if a document is loaded.
+  Possible options are "best-fit" and "width".
 
-page-padding
-^^^^^^^^^^^^
-The page padding defines the gap in pixels between each rendered page.
+  * Value type: String
+  * Default value: best-fit
 
-* Value type: Integer
-* Default value: 1
+*advance-pages-per-row*
+  Defines if the number of pages per row should be honored when advancing a page.
 
-page-cache-size
-^^^^^^^^^^^^^^^
-Defines the maximum number of pages that could be kept in the page cache. When
-the cache is full and a new page that isn't cached becomes visible, the least
-recently viewed page in the cache will be evicted to make room for the new one.
-Large values for this variable are NOT recommended, because this will lead to
-consuming a significant portion of the system memory.
+  * Value type: Boolean
+  * Default value: false
 
-* Value type: Integer
-* Default value: 15
+*continuous-hist-save*
+  Tells zathura whether to save document history at each page change or only when
+  closing a document.
 
-page-thumbnail-size
-^^^^^^^^^^^^^^^^^^^
-Defines the maximum size in pixels of the thumbnail that could be kept in the
-thumbnail cache per page. The thumbnail is scaled for a quick preview during
-zooming before the page is rendered. When the page is rendered, the result is
-saved as the thumbnail only if the size is no more than this value. A larger
-value increases quality but introduces longer delay in zooming and uses more
-system memory.
+  * Value type: Boolean
+  * Default value: false
 
-* Value type: Integer
-* Default value: 4194304 (4M)
+*database*
+  Defines the database backend to use for bookmarks and input history. Possible
+  values are "plain", "sqlite" (if built with sqlite support) and "null". If
+  "null" is used, bookmarks and input history will not be stored.
 
-pages-per-row
-^^^^^^^^^^^^^
-Defines the number of pages that are rendered next to each other in a row.
+  * Value type: String
+  * Default value: plain
 
-* Value type: Integer
-* Default value: 1
+*dbus-service*
+  En/Disables the D-Bus service. If the services is disabled, SyncTeX forward
+  synchronization is not available.
 
-first-page-column
-^^^^^^^^^^^^^^^^^
-Defines the column in which the first page will be displayed.
-This setting is stored separately for every value of pages-per-row according to
-the following pattern <1 page per row>:[<2 pages per row>[: ...]]. The last
-value in the list will be used for all other number of pages per row if not set
-explicitly.
+  * Value type: Boolean
+  * Default value: true
 
-Per default, the first column is set to 2 for double-page layout, i.e. the faule
-is set to 1:2. A value of 1:1:3 would put the first page in dual-page layour in
-the first column, and for layouts with more columns the first page would be put
-in the 3rd column.
+*filemonitor*
+  Defines the file monitor backend used to check for changes in files. Possible
+  values are "glib", "signal" (if signal handling is supported), and "noop". The
+  "noop" file monitor does not trigger reloads.
 
-* Value type: String
-* Default value: 1:2
+  * Value type: String
+  * Default value: glib
 
-recolor
-^^^^^^^
-En/Disables recoloring
+*incremental-search*
+  En/Disables incremental search (search while typing).
 
-* Value type: Boolean
-* Default value: false
+  * Value type: Boolean
+  * Default value: true
 
-recolor-keephue
-^^^^^^^^^^^^^^^
-En/Disables keeping original hue when recoloring
+*highlight-color*
+  Defines the color that is used for highlighting parts of the document (e.g.:
+  show search results)
 
-* Value type: Boolean
-* Default value: false
+  * Value type: String
+  * Default value: #9FBC00
 
-recolor-darkcolor
-^^^^^^^^^^^^^^^^^
-Defines the color value that is used to represent dark colors in recoloring mode
+*highlight-active-color*
+  Defines the color that is used to show the current selected highlighted element
+  (e.g: current search result)
 
-* Value type: String
-* Default value: #FFFFFF
+  * Value type: String
+  * Default value: #00BC00
 
-recolor-lightcolor
-^^^^^^^^^^^^^^^^^^
-Defines the color value that is used to represent light colors in recoloring mode
+*highlight-transparency*
+  Defines the opacity of a highlighted element
 
-* Value type: String
-* Default value: #000000
+  * Value type: Float
+  * Default value: 0.5
 
-recolor-reverse-video
-^^^^^^^^^^^^^^^^^^^^^
-Defines if original image colors should be kept while recoloring.
+*page-padding*
+  The page padding defines the gap in pixels between each rendered page.
 
-* Value type: Boolean
-* Default value: false
+  * Value type: Integer
+  * Default value: 1
 
-render-loading
-^^^^^^^^^^^^^^
-Defines if the "Loading..." text should be displayed if a page is rendered.
+*page-cache-size*
+  Defines the maximum number of pages that could be kept in the page cache. When
+  the cache is full and a new page that isn't cached becomes visible, the least
+  recently viewed page in the cache will be evicted to make room for the new one.
+  Large values for this variable are NOT recommended, because this will lead to
+  consuming a significant portion of the system memory.
 
-* Value type: Boolean
-* Default value: true
+  * Value type: Integer
+  * Default value: 15
 
-render-loading-bg
-^^^^^^^^^^^^^^^^^
-Defines the background color that is used for the "Loading..." text.
+*page-thumbnail-size*
+  Defines the maximum size in pixels of the thumbnail that could be kept in the
+  thumbnail cache per page. The thumbnail is scaled for a quick preview during
+  zooming before the page is rendered. When the page is rendered, the result is
+  saved as the thumbnail only if the size is no more than this value. A larger
+  value increases quality but introduces longer delay in zooming and uses more
+  system memory.
 
-* Value type: String
-* Default value: #FFFFFF
+  * Value type: Integer
+  * Default value: 4194304 (4M)
 
-render-loading-fg
-^^^^^^^^^^^^^^^^^
-Defines the foreground color that is used for the "Loading..." text.
+*pages-per-row*
+  Defines the number of pages that are rendered next to each other in a row.
 
-* Value type: String
-* Default value: #000000
+  * Value type: Integer
+  * Default value: 1
 
-scroll-hstep
-^^^^^^^^^^^^
-Defines the horizontal step size of scrolling by calling the scroll command once
+*first-page-column*
+  Defines the column in which the first page will be displayed.
+  This setting is stored separately for every value of pages-per-row according to
+  the following pattern <1 page per row>:[<2 pages per row>[: ...]]. The last
+  value in the list will be used for all other number of pages per row if not set
+  explicitly.
 
-* Value type: Float
-* Default value: -1
+  Per default, the first column is set to 2 for double-page layout, i.e. the faule
+  is set to 1:2. A value of 1:1:3 would put the first page in dual-page layour in
+  the first column, and for layouts with more columns the first page would be put
+  in the 3rd column.
 
-scroll-step
-^^^^^^^^^^^
-Defines the step size of scrolling by calling the scroll command once
+  * Value type: String
+  * Default value: 1:2
 
-* Value type: Float
-* Default value: 40
+*recolor*
+  En/Disables recoloring
 
-scroll-full-overlap
-^^^^^^^^^^^^^^^^^^^
-Defines the proportion of the current viewing area that should be
-visible after scrolling a full page.
+  * Value type: Boolean
+  * Default value: false
 
-* Value type: Float
-* Default value: 0
+*recolor-keephue*
+  En/Disables keeping original hue when recoloring
 
-scroll-wrap
-^^^^^^^^^^^
-Defines if the last/first page should be wrapped
+  * Value type: Boolean
+  * Default value: false
 
-* Value type: Boolean
-* Default value: false
+*recolor-darkcolor*
+  Defines the color value that is used to represent dark colors in recoloring mode
 
+  * Value type: String
+  * Default value: #FFFFFF
 
-show-directories
-^^^^^^^^^^^^^^^^
-Defines if the directories should be displayed in completion.
+*recolor-lightcolor*
+  Defines the color value that is used to represent light colors in recoloring mode
 
-* Value type: Boolean
-* Default value: true
+  * Value type: String
+  * Default value: #000000
 
-show-hidden
-^^^^^^^^^^^
-Defines if hidden files and directories should be displayed in completion.
+*recolor-reverse-video*
+  Defines if original image colors should be kept while recoloring.
 
-* Value type: Boolean
-* Default value: false
+  * Value type: Boolean
+  * Default value: false
 
-show-recent
-^^^^^^^^^^^
-Defines the number of recent files that should be displayed in completion.
-If the value is negative, no upper bounds are applied. If the value is 0, no
-recent files are shown.
+*render-loading*
+  Defines if the "Loading..." text should be displayed if a page is rendered.
 
-* Value type: Integer
-* Default value: 10
+  * Value type: Boolean
+  * Default value: true
 
-scroll-page-aware
-^^^^^^^^^^^^^^^^^
-Defines if scrolling by half or full pages stops at page boundaries.
+*render-loading-bg*
+  Defines the background color that is used for the "Loading..." text.
 
-* Value type: Boolean
-* Default value: false
+  * Value type: String
+  * Default value: #FFFFFF
 
-link-zoom
-^^^^^^^^^
-En/Disables the ability of changing zoom when following links.
+*render-loading-fg*
+  Defines the foreground color that is used for the "Loading..." text.
 
-* Value type: Boolean
-* Default value: true
+  * Value type: String
+  * Default value: #000000
 
-link-hadjust
-^^^^^^^^^^^^
-En/Disables aligning to the left internal link targets, for example from the
-index.
+*scroll-hstep*
+  Defines the horizontal step size of scrolling by calling the scroll command once
 
-* Value type: Boolean
-* Default value: true
+  * Value type: Float
+  * Default value: -1
 
-search-hadjust
-^^^^^^^^^^^^^^
-En/Disables horizontally centered search results.
+*scroll-step*
+  Defines the step size of scrolling by calling the scroll command once
 
-* Value type: Boolean
-* Default value: true
+  * Value type: Float
+  * Default value: 40
 
-window-title-basename
-^^^^^^^^^^^^^^^^^^^^^
-Use basename of the file in the window title.
+*scroll-full-overlap*
+  Defines the proportion of the current viewing area that should be
+  visible after scrolling a full page.
 
-* Value type: Boolean
-* Default value: false
+  * Value type: Float
+  * Default value: 0
 
-window-title-home-tilde
-^^^^^^^^^^^^^^^^^^^^^^^
-Display a short version of the file path, which replaces $HOME with ~, in the window title.
+*scroll-wrap*
+  Defines if the last/first page should be wrapped
 
-* Value type: Boolean
-* Default value: false
+  * Value type: Boolean
+  * Default value: false
 
-window-title-page
-^^^^^^^^^^^^^^^^^
-Display the page number in the window title.
 
-* Value type: Boolean
-* Default value: false
+*show-directories*
+  Defines if the directories should be displayed in completion.
 
-statusbar-basename
-^^^^^^^^^^^^^^^^^^
-Use basename of the file in the statusbar.
+  * Value type: Boolean
+  * Default value: true
 
-* Value type: Boolean
-* Default value: false
+*show-hidden*
+  Defines if hidden files and directories should be displayed in completion.
 
-statusbar-home-tilde
-^^^^^^^^^^^^^^^^^^^^
-Display a short version of the file path, which replaces $HOME with ~, in the statusbar.
+  * Value type: Boolean
+  * Default value: false
 
-* Value type: Boolean
-* Default value: false
+*show-recent*
+  Defines the number of recent files that should be displayed in completion.
+  If the value is negative, no upper bounds are applied. If the value is 0, no
+  recent files are shown.
 
-zoom-center
-^^^^^^^^^^^
-En/Disables horizontally centered zooming.
+  * Value type: Integer
+  * Default value: 10
 
-* Value type: Boolean
-* Default value: false
+*scroll-page-aware*
+  Defines if scrolling by half or full pages stops at page boundaries.
 
-vertical-center
-^^^^^^^^^^^^^^^
-Center the screen at the vertical midpoint of the page by default.
+  * Value type: Boolean
+  * Default value: false
 
-* Value type: Boolean
-* Default value: false
+*link-zoom*
+  En/Disables the ability of changing zoom when following links.
 
-zoom-max
-^^^^^^^^
-Defines the maximum percentage that the zoom level can be.
+  * Value type: Boolean
+  * Default value: true
 
-* Value type: Integer
-* Default value: 1000
+*link-hadjust*
+  En/Disables aligning to the left internal link targets, for example from the
+  index.
 
-zoom-min
-^^^^^^^^
-Defines the minimum percentage that the zoom level can be.
+  * Value type: Boolean
+  * Default value: true
 
-* Value type: Integer
-* Default value: 10
+*search-hadjust*
+  En/Disables horizontally centered search results.
 
-zoom-step
-^^^^^^^^^
-Defines the amount of percent that is zoomed in or out on each command.
+  * Value type: Boolean
+  * Default value: true
 
-* Value type: Integer
-* Default value: 10
+*window-title-basename*
+  Use basename of the file in the window title.
 
-selection-clipboard
-^^^^^^^^^^^^^^^^^^^
-Defines the X clipboard into which mouse-selected data will be written.  When it
-is "clipboard", selected data will be written to the CLIPBOARD clipboard, and
-can be pasted using the Ctrl+v key combination.  When it is "primary", selected
-data will be written to the PRIMARY clipboard, and can be pasted using the
-middle mouse button, or the Shift-Insert key combination.
+  * Value type: Boolean
+  * Default value: false
 
-* Value type: String
-* Default value: primary
+*window-title-home-tilde*
+  Display a short version of the file path, which replaces $HOME with ~, in the window title.
 
-selection-notification
-^^^^^^^^^^^^^^^^^^^^^^
-Defines if a notification should be displayed after selecting text.
+  * Value type: Boolean
+  * Default value: false
 
-* Value type: Boolean
-* Default value: true
+*window-title-page*
+  Display the page number in the window title.
 
-synctex
-^^^^^^^
-En/Disables SyncTeX backward synchronization support.
+  * Value type: Boolean
+  * Default value: false
 
-* Value type: Boolean
-* Default value: true
+*statusbar-basename*
+  Use basename of the file in the statusbar.
 
-synctex-editor-command
-^^^^^^^^^^^^^^^^^^^^^^
-Defines the command executed for SyncTeX backward synchronization.
+  * Value type: Boolean
+  * Default value: false
 
-* Value type: String
-* Default value:
+*statusbar-home-tilde*
+  Display a short version of the file path, which replaces $HOME with ~, in the statusbar.
 
-index-fg
-^^^^^^^^
-Defines the foreground color of the index mode.
+  * Value type: Boolean
+  * Default value: false
 
-* Value type: String
-* Default value: #DDDDDD
+*zoom-center*
+  En/Disables horizontally centered zooming.
 
-index-bg
-^^^^^^^^
-Define the background color of the index mode.
+  * Value type: Boolean
+  * Default value: false
 
-* Value type: String
-* Default value: #232323
+*vertical-center*
+  Center the screen at the vertical midpoint of the page by default.
 
-index-active-fg
-^^^^^^^^^^^^^^^
-Defines the foreground color of the selected element in index mode.
+  * Value type: Boolean
+  * Default value: false
 
-* Value type: String
-* Default value: #232323
+*zoom-max*
+  Defines the maximum percentage that the zoom level can be.
 
-index-active-bg
-^^^^^^^^^^^^^^^
-Define the background color of the selected element in index mode.
+  * Value type: Integer
+  * Default value: 1000
 
-* Value type: String
-* Default value: #9FBC00
+*zoom-min*
+  Defines the minimum percentage that the zoom level can be.
 
-sandbox
-^^^^^^^
-Defines the sandbox mode to use for the seccomp syscall filter. Possible
-values are "none", "normal" and "strict". If "none" is used, the sandbox
-will be disabled. The use of "normal" will provide minimal protection and
-allow normal use of zathura with support for all features. The "strict" mode
-is a read only sandbox that is intended for viewing documents only.
+  * Value type: Integer
+  * Default value: 10
 
-* Value type: String
-* Default value: normal
+*zoom-step*
+  Defines the amount of percent that is zoomed in or out on each command.
 
-Some features are disabled when using strict sandbox mode:
+  * Value type: Integer
+  * Default value: 10
 
-* saving/writing files
-* use of input methods like ibus
-* printing
-* bookmarks and history
+*selection-clipboard*
+  Defines the X clipboard into which mouse-selected data will be written.  When it
+  is "clipboard", selected data will be written to the CLIPBOARD clipboard, and
+  can be pasted using the Ctrl+v key combination.  When it is "primary", selected
+  data will be written to the PRIMARY clipboard, and can be pasted using the
+  middle mouse button, or the Shift-Insert key combination.
 
-No feature regressions are expected when using normal sandbox mode.
+  * Value type: String
+  * Default value: primary
 
-When running under WSL, the default is "none" since seccomp is not supported in
-that environment.
+*selection-notification*
+  Defines if a notification should be displayed after selecting text.
 
-window-icon-document
-^^^^^^^^^^^^^^^^^^^^
-Defines whether the window document should be updated based on the first page of
-a dcument.
+  * Value type: Boolean
+  * Default value: true
 
-* Value type: Boolean
-* Default value: false
+*synctex*
+  En/Disables SyncTeX backward synchronization support.
 
-page-right-to-left
-^^^^^^^^^^^^^^^^^^
-Defines whether pages in multi-column view should start from the right side.
+  * Value type: Boolean
+  * Default value: true
 
-* Value type: Boolean
-* Default value: false
+*synctex-editor-command*
+  Defines the command executed for SyncTeX backward synchronization.
+
+  * Value type: String
+  * Default value:
+
+*index-fg*
+  Defines the foreground color of the index mode.
+
+  * Value type: String
+  * Default value: #DDDDDD
+
+*index-bg*
+  Define the background color of the index mode.
+
+  * Value type: String
+  * Default value: #232323
+
+*index-active-fg*
+  Defines the foreground color of the selected element in index mode.
+
+  * Value type: String
+  * Default value: #232323
+
+*index-active-bg*
+  Define the background color of the selected element in index mode.
+
+  * Value type: String
+  * Default value: #9FBC00
+
+*sandbox*
+  Defines the sandbox mode to use for the seccomp syscall filter. Possible
+  values are "none", "normal" and "strict". If "none" is used, the sandbox
+  will be disabled. The use of "normal" will provide minimal protection and
+  allow normal use of zathura with support for all features. The "strict" mode
+  is a read only sandbox that is intended for viewing documents only.
+
+  * Value type: String
+  * Default value: normal
+
+  Some features are disabled when using strict sandbox mode:
+
+  * saving/writing files
+  * use of input methods like ibus
+  * printing
+  * bookmarks and history
+
+  No feature regressions are expected when using normal sandbox mode.
+
+  When running under WSL, the default is "none" since seccomp is not supported in
+  that environment.
+
+*window-icon-document*
+  Defines whether the window document should be updated based on the first page of
+  a dcument.
+
+  * Value type: Boolean
+  * Default value: false
+
+*page-right-to-left*
+  Defines whether pages in multi-column view should start from the right side.
+
+  * Value type: Boolean
+  * Default value: false
 
 SEE ALSO
 ========


### PR DESCRIPTION
- in zathura.1.rst, move "Environmental variables" section closer to bottom

- in zathurarc.5.rst, change from using subsections to using
  definitions (in order to make levels clearer on output to terminal)