### PR TITLE
document.c: exit when file is not found

### DIFF
--- a/zathura/document.c
+++ b/zathura/document.c
@@ -106,6 +106,12 @@ zathura_document_t* zathura_document_open(zathura_t* zathura, const char* path, 
   const zathura_plugin_t* plugin = NULL;
   zathura_document_t* document   = NULL;
 
+  if (!g_file_query_exists(file, NULL)) {
+    girara_error("File '%s' does not exist", path);
+    check_set_error(error, ZATHURA_ERROR_FILE_NOT_FOUND);
+	exit(1);
+  }
+
   if (file == NULL) {
     girara_error("Error while handling path '%s'.", path);
     check_set_error(error, ZATHURA_ERROR_UNKNOWN);

--- a/zathura/types.h
+++ b/zathura/types.h
@@ -55,7 +55,8 @@ typedef enum zathura_plugin_error_e {
   ZATHURA_ERROR_OUT_OF_MEMORY,     /**< Out of memory */
   ZATHURA_ERROR_NOT_IMPLEMENTED,   /**< The called function has not been implemented */
   ZATHURA_ERROR_INVALID_ARGUMENTS, /**< Invalid arguments have been passed */
-  ZATHURA_ERROR_INVALID_PASSWORD   /**< The provided password is invalid */
+  ZATHURA_ERROR_INVALID_PASSWORD,  /**< The provided password is invalid */
+  ZATHURA_ERROR_FILE_NOT_FOUND     /**< The provided file path does not exist */
 } zathura_error_t;
 
 /**


### PR DESCRIPTION
It is annoying to deal with 10 windows opening when I accidentally copy a file name that has spaces without quotes.