### PR TITLE
DRAFT: Add landlock support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -79,6 +79,7 @@ flags = cc.get_supported_arguments(flags)
 additional_sources = []
 synctex = dependency('synctex', version: '>=1.19', required: get_option('synctex'))
 seccomp = dependency('libseccomp', required: get_option('seccomp'))
+#landlock = dependency('linux', version: '>=5.13', required: get_option('landlock'))
 
 if synctex.found()
   build_dependencies += synctex
@@ -92,6 +93,11 @@ if seccomp.found()
   build_dependencies += seccomp
   defines += '-DWITH_SECCOMP'
   additional_sources += files('zathura/seccomp-filters.c')
+endif
+
+if get_option('landlock').auto()
+  defines += '-DWITH_LANDLOCK'
+  additional_sources += files('zathura/landlock.c')
 endif
 
 # generate version header file

--- a/meson.build
+++ b/meson.build
@@ -79,7 +79,7 @@ flags = cc.get_supported_arguments(flags)
 additional_sources = []
 synctex = dependency('synctex', version: '>=1.19', required: get_option('synctex'))
 seccomp = dependency('libseccomp', required: get_option('seccomp'))
-#landlock = dependency('linux', version: '>=5.13', required: get_option('landlock'))
+landlock = cc.check_header('linux/landlock.h', required: get_option('landlock'))
 
 if synctex.found()
   build_dependencies += synctex
@@ -95,7 +95,7 @@ if seccomp.found()
   additional_sources += files('zathura/seccomp-filters.c')
 endif
 
-if get_option('landlock').auto()
+if landlock
   defines += '-DWITH_LANDLOCK'
   additional_sources += files('zathura/landlock.c')
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,6 +8,11 @@ option('seccomp',
   value: 'auto',
   description: 'seccomp-based sandbox'
 )
+option('landlock',
+  type: 'feature',
+  value: 'auto',
+  description: 'landlock-based sandbox'
+)
 option('manpages',
   type: 'feature',
   value: 'auto',

--- a/zathura/landlock.c
+++ b/zathura/landlock.c
@@ -1,7 +1,9 @@
+#if WITH_LANDLOCK
 #define _GNU_SOURCE
 #include <linux/landlock.h>
 #include <sys/prctl.h>
 #include <sys/syscall.h>
+#endif
 #include <stdio.h>
 #include <fcntl.h> 
 #include <unistd.h> 
@@ -71,18 +73,20 @@ landlock_drop (__u64 fs_access)
   LANDLOCK_ACCESS_FS_READ_FILE | \
   LANDLOCK_ACCESS_FS_READ_DIR)
 
