### PR TITLE
Disable page adjustment on gesture zoom

### DIFF
--- a/zathura/callbacks.c
+++ b/zathura/callbacks.c
@@ -823,6 +823,7 @@ cb_gesture_zoom_scale_changed(GtkGestureZoom* UNUSED(self), gdouble scale, void*
 
   const double next_zoom = zathura->gesture.initial_zoom * scale;
   const double corrected_zoom = zathura_correct_zoom_value(zathura->ui.session, next_zoom);
+  zathura_document_set_adjust_mode(zathura->document, ZATHURA_ADJUST_NONE);
   zathura_document_set_zoom(zathura->document, corrected_zoom);
   render_all(zathura);
   refresh_view(zathura);


### PR DESCRIPTION
This fixes zoom breaking when page adjustment is active.

Repro:
- open any PDF
- press A or S to enable page adjustment
- try zooming by pinching on the touchpad

This gets zoom stuck in a weird broken state which can only be cleared by resizing the window.

I just copied this line over from sc_zoom(), but I wonder if a better fix isn't to simply call that? It's what scroll zoom does (including touchpad smooth scroll), and there's less potential for bugs if every zoom input takes the same code path.