### PR TITLE
Fix documentation for `cycle_first_column`

### DIFF
--- a/doc/man/zathurarc.5.rst
+++ b/doc/man/zathurarc.5.rst
@@ -225,7 +225,7 @@ They can also be combined with modifiers:
 
     Change current mode. Pass the desired mode as argument.
 
-  * ``cycle_first_page``
+  * ``cycle_first_column``
 
     In multiple page layout, cycle the column in which the first page is displayed.
 


### PR DESCRIPTION
Fix documentation typo in https://github.com/pwmt/zathura/commit/caf087ca2047123e8af0a532a1e39e91812b25cf.