### PR TITLE
fix: Make Home/End generate jumplist entry

### DIFF
--- a/zathura/config.c
+++ b/zathura/config.c
@@ -386,7 +386,9 @@ void config_load_default(zathura_t* zathura) {
   girara_shortcut_add(gsession, 0, GDK_KEY_f, NULL, sc_follow, (mode), 0, NULL);                                       \
                                                                                                                        \
   girara_shortcut_add(gsession, 0, 0, "gg", sc_goto, (mode), TOP, NULL);                                               \
+  girara_shortcut_add(gsession, 0, GDK_KEY_Home, NULL, sc_goto, (mode), TOP, NULL);                                    \
   girara_shortcut_add(gsession, 0, 0, "G", sc_goto, (mode), BOTTOM, NULL);                                             \
+  girara_shortcut_add(gsession, 0, GDK_KEY_End, NULL, sc_goto, (mode), BOTTOM, NULL);                                  \
                                                                                                                        \
   girara_shortcut_add(gsession, 0, GDK_KEY_m, NULL, sc_mark_add, (mode), 0, NULL);                                     \
   girara_shortcut_add(gsession, 0, GDK_KEY_apostrophe, NULL, sc_mark_evaluate, (mode), 0, NULL);                       \


### PR DESCRIPTION
Fixes part one of #461 , making `Home` and `End` call the same function as `gg` and `G`

I however disagree of the second part of the issue (to make `End` go to the bottom of the last page instead of the top). However, this should be easy to implement so feel free to comment