### PR TITLE
Faster SyncTeX by reusing scanner object

### DIFF
--- a/zathura/callbacks.c
+++ b/zathura/callbacks.c
@@ -695,7 +695,7 @@ void cb_page_widget_scaled_button_release(ZathuraPage* page_widget, GdkEventButt
     }
 
     if (zathura->dbus != NULL) {
-      zathura_dbus_edit(zathura->dbus, zathura_page_get_index(page), event->x, event->y);
+      zathura_dbus_edit(zathura, zathura_page_get_index(page), event->x, event->y);
     }
 
     char* editor = NULL;
@@ -706,7 +706,7 @@ void cb_page_widget_scaled_button_release(ZathuraPage* page_widget, GdkEventButt
       return;
     }
 
-    synctex_edit(editor, page, event->x, event->y);
+    synctex_edit(zathura, editor, page, event->x, event->y);
     g_free(editor);
   }
 }

--- a/zathura/dbus-interface.c
+++ b/zathura/dbus-interface.c
@@ -167,7 +167,8 @@ const char* zathura_dbus_get_name(zathura_t* zathura) {
   return priv->bus_name;
 }
 
-void zathura_dbus_edit(ZathuraDbus* edit, unsigned int page, unsigned int x, unsigned int y) {
+void zathura_dbus_edit(zathura_t* zathura, unsigned int page, unsigned int x, unsigned int y) {
+  ZathuraDbus* edit = zathura->dbus;
   ZathuraDbusPrivate* priv = zathura_dbus_get_instance_private(edit);
 
   const char* filename = zathura_document_get_path(priv->zathura->document);
@@ -176,7 +177,7 @@ void zathura_dbus_edit(ZathuraDbus* edit, unsigned int page, unsigned int x, uns
   unsigned int line   = 0;
   unsigned int column = 0;
 
-  if (synctex_get_input_line_column(filename, page, x, y, &input_file, &line, &column) == false) {
+  if (synctex_get_input_line_column(zathura, filename, page, x, y, &input_file, &line, &column) == false) {
     return;
   }
 

--- a/zathura/dbus-interface.h
+++ b/zathura/dbus-interface.h
@@ -34,12 +34,12 @@ const char* zathura_dbus_get_name(zathura_t* zathura);
 /**
  * Emit the 'Edit' signal on the D-Bus connection.
  *
- * @param dbus ZathuraDbus instance
+ * @param zathura Zathura session
  * @param page page
  * @param x x coordinate
  * @param y y coordinate
  */
-void zathura_dbus_edit(ZathuraDbus* dbus, unsigned int page, unsigned int x, unsigned int y);
+void zathura_dbus_edit(zathura_t* zathura, unsigned int page, unsigned int x, unsigned int y);
 
 /**
  * Highlight rectangles in a zathura instance that has filename open.

--- a/zathura/synctex.c
+++ b/zathura/synctex.c
@@ -16,7 +16,6 @@
 #include "adjustment.h"
 
 #ifdef WITH_SYNCTEX
-
 // Create scanner from given PDF file name.
 // Returns zathura->synctex.scanner. (May be NULL on error.)
 synctex_scanner_p synctex_make_scanner(zathura_t *zathura, const char* pdf_filename) {

--- a/zathura/synctex.c
+++ b/zathura/synctex.c
@@ -250,7 +250,7 @@ bool synctex_get_input_line_column(zathura_t* UNUSED(zathura), const char* UNUSE
   return false;
 }
 
-void synctex_edit(const char* UNUSED(editor), zathura_page_t* UNUSED(page), int UNUSED(x), int UNUSED(y)) {}
+void synctex_edit(zathura_t* UNUSED(zathura), const char* UNUSED(editor), zathura_page_t* UNUSED(page), int UNUSED(x), int UNUSED(y)) {}
 
 girara_list_t* synctex_rectangles_from_position(zathura_t* UNUSED(zathura), const char* UNUSED(filename), const char* UNUSED(input_file),
                                                 int UNUSED(line), int UNUSED(column), unsigned int* UNUSED(page),

--- a/zathura/synctex.h
+++ b/zathura/synctex.h
@@ -10,14 +10,14 @@ typedef struct synctex_page_rect_s {
   zathura_rectangle_t rect;
 } synctex_page_rect_t;
 
-bool synctex_get_input_line_column(const char* filename, unsigned int page, int x, int y, char** input_file,
+bool synctex_get_input_line_column(zathura_t* zathura, const char* filename, unsigned int page, int x, int y, char** input_file,
                                    unsigned int* line, unsigned int* column);
 
-void synctex_edit(const char* editor, zathura_page_t* page, int x, int y);
+void synctex_edit(zathura_t* zathura, const char* editor, zathura_page_t* page, int x, int y);
 
 bool synctex_parse_input(const char* synctex, char** input_file, int* line, int* column);
 
-girara_list_t* synctex_rectangles_from_position(const char* filename, const char* input_file, int line, int column,
+girara_list_t* synctex_rectangles_from_position(zathura_t* zathura, const char* filename, const char* input_file, int line, int column,
                                                 unsigned int* page, girara_list_t** secondary_rects);
 
 void synctex_highlight_rects(zathura_t* zathura, unsigned int page, girara_list_t** rectangles);

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -536,9 +536,7 @@ void zathura_free(zathura_t* zathura) {
   if (zathura->synctex.scanner != NULL) {
     synctex_scanner_free(zathura->synctex.scanner);
   }
-  if (zathura->synctex.last_pdf_filename != NULL) {
-    g_free(zathura->synctex.last_pdf_filename);
-  }
+  g_free(zathura->synctex.last_pdf_filename);
 #endif
 
   g_free(zathura);

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -536,8 +536,8 @@ void zathura_free(zathura_t* zathura) {
   if (zathura->synctex.scanner != NULL) {
     synctex_scanner_free(zathura->synctex.scanner);
   }
-  if (zathura->synctex.last_pdf_file_name != NULL) {
-    g_free(zathura->synctex.last_pdf_file_name);
+  if (zathura->synctex.last_pdf_filename != NULL) {
+    g_free(zathura->synctex.last_pdf_filename);
   }
 #endif
 

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -531,6 +531,16 @@ void zathura_free(zathura_t* zathura) {
     girara_list_free(zathura->jumplist.list);
   }
 
+#ifdef WITH_SYNCTEX
+  /* synctex cached scanner */
+  if (zathura->synctex.scanner != NULL) {
+    synctex_scanner_free(zathura->synctex.scanner);
+  }
+  if (zathura->synctex.last_pdf_file_name != NULL) {
+    g_free(zathura->synctex.last_pdf_file_name);
+  }
+#endif
+
   g_free(zathura);
 }
 

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -531,14 +531,6 @@ void zathura_free(zathura_t* zathura) {
     girara_list_free(zathura->jumplist.list);
   }
 
-#ifdef WITH_SYNCTEX
-  /* synctex cached scanner */
-  if (zathura->synctex.scanner != NULL) {
-    synctex_scanner_free(zathura->synctex.scanner);
-  }
-  g_free(zathura->synctex.last_pdf_filename);
-#endif
-
   g_free(zathura);
 }
 
@@ -1542,6 +1534,14 @@ bool document_close(zathura_t* zathura, bool keep_monitor) {
 
   /* update title */
   girara_set_window_title(zathura->ui.session, "zathura");
+
+#ifdef WITH_SYNCTEX
+  /* invalidate synctex scanner */
+  if (zathura->synctex.scanner) {
+    synctex_scanner_free(zathura->synctex.scanner);
+    zathura->synctex.scanner = NULL;
+  }
+#endif
 
   return true;
 }

--- a/zathura/zathura.h
+++ b/zathura/zathura.h
@@ -233,8 +233,6 @@ struct zathura_s {
    */
   struct {
     synctex_scanner_p scanner;
-    time_t last_modification_time; // of the synctex file
-    char* last_pdf_filename;
   } synctex;
 #endif
 };

--- a/zathura/zathura.h
+++ b/zathura/zathura.h
@@ -234,8 +234,8 @@ struct zathura_s {
    */
   struct {
     synctex_scanner_p scanner;
-    time_t last_modification_time; // the last modification time of the synctex file
-    char* last_pdf_file_name; // the last output file name
+    time_t last_modification_time; // of the synctex file
+    char* last_pdf_filename;
   } synctex;
 #endif
 };

--- a/zathura/zathura.h
+++ b/zathura/zathura.h
@@ -7,6 +7,10 @@
 #include <girara/types.h>
 #include <girara/session.h>
 #include <gtk/gtk.h>
+#ifdef WITH_SYNCTEX
+#include <sys/stat.h>
+#include <synctex/synctex_parser.h>
+#endif
 #ifdef GDK_WINDOWING_X11
 #include <gtk/gtkx.h>
 #endif
@@ -223,6 +227,15 @@ struct zathura_s {
    * Context for MIME type detection
    */
   zathura_content_type_context_t* content_type_context;
+
+  /**
+   * SyncTeX context. The scanner object is cached for better performance.
+   */
+  struct {
+    synctex_scanner_p scanner;
+    time_t last_modification_time; // the last modification time of the synctex file
+    char* last_pdf_file_name; // the last output file name
+  } synctex;
 };
 
 /**

--- a/zathura/zathura.h
+++ b/zathura/zathura.h
@@ -228,6 +228,7 @@ struct zathura_s {
    */
   zathura_content_type_context_t* content_type_context;
 
+#ifdef WITH_SYNCTEX
   /**
    * SyncTeX context. The scanner object is cached for better performance.
    */
@@ -236,6 +237,7 @@ struct zathura_s {
     time_t last_modification_time; // the last modification time of the synctex file
     char* last_pdf_file_name; // the last output file name
   } synctex;
+#endif
 };
 
 /**

--- a/zathura/zathura.h
+++ b/zathura/zathura.h
@@ -8,7 +8,6 @@
 #include <girara/session.h>
 #include <gtk/gtk.h>
 #ifdef WITH_SYNCTEX
-#include <sys/stat.h>
 #include <synctex/synctex_parser.h>
 #endif
 #ifdef GDK_WINDOWING_X11


### PR DESCRIPTION
Fixes #685 .

The code is mostly copied from synctex's own code for new interactive feature.

A disadvantage I can think of is the scanner object consumes memory even when user is not looking up anything, but I think this is inevitable.