### PR TITLE
Disable default gtk dbus connection

### DIFF
--- a/zathura/main-sandbox.c
+++ b/zathura/main-sandbox.c
@@ -188,6 +188,10 @@ GIRARA_VISIBLE int main(int argc, char* argv[]) {
     }
   }
 
+  girara_debug("Running zathura-sandbox, disable IPC services");
+  /* Prevent default gtk dbus connection */
+  g_setenv("DBUS_SESSION_BUS_ADDRESS", "disabled:", TRUE);
+
   /* Initialize GTK+ */
   gtk_init(&argc, &argv);
 


### PR DESCRIPTION
Prevents gtk_init() from opening a dbus socket connection that could potentially be used for sandbox escape