### PR TITLE
Add warning when landlock lsm is not available

### DIFF
--- a/zathura/landlock.c
+++ b/zathura/landlock.c
@@ -56,7 +56,7 @@ static void landlock_drop(__u64 fs_access) {
 
 #define _LANDLOCK_ACCESS_FS_READ (LANDLOCK_ACCESS_FS_READ_FILE | LANDLOCK_ACCESS_FS_READ_DIR)
 
-void landlock_check_kernel(void) {
+static void landlock_check_kernel(void) {
   int abi = landlock_create_ruleset(NULL, 0,
                                   LANDLOCK_CREATE_RULESET_VERSION);
   if (abi == -1) {

--- a/zathura/landlock.c
+++ b/zathura/landlock.c
@@ -38,12 +38,12 @@ static void landlock_drop(__u64 fs_access) {
 
   int ruleset_fd = landlock_create_ruleset(&ruleset_attr, sizeof(ruleset_attr), 0);
   if (ruleset_fd < 0) {
-    perror("Failed to create a landlock ruleset");
+    girara_error("Failed to create a landlock ruleset");
     return;
   }
   prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
   if (landlock_restrict_self(ruleset_fd, 0)) {
-    perror("landlock_restrict_self");
+    girara_error("landlock_restrict_self");
   }
   close(ruleset_fd);
 }
@@ -64,7 +64,6 @@ void landlock_check_kernel(void) {
      * Kernel too old, not compiled with Landlock,
      * or Landlock was not enabled at boot time.
      */
-    perror("Unable to use Landlock");
     girara_warning("Unable to use Landlock: Kernel too old, not compiled with Landlock,\
             or Landlock was not enabled at boot time. Sandbox partly disabled.");
     return;  /* Graceful fallback: Do nothing. */
@@ -101,10 +100,10 @@ void landlock_write_fd(const int dir_fd) {
   if (!landlock_add_rule(ruleset_fd, LANDLOCK_RULE_PATH_BENEATH, &path_beneath, 0)) {
     prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
     if (landlock_restrict_self(ruleset_fd, 0)) {
-      perror("landlock_restrict_self");
+      girara_error("landlock_restrict_self");
     }
   } else {
-    perror("landlock_add_rule");
+    girara_error("landlock_add_rule");
   }
 
   if (dir_fd == -1) {


### PR DESCRIPTION
When zathura-sandbox is build with landlock support but the kernel does not include the landlock lsm, show an error to inform the user about the missing protection.

Partly fixes #654 