### PR TITLE
Fix flickering page number

### DIFF
--- a/zathura/shortcuts.c
+++ b/zathura/shortcuts.c
@@ -648,7 +648,9 @@ bool sc_scroll(girara_session_t* session, girara_argument_t* argument, girara_ev
   const double new_x = scroll_wrap ? 1.0 - end_x : end_x;
   const double new_y = scroll_wrap ? 1.0 - end_y : end_y;
 
-  if (pos_x < end_x) {
+  /* NOTE: the following `+ DBL_EPSILON` is added to avoid rounding errors, which can result in
+   *       unwanted changes of page when positioned precisely in the middle of a dual-pane layout */
+  if (pos_x < end_x + DBL_EPSILON) {
     pos_x = new_x;
   } else if (pos_x > 1.0 - end_x) {
     pos_x = 1 - new_x;


### PR DESCRIPTION
Previously, when scrolling with dual-page layout positioned in the exact center (for example obtained by best-fit adjustment), the boundary handling could change horizontal alignment in such a way that resulted in flickering of the page number between two visible pages.

This simple fix seems to work, however, I am not sure whether this is the best way. Other suggestions are welcome.

Fixes #646.