### PR TITLE
feat: Highlight the current index row when toggling the index

### DIFF
--- a/zathura/shortcuts.c
+++ b/zathura/shortcuts.c
@@ -1094,7 +1094,7 @@ sc_navigate_index(girara_session_t* session, girara_argument_t* argument,
       path = gtk_tree_path_new_first();
       break;
     case BOTTOM:
-      /* go to the last visiible node */
+      /* go to the last visible node */
       gtk_tree_path_free(path);
       path = gtk_tree_path_new_from_indices(gtk_tree_model_iter_n_children(model, NULL) - 1, -1);
       gtk_tree_model_get_iter(model, &iter, path);
@@ -1294,6 +1294,7 @@ sc_toggle_index(girara_session_t* session, girara_argument_t* UNUSED(argument),
     }
 
     girara_set_view(session, zathura->ui.index);
+    index_scroll_to_current_page(session);
     gtk_widget_show(GTK_WIDGET(zathura->ui.index));
     girara_mode_set(zathura->ui.session, zathura->modes.index);
   }

--- a/zathura/utils.c
+++ b/zathura/utils.c
@@ -116,6 +116,36 @@ void document_index_build(girara_session_t* session, GtkTreeModel* model,
   }
 }
 
+gboolean _for_each_func(GtkTreeModel* model, GtkTreePath* path, GtkTreeIter *iter, gpointer data)
+{
+  zathura_t *zathura = (zathura_t* )data;
+  zathura_index_element_t* index_element;
+  gtk_tree_model_get(model, iter, 3, &index_element, -1);
+  zathura_link_target_t target  = zathura_link_get_target(index_element->link);
+  unsigned int current_page_nb = zathura_document_get_current_page_number(zathura->document);
+  if (current_page_nb < target.page_number)
+  {
+    GtkTreeView *tree_view = gtk_container_get_children(GTK_CONTAINER(zathura->ui.index))->data;
+    if (gtk_tree_path_prev(path) != FALSE)
+    {
+      gtk_tree_view_expand_to_path(tree_view, path);
+      gtk_tree_view_set_cursor(tree_view, path, NULL, FALSE);
+      gtk_tree_view_scroll_to_cell(tree_view, path, NULL, TRUE, 0.5, 0.0);
+    }
+
+    return TRUE;
+  }
+  return FALSE;
+}
+
+void index_scroll_to_current_page(girara_session_t* session)
+{
+  zathura_t *zathura = session->global.data;
+  GtkTreeView *tree_view = gtk_container_get_children(GTK_CONTAINER(zathura->ui.index))->data;
+  GtkTreeModel *model = gtk_tree_view_get_model(tree_view);
+  gtk_tree_model_foreach(model, _for_each_func, (gpointer)zathura);
+}
+
 zathura_rectangle_t rotate_rectangle(zathura_rectangle_t rectangle, unsigned int degree, double height, double width) {
   zathura_rectangle_t tmp;
   switch (degree) {

--- a/zathura/utils.h
+++ b/zathura/utils.h
@@ -38,6 +38,7 @@ bool file_valid_extension(zathura_t* zathura, const char* path);
  */
 void document_index_build(girara_session_t* session, GtkTreeModel* model, GtkTreeIter* parent, girara_tree_node_t* tree);
 
+void index_scroll_to_current_page(girara_session_t* session);
 /**
  * Rotate a rectangle by 0, 90, 180 or 270 degree
  *


### PR DESCRIPTION
First step at fixing #430 

When open the index, the cursor is now at the row where the current page is contained