+#if WITH_LANDLOCK
 void
 landlock_drop_write (void)
 {
-  landlock_drop(_LANDLOCK_ACCESS_FS_WRITE | \
+  landlock_drop(_LANDLOCK_ACCESS_FS_WRITE |
     LANDLOCK_ACCESS_FS_EXECUTE);
 }
+#endif
 
 void
 landlock_drop_all (void)
 {
-  landlock_drop(_LANDLOCK_ACCESS_FS_READ | \
-    _LANDLOCK_ACCESS_FS_WRITE | \
+  landlock_drop(_LANDLOCK_ACCESS_FS_READ |
+    _LANDLOCK_ACCESS_FS_WRITE |
     LANDLOCK_ACCESS_FS_EXECUTE);
 }
 

--- a/zathura/landlock.c
+++ b/zathura/landlock.c
@@ -1,0 +1,155 @@
+#define _GNU_SOURCE
+#include <linux/landlock.h>
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+#include <stdio.h>
+#include <fcntl.h> // for open
+#include <unistd.h> // for close
+#include <girara/utils.h>
+
+//#include <stdlib.h>
+
+#include "landlock.h"
+
+
+#ifndef landlock_create_ruleset
+static inline int
+landlock_create_ruleset(const struct landlock_ruleset_attr *const attr,
+			const size_t size, const __u32 flags)
+{
+	return syscall(__NR_landlock_create_ruleset, attr, size, flags);
+}
+#endif
+
+#ifndef landlock_add_rule
+static inline int
+landlock_add_rule(const int ruleset_fd,
+		  const enum landlock_rule_type rule_type,
+		  const void *const rule_attr, const __u32 flags)
+{
+	return syscall(__NR_landlock_add_rule, ruleset_fd, rule_type,
+			rule_attr, flags);
+}
+#endif
+
+#ifndef landlock_restrict_self
+static inline int
+landlock_restrict_self(const int ruleset_fd, const __u32 flags)
+{
+	return syscall(__NR_landlock_restrict_self, ruleset_fd, flags);
+}
+#endif
+
+/*
+struct landlock_ruleset_attr ruleset_attr = {
+    .handled_access_fs =
+        LANDLOCK_ACCESS_FS_EXECUTE |
+        LANDLOCK_ACCESS_FS_WRITE_FILE |
+        LANDLOCK_ACCESS_FS_READ_FILE |
+        LANDLOCK_ACCESS_FS_READ_DIR |
+        LANDLOCK_ACCESS_FS_REMOVE_DIR |
+        LANDLOCK_ACCESS_FS_REMOVE_FILE |
+        LANDLOCK_ACCESS_FS_MAKE_CHAR |
+        LANDLOCK_ACCESS_FS_MAKE_DIR |
+        LANDLOCK_ACCESS_FS_MAKE_REG |
+        LANDLOCK_ACCESS_FS_MAKE_SOCK |
+        LANDLOCK_ACCESS_FS_MAKE_FIFO |
+        LANDLOCK_ACCESS_FS_MAKE_BLOCK |
+        LANDLOCK_ACCESS_FS_MAKE_SYM |
+        LANDLOCK_ACCESS_FS_REFER,
+};
+*/
+
+static void
+landlock_drop (__u64 fs_access)
+{
+  const struct landlock_ruleset_attr ruleset_attr = {
+    .handled_access_fs = fs_access,
+  };
+  int ruleset_fd;
+
+  ruleset_fd = landlock_create_ruleset(&ruleset_attr, sizeof(ruleset_attr), 0);
+  if (ruleset_fd < 0)
+    return;
+  prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
+  if (landlock_restrict_self(ruleset_fd, 0))
+    perror ("landlock_restrict_self");
+  close(ruleset_fd);
+}
+
+#define _LANDLOCK_ACCESS_FS_WRITE ( \
+  LANDLOCK_ACCESS_FS_WRITE_FILE | \
+  LANDLOCK_ACCESS_FS_REMOVE_DIR | \
+  LANDLOCK_ACCESS_FS_REMOVE_FILE | \
+  LANDLOCK_ACCESS_FS_MAKE_CHAR | \
+  LANDLOCK_ACCESS_FS_MAKE_DIR | \
+  LANDLOCK_ACCESS_FS_MAKE_REG | \
+  LANDLOCK_ACCESS_FS_MAKE_SOCK | \
+  LANDLOCK_ACCESS_FS_MAKE_FIFO | \
+  LANDLOCK_ACCESS_FS_MAKE_BLOCK | \
+  LANDLOCK_ACCESS_FS_MAKE_SYM)
+
+#define _LANDLOCK_ACCESS_FS_READ ( \
+  LANDLOCK_ACCESS_FS_READ_FILE | \
+  LANDLOCK_ACCESS_FS_READ_DIR)
+
+void
+landlock_drop_write (void)
+{
+  landlock_drop(_LANDLOCK_ACCESS_FS_WRITE | \
+    LANDLOCK_ACCESS_FS_EXECUTE);
+}
+
+void
+landlock_drop_all (void)
+{
+  landlock_drop(_LANDLOCK_ACCESS_FS_READ | \
+    _LANDLOCK_ACCESS_FS_WRITE | \
+    LANDLOCK_ACCESS_FS_EXECUTE);
+}
+
+
+
+void
+landlock_write_fd (const int dir_fd)
+{
+  const struct landlock_ruleset_attr ruleset_attr = {
+    .handled_access_fs = \
+      _LANDLOCK_ACCESS_FS_WRITE | \
+      LANDLOCK_ACCESS_FS_EXECUTE,
+  };
+  struct landlock_path_beneath_attr path_beneath = {
+    .allowed_access = _LANDLOCK_ACCESS_FS_WRITE,
+  };
+  int ruleset_fd;
+
+  ruleset_fd = landlock_create_ruleset(&ruleset_attr, sizeof(ruleset_attr), 0);
+  if (ruleset_fd < 0)
+    return;
+  if (dir_fd == -1)
+    path_beneath.parent_fd = open(".", O_PATH | O_CLOEXEC | O_DIRECTORY);
+  else
+    path_beneath.parent_fd = dir_fd;
+
+  if (!landlock_add_rule(ruleset_fd, LANDLOCK_RULE_PATH_BENEATH, &path_beneath, 0)) {
+    prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
+    if (landlock_restrict_self(ruleset_fd, 0))
+      perror ("landlock_restrict_self");
+  } else {
+    perror ("landlock_add_rule");
+  }
+
+  if (dir_fd == -1)
+    close (path_beneath.parent_fd);
+  close(ruleset_fd);
+}
+
+
+
+void
+landlock_restrict_write(void)
+{
+    char* data_path = girara_get_xdg_path(XDG_DATA);
+    int fd = open(data_path, O_PATH | O_CLOEXEC | O_DIRECTORY);
+    landlock_write_fd(fd);
+}

