### PR TITLE
bash completion: Allow completions to work without external functions

### DIFF
--- a/data/bash-completion.in
+++ b/data/bash-completion.in
@@ -9,7 +9,7 @@ _zathura() {
         EXTS="$EXTS|pdf|PDF"
         ;;
       libpdf-mupdf.so)
-        EXTS="$EXTS|pdf|PDF|epub|oxps"
+        EXTS="$EXTS|pdf|PDF|epub|oxps|xhtml"
         ;;
       libps.so)
         EXTS="$EXTS|ps|eps|epsi|epsf"

--- a/data/bash-completion.in
+++ b/data/bash-completion.in
@@ -1,5 +1,6 @@
+#!/bin/bash
 _zathura() {
-  _init_completion || return
+  _init_completion 2>/dev/null || true
 
   local EXTS=""
   for PLUGIN in @PLUGINDIR@/lib*.so; do
@@ -22,6 +23,6 @@ _zathura() {
     esac
   done
 
-  _filedir "${EXTS#|}"
+  _filedir "${EXTS#|}" 2>/dev/null || COMPREPLY=($(shopt -s extglob; compgen -f -X "!*.@($EXTS)"))
 }
 complete -F _zathura zathura


### PR DESCRIPTION
bash completion: Allow completions to work without external functions

If bash_completion wasn't installed, _filedir wouldn't be defined which
led to all filename-based completions to error out. Specifically
autocompletion would fail when a filename was expected and when
bash_completion wasn't installed. Now we fall back to compgen -f if
_filedir fails. According to _filedir's comments, compgen doesn't
handle files with spaces well, but it is still better to complete most
files than none.

Also allowed xhtml files to be autocompleted since MuPDF supports them.

