### PR TITLE
First step at enabling searching in index page

### DIFF
--- a/zathura/shortcuts.c
+++ b/zathura/shortcuts.c
@@ -1203,6 +1203,8 @@ bool sc_toggle_index(girara_session_t* session, girara_argument_t* UNUSED(argume
     g_object_set(G_OBJECT(renderer), "ellipsize", PANGO_ELLIPSIZE_END, NULL);
     g_object_set(G_OBJECT(gtk_tree_view_get_column(GTK_TREE_VIEW(treeview), 0)), "expand", TRUE, NULL);
     gtk_tree_view_column_set_alignment(gtk_tree_view_get_column(GTK_TREE_VIEW(treeview), 1), 1.0f);
+    gtk_tree_view_set_search_equal_func(GTK_TREE_VIEW(treeview), search_equal_func_index, treeview, NULL);
+    gtk_tree_view_set_enable_search(GTK_TREE_VIEW(treeview), FALSE);
     g_signal_connect(G_OBJECT(treeview), "row-activated", G_CALLBACK(cb_index_row_activated), zathura);
 
     gtk_container_add(GTK_CONTAINER(zathura->ui.index), treeview);
@@ -1227,6 +1229,8 @@ bool sc_toggle_index(girara_session_t* session, girara_argument_t* UNUSED(argume
     }
 
     girara_set_view(session, zathura->ui.index);
+    GtkTreeView* tree_view = gtk_container_get_children(GTK_CONTAINER(zathura->ui.index))->data;
+    gtk_widget_grab_focus(GTK_WIDGET(tree_view));
     index_scroll_to_current_page(zathura);
     girara_mode_set(zathura->ui.session, zathura->modes.index);
   }

--- a/zathura/utils.c
+++ b/zathura/utils.c
@@ -130,8 +130,8 @@ static gboolean search_current_index(GtkTreeModel* model, GtkTreePath* UNUSED(pa
 
 static bool find_substring(const char* source_str, const char* search_str) {
   gchar *normalized_source_str, *normalized_search_str;
-  gchar *case_normalized_source_str = NULL;
-  gchar *case_normalized_search_str = NULL;
+  gchar* case_normalized_source_str = NULL;
+  gchar* case_normalized_search_str = NULL;
 
   normalized_source_str = g_utf8_normalize(source_str, -1, G_NORMALIZE_ALL);
   normalized_search_str = g_utf8_normalize(search_str, -1, G_NORMALIZE_ALL);
@@ -146,8 +146,8 @@ static bool find_substring(const char* source_str, const char* search_str) {
 
 static gboolean search_equal_iter(GtkTreeModel* model, gint column, const gchar* key, GtkTreeIter* iter) {
 
-  const gchar *source_string;
-  GValue value = G_VALUE_INIT;
+  const gchar* source_string;
+  GValue value       = G_VALUE_INIT;
   GValue transformed = G_VALUE_INIT;
 
   gtk_tree_model_get_value(model, iter, column, &value);
@@ -160,22 +160,22 @@ static gboolean search_equal_iter(GtkTreeModel* model, gint column, const gchar*
   }
 
   g_value_unset(&value);
-  source_string = g_value_get_string (&transformed);
-  if (!source_string)
-    {
-      g_value_unset (&transformed);
-      return TRUE;
-    }
+  source_string = g_value_get_string(&transformed);
+  if (!source_string) {
+    g_value_unset(&transformed);
+    return TRUE;
+  }
   if (find_substring(source_string, key)) {
     return FALSE;
   }
   return TRUE;
 }
 
-gboolean search_equal_func_index(GtkTreeModel* model, gint column, const gchar* key, GtkTreeIter* iter, gpointer search_data) {
+gboolean search_equal_func_index(GtkTreeModel* model, gint column, const gchar* key, GtkTreeIter* iter,
+                                 gpointer search_data) {
 
-  GtkTreeView *tree_view = GTK_TREE_VIEW(search_data);
-  GtkTreePath *current_path = gtk_tree_model_get_path(model, iter);
+  GtkTreeView* tree_view    = GTK_TREE_VIEW(search_data);
+  GtkTreePath* current_path = gtk_tree_model_get_path(model, iter);
   if (!(search_equal_iter(model, column, key, iter))) {
     return FALSE;
   }
@@ -191,7 +191,7 @@ gboolean search_equal_func_index(GtkTreeModel* model, gint column, const gchar* 
 
   do {
     if (!search_equal_func_index(model, column, key, &child_iter, tree_view)) {
-      GtkTreePath *child_path = gtk_tree_model_get_path(model, &child_iter);
+      GtkTreePath* child_path = gtk_tree_model_get_path(model, &child_iter);
       gtk_tree_view_scroll_to_cell(tree_view, child_path, NULL, TRUE, 0.5, 0.0);
       gtk_tree_path_free(current_path);
       gtk_tree_path_free(child_path);

--- a/zathura/utils.h
+++ b/zathura/utils.h
@@ -49,7 +49,8 @@ void document_index_build(girara_session_t* session, GtkTreeModel* model, GtkTre
  * @param iter The tree iterator
  * @param search_data User data pointer
  */
-gboolean search_equal_func_index(GtkTreeModel* model, gint column, const gchar* key, GtkTreeIter* iter, gpointer search_data);
+gboolean search_equal_func_index(GtkTreeModel* model, gint column, const gchar* key, GtkTreeIter* iter,
+                                 gpointer search_data);
 /**
  * Scrolls the document index to the current page
  *

--- a/zathura/utils.h
+++ b/zathura/utils.h
@@ -39,6 +39,18 @@ void document_index_build(girara_session_t* session, GtkTreeModel* model, GtkTre
                           girara_tree_node_t* tree);
 
 /**
+ * A custom search equal function for the index tree view, so that
+ * when interactively searching, the string will be recursively compared
+ * to all the children of visible entries
+ *
+ * @param model The tree model
+ * @param column The column of the entry
+ * @param key The keyword to be compared
+ * @param iter The tree iterator
+ * @param search_data User data pointer
+ */
+gboolean search_equal_func_index(GtkTreeModel* model, gint column, const gchar* key, GtkTreeIter* iter, gpointer search_data);
+/**
  * Scrolls the document index to the current page
  *
  * @param zathura The zathura instance


### PR DESCRIPTION
This PR is a proof of concept for enabling search in index page. It only use the native functionality of `GTK`.

The behavior:
- Open the index page, press `C-f` (the default shortcut of `GTK`) to have the interactive search window appear
- Start typing the keyword, the index's cursor will jump to the first occurence,
- Disable interactive search by default so that when the search window is not present, all the keywords works normally (As opposed to before)

Partly fixes #565 