### PR TITLE
Refactor/fix current index row

### DIFF
--- a/zathura/shortcuts.c
+++ b/zathura/shortcuts.c
@@ -1248,7 +1248,7 @@ bool sc_toggle_index(girara_session_t* session, girara_argument_t* UNUSED(argume
     }
 
     girara_set_view(session, zathura->ui.index);
-    index_scroll_to_current_page(session);
+    index_scroll_to_current_page(zathura);
     gtk_widget_show(GTK_WIDGET(zathura->ui.index));
     girara_mode_set(zathura->ui.session, zathura->modes.index);
   }

--- a/zathura/utils.h
+++ b/zathura/utils.h
@@ -38,7 +38,13 @@ bool file_valid_extension(zathura_t* zathura, const char* path);
 void document_index_build(girara_session_t* session, GtkTreeModel* model, GtkTreeIter* parent,
                           girara_tree_node_t* tree);
 
-void index_scroll_to_current_page(girara_session_t* session);
+/**
+ * Scrolls the document index to the current page
+ *
+ * @param zathura The zathura instance
+ */
+void index_scroll_to_current_page(zathura_t* zathura);
+
 /**
  * Rotate a rectangle by 0, 90, 180 or 270 degree
  *


### PR DESCRIPTION
Refactor and simplify by remembering the last index path with `index path page number` <= `current page`.

Fix #613.