### PR TITLE
Show grid padding when recode (black pages)

### DIFF
--- a/data/zathura.css_t
+++ b/data/zathura.css_t
@@ -9,3 +9,7 @@
   color: @index-active-fg@;
   background-color: @index-active-bg@;
 }
+
+#@session@ grid {
+    background-color: #444;
+}


### PR DESCRIPTION
*On GitLab by @softmoth on Mar 1, 2021, 12:05*

---

It is nice to see the page grid both normally and when colors have been
recoded. The easy way to do this is to change the grid background to
gray instead of pure black, so it contrasts against either white pages
(typical of most documents) or black pages (typical recoded color).