### PR TITLE
Preserve search state on reload

### DIFF
--- a/zathura/commands.c
+++ b/zathura/commands.c
@@ -401,7 +401,8 @@ bool cmd_search(girara_session_t* session, const char* input, girara_argument_t*
   g_return_val_if_fail(session->global.data != NULL, false);
   zathura_t* zathura = session->global.data;
 
-  if (zathura->document == NULL || strlen(input) == 0) {
+  size_t input_len = strlen(input);
+  if (zathura->document == NULL || input_len == 0) {
     return false;
   }
 
@@ -409,7 +410,29 @@ bool cmd_search(girara_session_t* session, const char* input, girara_argument_t*
 
   /* set search direction */
   zathura->global.search_direction = argument->n;
-
+  
+  size_t search_string_len = 0;
+  if(zathura->global.search_string != NULL){
+    search_string_len = strlen(zathura->global.search_string);
+  }
+  /* allocate memory to search string */
+  if(search_string_len == 0){
+    zathura->global.search_string = g_try_malloc(input_len + 1);
+  }
+  /* reallocate memory to fit new search string */
+  else if(input_len < search_string_len){
+    zathura->global.search_string = g_try_realloc(zathura->global.search_string,  input_len + 1);
+  }
+  else if(input_len > search_string_len){
+    zathura->global.search_string = g_try_realloc(zathura->global.search_string, search_string_len + input_len + 1);
+  } 
+  /* check whether the memory allocation was successful */
+  if(zathura->global.search_string == NULL){
+    return false;
+  }
+  /* set search string */
+  strcpy(zathura->global.search_string, input);
+  
   unsigned int number_of_pages     = zathura_document_get_number_of_pages(zathura->document);
   unsigned int current_page_number = zathura_document_get_current_page_number(zathura->document);
 

--- a/zathura/utils.c
+++ b/zathura/utils.c
@@ -221,6 +221,9 @@ void document_draw_search_results(zathura_t* zathura, bool value) {
     return;
   }
 
+  /* set state of search results highlight */
+  zathura->global.are_search_results_highlighted = true;
+
   unsigned int number_of_pages = zathura_document_get_number_of_pages(zathura->document);
   for (unsigned int page_id = 0; page_id < number_of_pages; page_id++) {
     g_object_set(zathura->pages[page_id], "draw-search-results", (value == true) ? TRUE : FALSE, NULL);

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -82,10 +82,12 @@ zathura_t* zathura_create(void) {
   }
 
   /* global settings */
-  zathura->global.search_direction     = FORWARD;
-  zathura->global.synctex_edit_modmask = GDK_CONTROL_MASK;
-  zathura->global.highlighter_modmask  = GDK_SHIFT_MASK;
-  zathura->global.double_click_follow  = true;
+  zathura->global.search_direction               = FORWARD;
+  zathura->global.search_string                  = NULL;
+  zathura->global.are_search_results_highlighted = false;
+  zathura->global.synctex_edit_modmask           = GDK_CONTROL_MASK;
+  zathura->global.highlighter_modmask            = GDK_SHIFT_MASK;
+  zathura->global.double_click_follow            = true;
 
   /* initialize with default paths */
   gchar* path                = girara_get_xdg_path(XDG_CONFIG);
@@ -521,6 +523,11 @@ void zathura_free(zathura_t* zathura) {
   g_free(zathura->config.config_dir);
   g_free(zathura->config.data_dir);
   g_free(zathura->config.cache_dir);
+  
+  if(zathura->global.search_string != NULL){
+    g_free(zathura->global.search_string);
+    zathura->global.search_string = NULL;
+  }
 
   /* free jumplist */
   if (zathura->jumplist.cur != NULL) {
@@ -1446,6 +1453,8 @@ bool document_close(zathura_t* zathura, bool keep_monitor) {
       g_free(zathura->file_monitor.password);
       zathura->file_monitor.password = NULL;
     }
+    g_free(zathura->global.search_string);
+    zathura->global.search_string = NULL;
   }
 
   /* store file information */

--- a/zathura/zathura.h
+++ b/zathura/zathura.h
@@ -135,7 +135,9 @@ struct zathura_s {
   struct {
     girara_list_t* marks;                 /**< Marker */
     char** arguments;                     /**> Arguments that were passed at startup */
+    char* search_string;                  /**< Current search string */
     int search_direction;                 /**< Current search direction (FORWARD or BACKWARD) */
+    bool are_search_results_highlighted;  /**< Current state of the highlight of the search results */
     GdkModifierType synctex_edit_modmask; /**< Modifier to trigger synctex edit */
     GdkModifierType highlighter_modmask;  /**< Modifier to draw with a highlighter */
     bool double_click_follow;             /**< Double/Single click to follow link */


### PR DESCRIPTION
With this, when reloading the document, the search state is preserved, including the search string and the search highlight. 
As I am new to contributing, review and suggestions are appreciated.

Closes #598 