### PR TITLE
Renders the page again so it shouldn't truncate the document

### DIFF
--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -1767,10 +1767,12 @@ bool adjust_view(zathura_t* zathura) {
   } else {
     /* otherwise set the old zoom and leave */
     zathura_document_set_zoom(zathura->document, zoom);
+    render_all(zathura);
+    refresh_view(zathura);
   }
 
-error_ret:
-  return false;
+  error_ret:
+    return false;
 }
 
 #ifdef G_OS_UNIX


### PR DESCRIPTION
Fixed issue #657

**Changes Made**
This pull request fixes the bug where the page is truncated. The highlighting also doesn't bug out when the document is zoomed in and out.

**Testing:**
Went over the steps in the issue to check if the document was still truncated.