--- a/zathura/landlock.c
+++ b/zathura/landlock.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Zlib */
+
 #if WITH_LANDLOCK
 #define _GNU_SOURCE
 #include <linux/landlock.h>

--- a/zathura/landlock.c
+++ b/zathura/landlock.c
@@ -3,11 +3,9 @@
 #include <sys/prctl.h>
 #include <sys/syscall.h>
 #include <stdio.h>
-#include <fcntl.h> // for open
-#include <unistd.h> // for close
+#include <fcntl.h> 
+#include <unistd.h> 
 #include <girara/utils.h>
-
-//#include <stdlib.h>
 
 #include "landlock.h"
 
@@ -39,26 +37,6 @@ landlock_restrict_self(const int ruleset_fd, const __u32 flags)
 	return syscall(__NR_landlock_restrict_self, ruleset_fd, flags);
 }
 #endif
-
-/*
-struct landlock_ruleset_attr ruleset_attr = {
-    .handled_access_fs =
-        LANDLOCK_ACCESS_FS_EXECUTE |
-        LANDLOCK_ACCESS_FS_WRITE_FILE |
-        LANDLOCK_ACCESS_FS_READ_FILE |
-        LANDLOCK_ACCESS_FS_READ_DIR |
-        LANDLOCK_ACCESS_FS_REMOVE_DIR |
-        LANDLOCK_ACCESS_FS_REMOVE_FILE |
-        LANDLOCK_ACCESS_FS_MAKE_CHAR |
-        LANDLOCK_ACCESS_FS_MAKE_DIR |
-        LANDLOCK_ACCESS_FS_MAKE_REG |
-        LANDLOCK_ACCESS_FS_MAKE_SOCK |
-        LANDLOCK_ACCESS_FS_MAKE_FIFO |
-        LANDLOCK_ACCESS_FS_MAKE_BLOCK |
-        LANDLOCK_ACCESS_FS_MAKE_SYM |
-        LANDLOCK_ACCESS_FS_REFER,
-};
-*/
 
 static void
 landlock_drop (__u64 fs_access)
@@ -108,8 +86,6 @@ landlock_drop_all (void)
     LANDLOCK_ACCESS_FS_EXECUTE);
 }
 
-
-
 void
 landlock_write_fd (const int dir_fd)
 {
@@ -143,8 +119,6 @@ landlock_write_fd (const int dir_fd)
     close (path_beneath.parent_fd);
   close(ruleset_fd);
 }
-
-
 
 void
 landlock_restrict_write(void)

--- a/zathura/landlock.h
+++ b/zathura/landlock.h
@@ -1,0 +1,3 @@
+void landlock_drop_write (void);
+void landlock_restrict_write (void);
+

--- a/zathura/landlock.h
+++ b/zathura/landlock.h
@@ -1,3 +1,13 @@
+ #if WITH_LANDLOCK
+
+/*
+** remove write and execute permissions
+*/
 void landlock_drop_write (void);
+
+/*
+** restrict write permissions to XDG_DATA
+*/
 void landlock_restrict_write (void);
 
+#endif

--- a/zathura/landlock.h
+++ b/zathura/landlock.h
@@ -1,4 +1,7 @@
- #if WITH_LANDLOCK
+/* SPDX-License-Identifier: Zlib */
+
+#ifndef ZATHURA_LANDLOCK_H
+#define ZATHURA_LANDLOCK_H
 
 /*
 ** remove write and execute permissions


### PR DESCRIPTION
This adds landlock support to the sandbox feature.

While the seccomp filter should already prevent writing to files, this adds another safeguard to prevent file modifications.

Todo:
- fix dependency check in meson (check for kernel version)
- cleanup landlock.c (remove unused functions) 

