### PR TITLE
search once

### DIFF
--- a/zathura/callbacks.c
+++ b/zathura/callbacks.c
@@ -76,7 +76,8 @@ void update_visible_pages(zathura_t* zathura) {
       GObject* obj_page_widget = G_OBJECT(page_widget);
       g_object_get(obj_page_widget, "search-results", &results, NULL);
       if (results != NULL) {
-        g_object_set(obj_page_widget, "search-current", 0, NULL);
+        g_object_set(obj_page_widget, "search-current",
+                     zathura->global.search_direction == FORWARD ? 0 : girara_list_size(results) - 1, NULL);
       }
     }
   }

--- a/zathura/commands.c
+++ b/zathura/commands.c
@@ -403,6 +403,8 @@ bool cmd_search(girara_session_t* session, const char* input, girara_argument_t*
   g_return_val_if_fail(zathura->document != NULL, false);
   g_return_val_if_fail(strlen(input) != 0, false);
 
+  zathura->global.search_direction = argument->n;
+
   const unsigned int num_pages = zathura_document_get_number_of_pages(zathura->document);
 
   /* reset pages */

--- a/zathura/document.c
+++ b/zathura/document.c
@@ -26,6 +26,7 @@ struct zathura_document_s {
   char* file_path;                   /**< File path of the document */
   char* uri;                         /**< URI of the document */
   char* basename;                    /**< Basename of the document */
+  char* search_string;               /**< Current search string */
   uint8_t hash_sha256[32];           /**< SHA256 hash of the document */
   const char* password;              /**< Password of the document */
   unsigned int current_page_number;  /**< Current page number */
@@ -255,6 +256,9 @@ zathura_error_t zathura_document_free(zathura_document_t* document) {
   g_free(document->file_path);
   g_free(document->uri);
   g_free(document->basename);
+  if (document->search_string != NULL) {
+    g_free(document->search_string);
+  }
   g_free(document);
 
   return error;
@@ -290,6 +294,25 @@ const char* zathura_document_get_basename(zathura_document_t* document) {
   }
 
   return document->basename;
+}
+
+const char* zathura_document_get_search_string(zathura_document_t* document) {
+  if (document == NULL) {
+    return NULL;
+  }
+
+  return document->search_string;
+}
+
+void zathura_document_set_search_string(zathura_document_t* document, const char* search_string) {
+  if (document == NULL) {
+    return;
+  }
+
+  if (document->search_string != NULL) {
+    g_free(document->search_string);
+  }
+  document->search_string = g_strdup(search_string);
 }
 
 const char* zathura_document_get_password(zathura_document_t* document) {

--- a/zathura/document.h
+++ b/zathura/document.h
@@ -56,6 +56,22 @@ ZATHURA_PLUGIN_API const char* zathura_document_get_uri(zathura_document_t* docu
 ZATHURA_PLUGIN_API const char* zathura_document_get_basename(zathura_document_t* document);
 
 /**
+ * Returns the current search string
+ *
+ * @param document The document
+ * @return Current search string
+ */
+ZATHURA_PLUGIN_API const char* zathura_document_get_search_string(zathura_document_t* document);
+
+/**
+ * Sets the new search string
+ *
+ * @param document The document
+ * @return The new search string
+ */
+ZATHURA_PLUGIN_API void zathura_document_set_search_string(zathura_document_t* document, const char* search_string);
+
+/**
  * Returns the SHA256 hash of the document
  *
  * @param document The document

--- a/zathura/page-widget.c
+++ b/zathura/page-widget.c
@@ -36,6 +36,7 @@ typedef struct zathura_page_widget_private_s {
     girara_list_t* list; /**< A list if there are search results that should be drawn */
     int current;         /**< The index of the current search result */
     gboolean draw;       /**< Draw search results */
+    gboolean skip;       /**< Whether a search has been conducted on this page */
   } search;
 
   struct {
@@ -101,6 +102,7 @@ enum properties_e {
   PROP_SEARCH_RESULTS,
   PROP_SEARCH_RESULTS_LENGTH,
   PROP_SEARCH_RESULTS_CURRENT,
+  PROP_SEARCH_SKIP,
   PROP_DRAW_SEARCH_RESULTS,
   PROP_LAST_VIEW,
   PROP_DRAW_SIGNATURES,
@@ -161,6 +163,9 @@ static void zathura_page_widget_class_init(ZathuraPageClass* class) {
                                   g_param_spec_int("search-current", "search-current", "The current search result", -1,
                                                    INT_MAX, 0,
                                                    G_PARAM_WRITABLE | G_PARAM_READABLE | G_PARAM_STATIC_STRINGS));
+  g_object_class_install_property(object_class, PROP_SEARCH_SKIP,
+                                  g_param_spec_boolean("search-skip", "search-skip", "The current search result", FALSE,
+                                                       G_PARAM_WRITABLE | G_PARAM_READABLE | G_PARAM_STATIC_STRINGS));
   g_object_class_install_property(object_class, PROP_SEARCH_RESULTS_LENGTH,
                                   g_param_spec_int("search-length", "search-length", "The number of search results", -1,
                                                    INT_MAX, 0, G_PARAM_READABLE | G_PARAM_STATIC_STRINGS));
@@ -208,6 +213,7 @@ static void zathura_page_widget_init(ZathuraPage* widget) {
   priv->search.list    = NULL;
   priv->search.current = INT_MAX;
   priv->search.draw    = false;
+  priv->search.skip    = false;
 
   priv->selection.list = NULL;
   priv->selection.draw = false;
@@ -438,6 +444,9 @@ static void zathura_page_widget_set_property(GObject* object, guint prop_id, con
     }
     break;
   }
+  case PROP_SEARCH_SKIP:
+    priv->search.skip = g_value_get_boolean(value);
+    break;
   case PROP_DRAW_SEARCH_RESULTS:
     priv->search.draw = g_value_get_boolean(value);
 
@@ -493,6 +502,9 @@ static void zathura_page_widget_get_property(GObject* object, guint prop_id, GVa
     break;
   case PROP_SEARCH_RESULTS:
     g_value_set_pointer(value, priv->search.list);
+    break;
+  case PROP_SEARCH_SKIP:
+    g_value_set_boolean(value, priv->search.skip);
     break;
   case PROP_DRAW_SEARCH_RESULTS:
     g_value_set_boolean(value, priv->search.draw);


### PR DESCRIPTION
Instead of searching the whole document in one go, search and stop at the nearest page that produces a hit.

Fixes #132. UX won't be much different, besides that when the user views a page that hasn't been searched before, they will no longer see highlighted results in this page.