### PR TITLE
Check if page_label is NULL before strcmp

### DIFF
--- a/zathura/page.c
+++ b/zathura/page.c
@@ -67,7 +67,12 @@ zathura_page_t* zathura_page_new(zathura_document_t* document, unsigned int inde
 
     char page_number_string[G_ASCII_DTOSTR_BUF_SIZE];
     g_ascii_dtostr(page_number_string, G_ASCII_DTOSTR_BUF_SIZE, index + 1);
-    page->label_is_number = strcmp(page->label, page_number_string) == 0;
+    if (page->label != NULL) {
+      page->label_is_number = strcmp(page->label, page_number_string) == 0;
+    }
+    else {
+      page->label_is_number = false;
+    }
   }
 
   return page;


### PR DESCRIPTION
Check if `page_label` is NULL before `strcmp`, as some page can have no label return by the plugin (the cover page for example)