### PR TITLE
ui: dynamic page allocation to gtk grid

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -121,6 +121,7 @@ sources = files(
   'zathura/database-sqlite.c',
   'zathura/dbus-interface.c',
   'zathura/document.c',
+  'zathura/document-widget.c',
   'zathura/file-monitor.c',
   'zathura/file-monitor-glib.c',
   'zathura/file-monitor-noop.c',

--- a/zathura/adjustment.c
+++ b/zathura/adjustment.c
@@ -147,26 +147,3 @@ void zathura_adjustment_set_value(GtkAdjustment* adjustment, gdouble value) {
 
   gtk_adjustment_set_value(adjustment, MAX(lower, MIN(upper_m_size, value)));
 }
-
-gdouble zathura_adjustment_get_ratio(GtkAdjustment* adjustment) {
-  gdouble lower     = gtk_adjustment_get_lower(adjustment);
-  gdouble upper     = gtk_adjustment_get_upper(adjustment);
-  gdouble page_size = gtk_adjustment_get_page_size(adjustment);
-  gdouble value     = gtk_adjustment_get_value(adjustment);
-
-  return (value - lower + page_size / 2.0) / (upper - lower);
-}
-
-void zathura_adjustment_set_value_from_ratio(GtkAdjustment* adjustment, gdouble ratio) {
-  if (ratio == 0.0) {
-    return;
-  }
-
-  gdouble lower     = gtk_adjustment_get_lower(adjustment);
-  gdouble upper     = gtk_adjustment_get_upper(adjustment);
-  gdouble page_size = gtk_adjustment_get_page_size(adjustment);
-
-  gdouble value = (upper - lower) * ratio + lower - page_size / 2.0;
-
-  zathura_adjustment_set_value(adjustment, value);
-}

--- a/zathura/adjustment.h
+++ b/zathura/adjustment.h
@@ -82,26 +82,4 @@ bool page_is_visible(zathura_document_t* document, unsigned int page_number);
  */
 void zathura_adjustment_set_value(GtkAdjustment* adjustment, gdouble value);
 
-/**
- * Compute the adjustment ratio
- *
- * That is, the ratio between the length from the lower bound to the middle of
- * the slider, and the total length of the scrollbar.
- *
- * @param adjustment Scrollbar adjustment
- * @return Adjustment ratio
- */
-gdouble zathura_adjustment_get_ratio(GtkAdjustment* adjustment);
-
-/**
- * Set the adjustment value from ratio
- *
- * The ratio is usually obtained from a previous call to
- * zathura_adjustment_get_ratio().
- *
- * @param adjustment Adjustment instance
- * @param ratio Ratio from which the adjustment value will be set
- */
-void zathura_adjustment_set_value_from_ratio(GtkAdjustment* adjustment, gdouble ratio);
-
 #endif /* ZATHURA_ADJUSTMENT_H */

--- a/zathura/callbacks.c
+++ b/zathura/callbacks.c
@@ -15,6 +15,7 @@
 #include "zathura.h"
 #include "render.h"
 #include "document.h"
+#include "document-widget.h"
 #include "utils.h"
 #include "shortcuts.h"
 #include "page-widget.h"
@@ -97,7 +98,7 @@ void cb_view_hadjustment_value_changed(GtkAdjustment* adjustment, gpointer data)
   update_visible_pages(zathura);
 
   zathura_document_t* document = zathura_get_document(zathura);
-  const double position_x      = zathura_adjustment_get_ratio(adjustment);
+  const double position_x      = zathura_document_widget_get_ratio(zathura, adjustment, true); 
   const double position_y      = zathura_document_get_position_y(document);
   unsigned int page_id         = position_to_page_number(document, position_x, position_y);
 
@@ -123,7 +124,7 @@ void cb_view_vadjustment_value_changed(GtkAdjustment* adjustment, gpointer data)
 
   zathura_document_t* document = zathura_get_document(zathura);
   const double position_x      = zathura_document_get_position_x(document);
-  const double position_y      = zathura_adjustment_get_ratio(adjustment);
+  const double position_y      = zathura_document_widget_get_ratio(zathura, adjustment, false); 
   const unsigned int page_id   = position_to_page_number(document, position_x, position_y);
 
   zathura_document_set_position_x(document, position_x);
@@ -158,7 +159,8 @@ static void cb_view_adjustment_changed(GtkAdjustment* adjustment, zathura_t* zat
   /* reset the adjustment, in case bounds have changed */
   const double ratio =
       width == true ? zathura_document_get_position_x(document) : zathura_document_get_position_y(document);
-  zathura_adjustment_set_value_from_ratio(adjustment, ratio);
+
+  zathura_document_widget_set_value_from_ratio(zathura, adjustment, ratio, width);
 }
 
 void cb_view_hadjustment_changed(GtkAdjustment* adjustment, gpointer data) {
@@ -203,8 +205,8 @@ void cb_refresh_view(GtkWidget* GIRARA_UNUSED(view), gpointer data) {
   const double position_x = zathura_document_get_position_x(document);
   const double position_y = zathura_document_get_position_y(document);
 
-  zathura_adjustment_set_value_from_ratio(vadj, position_y);
-  zathura_adjustment_set_value_from_ratio(hadj, position_x);
+  zathura_document_widget_set_value_from_ratio(zathura, vadj, position_y, false);
+  zathura_document_widget_set_value_from_ratio(zathura, hadj, position_x, true);
 
   statusbar_page_number_update(zathura);
 }
@@ -318,7 +320,7 @@ void cb_page_layout_value_changed(girara_session_t* session, const char* name, g
   bool page_right_to_left = false;
   girara_setting_get(zathura->ui.session, "page-right-to-left", &page_right_to_left);
 
-  page_widget_set_mode(zathura, page_padding, pages_per_row, first_page_column, page_right_to_left);
+  zathura_document_widget_set_mode(zathura, page_padding, pages_per_row, first_page_column, page_right_to_left);
   zathura_document_set_page_layout(zathura_get_document(zathura), page_padding, pages_per_row, first_page_column);
 }
 

--- a/zathura/document-widget.c
+++ b/zathura/document-widget.c
@@ -1,82 +1,49 @@
 /* SPDX-License-Identifier: Zlib */
 
-#include "cairo.h"
-#include "gdk/gdk.h"
+#include <girara/log.h>
+
 #include "glib.h"
 #include "glibconfig.h"
 #include "gtk/gtk.h"
 #include "glib-object.h"
-#include "zathura/document.h"
-#include "zathura/page-widget.h"
-#include "zathura/page.h"
-#include "zathura/types.h"
-#include "zathura/zathura.h"
-#include <girara/log.h>
+#include "adjustment.h"
+#include "document.h"
 #include "document-widget.h"
+#include "page.h"
+#include "types.h"
+#include "zathura.h"
+
+int64_t cairo_max_size = INT16_MAX;
 
 typedef struct zathura_document_widget_private_s {
-  zathura_t *zathura;
   unsigned int spacing;
   unsigned int pages_per_row;
   unsigned int first_page_column;
   bool page_right_to_left;
+
+  unsigned int page_count;
+  unsigned int start_index;
+  bool do_render;
 } ZathuraDocumentPrivate;
 
 G_DEFINE_TYPE_WITH_CODE(ZathuraDocument, zathura_document_widget, GTK_TYPE_GRID, G_ADD_PRIVATE(ZathuraDocument))
 
-static void zathura_document_widget_set_property(GObject* object, guint prop_id, const GValue* value, GParamSpec* pspec);
-
-enum properties_e {
-  PROP_0,
-  PROP_ZATHURA,
-  PROP_SPACING,
-  PROP_PAGES_PER_ROW,
-  PROP_FIRST_PAGE_COLUMN,
-  PROP_PAGE_RIGHT_TO_LEFT,
-};
-
 static void zathura_document_widget_class_init(ZathuraDocumentClass* class) {
   /* overwrite methods */
-  // GtkWidgetClass* widget_class = GTK_WIDGET_CLASS(class);
-
+  GtkWidgetClass* widget_class = GTK_WIDGET_CLASS(class);
   GObjectClass* object_class = G_OBJECT_CLASS(class);
-  object_class->set_property = zathura_document_widget_set_property;
-
-  /* add properties */
-  g_object_class_install_property(
-      object_class, PROP_ZATHURA,
-      g_param_spec_pointer("zathura", "zathura", "zathura context",
-                           G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_property(
-      object_class, PROP_SPACING,
-      g_param_spec_uint("spacing", "spacing", "page spacing",
-                           0, G_MAXUINT, 0, G_PARAM_WRITABLE | G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_property(
-      object_class, PROP_PAGES_PER_ROW,
-      g_param_spec_uint("pages-per-row", "pages-per-row", "number of pages per row",
-                           1, 3, 1, G_PARAM_WRITABLE | G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_property(
-      object_class, PROP_FIRST_PAGE_COLUMN,
-      g_param_spec_uint("first-page-column", "first-page-column", "column to display the first page",
-                           0, 2, 0, G_PARAM_WRITABLE | G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_property(
-      object_class, PROP_PAGE_RIGHT_TO_LEFT,
-      g_param_spec_boolean("page-right-to-left", "page-right-to-left", "render pages right to left", 
-                           false, G_PARAM_WRITABLE | G_PARAM_STATIC_STRINGS));
 }
 
 static void zathura_document_widget_init(ZathuraDocument *widget) {
   ZathuraDocumentPrivate *priv = zathura_document_widget_get_instance_private(widget);
 
-  priv->zathura = NULL;
+  priv->page_count = 0;
+  priv->start_index = 0;
+  priv->do_render = true;
 }
 
-GtkWidget* zathura_document_widget_new(zathura_t *zathura) {
-  GObject* ret = g_object_new(ZATHURA_TYPE_DOCUMENT, "zathura", zathura, NULL);
+GtkWidget* zathura_document_widget_new(void) {
+  GObject* ret = g_object_new(ZATHURA_TYPE_DOCUMENT, NULL);
   if (ret == NULL) {
     return NULL;
   }
@@ -97,31 +64,6 @@ GtkWidget* zathura_document_widget_new(zathura_t *zathura) {
   return GTK_WIDGET(ret);
 }
 
-static void zathura_document_widget_set_property(GObject* object, guint prop_id, const GValue* value, GParamSpec* pspec) {
-  ZathuraDocument *widget = ZATHURA_DOCUMENT(object);
-  ZathuraDocumentPrivate *priv = zathura_document_widget_get_instance_private(widget);
-
-  switch (prop_id) {
-    case PROP_ZATHURA:
-      priv->zathura = g_value_get_pointer(value);
-      break;
-    case PROP_SPACING:
-      priv->spacing = g_value_get_uint(value);
-      break;
-    case PROP_FIRST_PAGE_COLUMN:
-      priv->first_page_column = g_value_get_uint(value);
-      break;
-    case PROP_PAGES_PER_ROW:
-      priv->pages_per_row = g_value_get_uint(value);
-      break;
-    case PROP_PAGE_RIGHT_TO_LEFT:
-      priv->page_right_to_left = g_value_get_boolean(value);
-      break;
-    default:
-      G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
-  }
-}
-
 static void remove_page_from_table(GtkWidget* page, gpointer UNUSED(permanent)) {
   gtk_container_remove(GTK_CONTAINER(gtk_widget_get_parent(page)), page);
 }
@@ -130,35 +72,231 @@ void zathura_document_widget_clear_pages(GtkWidget *widget) {
   gtk_container_foreach(GTK_CONTAINER(widget), remove_page_from_table, NULL);
 }
 
-void zathura_document_widget_update_pages(GtkWidget *widget) {
-  ZathuraDocument *document = ZATHURA_DOCUMENT(widget);
-  ZathuraDocumentPrivate *priv = zathura_document_widget_get_instance_private(document);
-  zathura_t *zathura = priv->zathura;
+static void zathura_document_widget_get_render_range(zathura_t *zathura, unsigned int *start_index, unsigned int *page_count) {
+  g_return_if_fail(zathura != NULL && zathura->document != NULL);
 
-  if (zathura == NULL) {
-    return;
-  }
+  ZathuraDocument *widget = ZATHURA_DOCUMENT(zathura->ui.document_widget);
+  ZathuraDocumentPrivate *priv = zathura_document_widget_get_instance_private(widget);
+  zathura_document_t *document = zathura_get_document(zathura);
+  
+  unsigned int current_page = zathura_document_get_current_page_number(document);
+  unsigned int number_of_pages = zathura_document_get_number_of_pages(document);
+  zathura_page_t *page = zathura_document_get_page(document, current_page);
+  double page_height = zathura_page_get_height(page);
 
-  if (zathura->document == NULL) {
-    return;
-  }
+  int64_t max_pages = MIN(number_of_pages, cairo_max_size * priv->pages_per_row / page_height);
+  *start_index = MAX(0, current_page - max_pages);
+  *page_count = MIN(number_of_pages, current_page + max_pages);
+}
 
-  int page_count = zathura_document_get_number_of_pages(zathura->document);
+static void zathura_document_update_grid(zathura_t *zathura) {
+  g_return_if_fail(zathura != NULL && zathura->document != NULL);
+
+  ZathuraDocument *widget = ZATHURA_DOCUMENT(zathura->ui.document_widget);
+  ZathuraDocumentPrivate *priv = zathura_document_widget_get_instance_private(widget);
+  zathura_document_t *document = zathura_get_document(zathura);
 
   gtk_grid_set_row_spacing(GTK_GRID(widget), priv->spacing);
   gtk_grid_set_column_spacing(GTK_GRID(widget), priv->spacing);
 
-  zathura_document_widget_clear_pages(widget);
+  zathura_document_widget_clear_pages(GTK_WIDGET(widget));
 
-  for (int i = 0; i < page_count; i++) {
+  unsigned int current_page = zathura_document_get_current_page_number(document);
+
+  zathura_document_widget_get_render_range(zathura, &priv->start_index, &priv->page_count);
+  girara_debug("updating grid: start %u current %d page count %u", priv->start_index, current_page, priv->page_count);
+
+  for (int64_t i = 0; i < priv->page_count; i++) {
     int x = (i + priv->first_page_column - 1) % priv->pages_per_row;
     int y = (i + priv->first_page_column - 1) / priv->pages_per_row;
 
-    GtkWidget* page_widget = zathura->pages[i];
+    GtkWidget* page_widget = zathura->pages[priv->start_index + i];
     if (priv->page_right_to_left) {
       x = priv->pages_per_row - 1 - x;
     }
 
     gtk_grid_attach(GTK_GRID(widget), page_widget, x, y, 1, 1);
   }
+
+  priv->do_render = false;
+}
+
+void zathura_document_widget_render(zathura_t *zathura) {
+  if (zathura == NULL || zathura->document == NULL) {
+    return;
+  }
+
+  ZathuraDocument *widget = ZATHURA_DOCUMENT(zathura->ui.document_widget);
+  ZathuraDocumentPrivate *priv = zathura_document_widget_get_instance_private(widget);
+  static unsigned int prev_start_index = -1;
+
+  if (priv->do_render) {
+    zathura_document_update_grid(zathura);
+    prev_start_index = priv->start_index;
+
+    return;
+  }
+
+  unsigned int current_page = zathura_document_get_current_page_number(zathura->document);
+  if (priv->start_index < current_page && current_page < priv->start_index + priv->page_count - 1) {
+    return;
+  }
+
+  if (priv->start_index == current_page && priv->start_index == prev_start_index) {
+    return;
+  }
+
+  zathura_document_update_grid(zathura);
+  prev_start_index = priv->start_index;
+}
+
+void zathura_document_widget_set_mode(zathura_t* zathura, unsigned int page_padding, unsigned int pages_per_row,
+                                      unsigned int first_page_column, bool page_right_to_left) {
+  if (zathura == NULL || zathura->document == NULL) {
+    return;
+  }
+
+  ZathuraDocument *widget = ZATHURA_DOCUMENT(zathura->ui.document_widget);
+  ZathuraDocumentPrivate *priv = zathura_document_widget_get_instance_private(widget);
+
+  priv->spacing = page_padding;
+  priv->page_right_to_left = page_right_to_left;
+  priv->do_render = true;
+
+  /* show at least one page */
+  if (pages_per_row == 0) {
+    pages_per_row = 1;
+  }
+
+  priv->pages_per_row = pages_per_row;
+
+  /* ensure: 0 < first_page_column <= pages_per_row */
+  if (first_page_column < 1) {
+    first_page_column = 1;
+  }
+  if (first_page_column > pages_per_row) {
+    first_page_column = ((first_page_column - 1) % pages_per_row) + 1;
+  }
+
+  priv->first_page_column = first_page_column;
+
+  zathura_document_widget_render(zathura);
+  gtk_widget_show_all(zathura->ui.document_widget);
+}
+
+static void zathura_document_widget_get_size(zathura_t *zathura, unsigned int* height, unsigned int* width) {
+  g_return_if_fail(zathura != NULL && zathura->document != NULL);
+
+  ZathuraDocument *widget = ZATHURA_DOCUMENT(zathura->ui.document_widget);
+  ZathuraDocumentPrivate *priv = zathura_document_widget_get_instance_private(widget);
+  zathura_document_t* document = zathura_get_document(zathura);
+
+  g_return_if_fail(document != NULL && height != NULL && width != NULL);
+
+  const unsigned int npag = priv->page_count;
+  const unsigned int ncol = zathura_document_get_pages_per_row(document);
+
+  if (npag == 0 || ncol == 0) {
+    return;
+  }
+
+  const unsigned int c0   = zathura_document_get_first_page_column(document);
+  const unsigned int nrow = (npag + c0 - 1 + ncol - 1) / ncol; /* number of rows */
+  const unsigned int pad  = zathura_document_get_page_padding(document);
+
+  unsigned int cell_height = 0;
+  unsigned int cell_width  = 0;
+  zathura_document_get_cell_size(document, &cell_height, &cell_width);
+
+  *width  = ncol * cell_width + (ncol - 1) * pad;
+  *height = nrow * cell_height + (nrow - 1) * pad;
+}
+
+static void zathura_document_widget_get_offset(zathura_t *zathura, double *pos_x, double *pos_y) {
+  g_return_if_fail(zathura != NULL && zathura->document != NULL);
+
+  ZathuraDocument *widget = ZATHURA_DOCUMENT(zathura->ui.document_widget);
+  ZathuraDocumentPrivate *priv = zathura_document_widget_get_instance_private(widget);
+  zathura_document_t* document = zathura_get_document(zathura);
+
+  double zero_x, zero_y;
+  page_number_to_position(document, 0, 0.0, 0.0, &zero_x, &zero_y);
+
+  double start_x, start_y;
+  page_number_to_position(document, priv->start_index, 0.0, 0.0, &start_x, &start_y);
+
+  *pos_x = start_x - zero_x;
+  *pos_y = start_y - zero_y;
+}
+
+static gdouble zathura_adjustment_get_ratio(GtkAdjustment* adjustment) {
+  gdouble lower     = gtk_adjustment_get_lower(adjustment);
+  gdouble upper     = gtk_adjustment_get_upper(adjustment);
+  gdouble page_size = gtk_adjustment_get_page_size(adjustment);
+  gdouble value     = gtk_adjustment_get_value(adjustment);
+
+  return (value - lower + page_size / 2.0) / (upper - lower);
+}
+
+gdouble zathura_document_widget_get_ratio(zathura_t *zathura, GtkAdjustment *adjustment, bool width) {
+  if (zathura == NULL || zathura->document == NULL) {
+    return 0.0;
+  }
+
+  zathura_document_t* document = zathura_get_document(zathura);
+
+  unsigned int doc_height, doc_width;
+  zathura_document_get_document_size(document, &doc_height, &doc_width);
+
+  unsigned int widget_height, widget_width;
+  zathura_document_widget_get_size(zathura, &widget_height, &widget_width);
+
+  gdouble ratio = zathura_adjustment_get_ratio(adjustment);
+
+  gdouble start_x, start_y;
+  zathura_document_widget_get_offset(zathura, &start_x, &start_y);
+
+  /* convert the ratio in the document widget coordinates to the document coordinates */
+  gdouble ratio_x = (ratio * widget_width) / doc_width + start_x;
+  gdouble ratio_y = (ratio * widget_height) / doc_height + start_y;
+
+  return width ? ratio_x : ratio_y;
+}
+
+static void zathura_adjustment_set_value_from_ratio(GtkAdjustment* adjustment, gdouble ratio) {
+  if (ratio == 0.0) {
+    return;
+  }
+
+  gdouble lower     = gtk_adjustment_get_lower(adjustment);
+  gdouble upper     = gtk_adjustment_get_upper(adjustment);
+  gdouble page_size = gtk_adjustment_get_page_size(adjustment);
+
+  gdouble value = (upper - lower) * ratio + lower - page_size / 2.0;
+
+  zathura_adjustment_set_value(adjustment, value);
+}
+
+void zathura_document_widget_set_value_from_ratio(zathura_t *zathura, GtkAdjustment *adjustment, double ratio, bool width) {
+  if (zathura == NULL || zathura->document == NULL) {
+    return;
+  }
+
+  zathura_document_t* document = zathura_get_document(zathura);
+  zathura_document_widget_render(zathura);
+
+  unsigned int doc_height, doc_width;
+  zathura_document_get_document_size(document, &doc_height, &doc_width);
+
+  unsigned int widget_height, widget_width;
+  zathura_document_widget_get_size(zathura, &widget_height, &widget_width);
+
+  gdouble start_x, start_y;
+  zathura_document_widget_get_offset(zathura, &start_x, &start_y);
+
+  /* convert the ratio in the document coordinates to the document widget coordinates */
+  double ratio_x = ((ratio - start_x) * doc_width) / widget_width;
+  double ratio_y = ((ratio - start_y) * doc_height) / widget_height;
+
+  zathura_adjustment_set_value_from_ratio(adjustment, width ? ratio_x : ratio_y);
 }

--- a/zathura/document-widget.c
+++ b/zathura/document-widget.c
@@ -1,0 +1,164 @@
+/* SPDX-License-Identifier: Zlib */
+
+#include "cairo.h"
+#include "gdk/gdk.h"
+#include "glib.h"
+#include "glibconfig.h"
+#include "gtk/gtk.h"
+#include "glib-object.h"
+#include "zathura/document.h"
+#include "zathura/page-widget.h"
+#include "zathura/page.h"
+#include "zathura/types.h"
+#include "zathura/zathura.h"
+#include <girara/log.h>
+#include "document-widget.h"
+
+typedef struct zathura_document_widget_private_s {
+  zathura_t *zathura;
+  unsigned int spacing;
+  unsigned int pages_per_row;
+  unsigned int first_page_column;
+  bool page_right_to_left;
+} ZathuraDocumentPrivate;
+
+G_DEFINE_TYPE_WITH_CODE(ZathuraDocument, zathura_document_widget, GTK_TYPE_GRID, G_ADD_PRIVATE(ZathuraDocument))
+
+static void zathura_document_widget_set_property(GObject* object, guint prop_id, const GValue* value, GParamSpec* pspec);
+
+enum properties_e {
+  PROP_0,
+  PROP_ZATHURA,
+  PROP_SPACING,
+  PROP_PAGES_PER_ROW,
+  PROP_FIRST_PAGE_COLUMN,
+  PROP_PAGE_RIGHT_TO_LEFT,
+};
+
+static void zathura_document_widget_class_init(ZathuraDocumentClass* class) {
+  /* overwrite methods */
+  // GtkWidgetClass* widget_class = GTK_WIDGET_CLASS(class);
+
+  GObjectClass* object_class = G_OBJECT_CLASS(class);
+  object_class->set_property = zathura_document_widget_set_property;
+
+  /* add properties */
+  g_object_class_install_property(
+      object_class, PROP_ZATHURA,
+      g_param_spec_pointer("zathura", "zathura", "zathura context",
+                           G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property(
+      object_class, PROP_SPACING,
+      g_param_spec_uint("spacing", "spacing", "page spacing",
+                           0, G_MAXUINT, 0, G_PARAM_WRITABLE | G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property(
+      object_class, PROP_PAGES_PER_ROW,
+      g_param_spec_uint("pages-per-row", "pages-per-row", "number of pages per row",
+                           1, 3, 1, G_PARAM_WRITABLE | G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property(
+      object_class, PROP_FIRST_PAGE_COLUMN,
+      g_param_spec_uint("first-page-column", "first-page-column", "column to display the first page",
+                           0, 2, 0, G_PARAM_WRITABLE | G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property(
+      object_class, PROP_PAGE_RIGHT_TO_LEFT,
+      g_param_spec_boolean("page-right-to-left", "page-right-to-left", "render pages right to left", 
+                           false, G_PARAM_WRITABLE | G_PARAM_STATIC_STRINGS));
+}
+
+static void zathura_document_widget_init(ZathuraDocument *widget) {
+  ZathuraDocumentPrivate *priv = zathura_document_widget_get_instance_private(widget);
+
+  priv->zathura = NULL;
+}
+
+GtkWidget* zathura_document_widget_new(zathura_t *zathura) {
+  GObject* ret = g_object_new(ZATHURA_TYPE_DOCUMENT, "zathura", zathura, NULL);
+  if (ret == NULL) {
+    return NULL;
+  }
+
+  ZathuraDocument* widget      = ZATHURA_DOCUMENT(ret);
+
+  gtk_grid_set_row_homogeneous(GTK_GRID(widget), TRUE);
+  gtk_grid_set_column_homogeneous(GTK_GRID(widget), TRUE);
+
+  gtk_widget_set_halign(GTK_WIDGET(widget), GTK_ALIGN_CENTER);
+  gtk_widget_set_valign(GTK_WIDGET(widget), GTK_ALIGN_CENTER);
+
+  gtk_widget_set_hexpand_set(GTK_WIDGET(widget), TRUE);
+  gtk_widget_set_hexpand(GTK_WIDGET(widget), FALSE);
+  gtk_widget_set_vexpand_set(GTK_WIDGET(widget), TRUE);
+  gtk_widget_set_vexpand(GTK_WIDGET(widget), FALSE);
+
+  return GTK_WIDGET(ret);
+}
+
+static void zathura_document_widget_set_property(GObject* object, guint prop_id, const GValue* value, GParamSpec* pspec) {
+  ZathuraDocument *widget = ZATHURA_DOCUMENT(object);
+  ZathuraDocumentPrivate *priv = zathura_document_widget_get_instance_private(widget);
+
+  switch (prop_id) {
+    case PROP_ZATHURA:
+      priv->zathura = g_value_get_pointer(value);
+      break;
+    case PROP_SPACING:
+      priv->spacing = g_value_get_uint(value);
+      break;
+    case PROP_FIRST_PAGE_COLUMN:
+      priv->first_page_column = g_value_get_uint(value);
+      break;
+    case PROP_PAGES_PER_ROW:
+      priv->pages_per_row = g_value_get_uint(value);
+      break;
+    case PROP_PAGE_RIGHT_TO_LEFT:
+      priv->page_right_to_left = g_value_get_boolean(value);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+  }
+}
+
+static void remove_page_from_table(GtkWidget* page, gpointer UNUSED(permanent)) {
+  gtk_container_remove(GTK_CONTAINER(gtk_widget_get_parent(page)), page);
+}
+
+void zathura_document_widget_clear_pages(GtkWidget *widget) {
+  gtk_container_foreach(GTK_CONTAINER(widget), remove_page_from_table, NULL);
+}
+
+void zathura_document_widget_update_pages(GtkWidget *widget) {
+  ZathuraDocument *document = ZATHURA_DOCUMENT(widget);
+  ZathuraDocumentPrivate *priv = zathura_document_widget_get_instance_private(document);
+  zathura_t *zathura = priv->zathura;
+
+  if (zathura == NULL) {
+    return;
+  }
+
+  if (zathura->document == NULL) {
+    return;
+  }
+
+  int page_count = zathura_document_get_number_of_pages(zathura->document);
+
+  gtk_grid_set_row_spacing(GTK_GRID(widget), priv->spacing);
+  gtk_grid_set_column_spacing(GTK_GRID(widget), priv->spacing);
+
+  zathura_document_widget_clear_pages(widget);
+
+  for (int i = 0; i < page_count; i++) {
+    int x = (i + priv->first_page_column - 1) % priv->pages_per_row;
+    int y = (i + priv->first_page_column - 1) / priv->pages_per_row;
+
+    GtkWidget* page_widget = zathura->pages[i];
+    if (priv->page_right_to_left) {
+      x = priv->pages_per_row - 1 - x;
+    }
+
+    gtk_grid_attach(GTK_GRID(widget), page_widget, x, y, 1, 1);
+  }
+}

--- a/zathura/document-widget.h
+++ b/zathura/document-widget.h
@@ -7,11 +7,17 @@
 #include "types.h"
 
 /**
- * The document view widget. 
+ * The document view widget. Places a subset of the pages of 
+ * the document into a grid. The widget handles updating the 
+ * grid to contain the pages in view, and as many pages around
+ * the view as the cairo surface will allow.
  *
- * Draw pages of the document to a canvas.
- * Place the canvas inside a scrolled window to allow scrolling.
- * Zoom by resizing the canvas'.
+ * zathura_document_widget_[get_ratio|set_value|set_value_from_ratio]
+ * functions replace the equivalent ones previously contained in 
+ * adjustment.c. They wrap these functions and perform the necessary 
+ * transformations to move between a ratio of [0,1] in the whole document, 
+ * to a ratio in the subset of the pages contained in the document widgets'
+ * grid.
  *
  * */
 struct zathura_document_widget_s {
@@ -31,23 +37,67 @@ struct zathura_document_widget_class_s {
 
 /**
  * Returns the type of the document view widget.
+ *
  * @return the type
  */
 GType zathura_document_widget_get_type(void) G_GNUC_CONST;
+
 /**
  * Create a document view widget.
+ * 
  * @param zathura the zathura instance
  * @return a document view widget
  */
-GtkWidget* zathura_document_widget_new(zathura_t *zathura);
+GtkWidget* zathura_document_widget_new(void);
+
+/**
+ * Builds the box structure to show the rendered pages
+ *
+ * @param zathura The zathura session
+ * @param page_padding padding in pixels between pages
+ * @param pages_per_row Number of shown pages per row
+ * @param first_page_column Column on which first page start
+ * @param page_right_to_left Render pages right to left
+ */
+void zathura_document_widget_set_mode(zathura_t* zathura, unsigned int page_padding, unsigned int pages_per_row,
+                                      unsigned int first_page_column, bool page_right_to_left);
+
 /**
  * Update the pages in the document view
+ *
  * @param widget the document view widget
  */
-void zathura_document_widget_update_pages(GtkWidget *widget);
+void zathura_document_widget_render(zathura_t *zathura);
+
 /**
  * Clear pages from the document view
+ *
  * @param widget the document view widget
  */
 void zathura_document_widget_clear_pages(GtkWidget *widget);
+
+/**
+ * Compute the adjustment ratio
+ *
+ * That is, the ratio between the length from the lower bound to the middle of
+ * the slider, and the total length of the scrollbar.
+ *
+ * @param adjustment Scrollbar adjustment
+ * @param width Is the adjustment for width?
+ * @return Adjustment ratio
+ */
+gdouble zathura_document_widget_get_ratio(zathura_t *zathura, GtkAdjustment *adjustment, bool width);
+
+/**
+ * Set the adjustment value from ratio
+ *
+ * The ratio is usually obtained from a previous call to
+ * zathura_document_widget_get_ratio().
+ *
+ * @param adjustment Adjustment instance
+ * @param ratio Ratio from which the adjustment value will be set
+ * @param width Is the adjustment for width?
+ */
+void zathura_document_widget_set_value_from_ratio(zathura_t *zathura, GtkAdjustment *adjustment, double ratio, bool width);
+
 #endif // DOCUMENT_WIDGET_H

--- a/zathura/document-widget.h
+++ b/zathura/document-widget.h
@@ -1,0 +1,53 @@
+/* SPDX-License-Identifier: Zlib */
+
+#ifndef DOCUMENT_WIDGET_H
+#define DOCUMENT_WIDGET_H
+
+#include <gtk/gtk.h>
+#include "types.h"
+
+/**
+ * The document view widget. 
+ *
+ * Draw pages of the document to a canvas.
+ * Place the canvas inside a scrolled window to allow scrolling.
+ * Zoom by resizing the canvas'.
+ *
+ * */
+struct zathura_document_widget_s {
+  GtkGrid parent;
+};
+
+struct zathura_document_widget_class_s {
+  GtkGridClass parent_class;
+};
+
+#define ZATHURA_TYPE_DOCUMENT (zathura_document_widget_get_type())
+#define ZATHURA_DOCUMENT(obj) (G_TYPE_CHECK_INSTANCE_CAST((obj), ZATHURA_TYPE_DOCUMENT, ZathuraDocument))
+#define ZATHURA_DOCUMENT_CLASS(obj) (G_TYPE_CHECK_CLASS_CAST((obj), ZATHURA_TYPE_DOCUMENT, ZathuraDocumentClass))
+#define ZATHURA_IS_DOCUMENT(obj) (G_TYPE_CHECK_INSTANCE_TYPE((obj), ZATHURA_TYPE_DOCUMENT))
+#define ZATHURA_IS_DOCUMENT_CLASS(obj) (G_TYPE_CHECK_CLASS_TYPE((obj), ZATHURA_TYPE_DOCUMENT))
+#define ZATHURA_DOCUMENT_GET_CLASS(obj) (G_TYPE_INSTANCE_GET_CLASS((obj), ZATHURA_TYPE_DOCUMENT, ZathuraDocumentClass))
+
+/**
+ * Returns the type of the document view widget.
+ * @return the type
+ */
+GType zathura_document_widget_get_type(void) G_GNUC_CONST;
+/**
+ * Create a document view widget.
+ * @param zathura the zathura instance
+ * @return a document view widget
+ */
+GtkWidget* zathura_document_widget_new(zathura_t *zathura);
+/**
+ * Update the pages in the document view
+ * @param widget the document view widget
+ */
+void zathura_document_widget_update_pages(GtkWidget *widget);
+/**
+ * Clear pages from the document view
+ * @param widget the document view widget
+ */
+void zathura_document_widget_clear_pages(GtkWidget *widget);
+#endif // DOCUMENT_WIDGET_H

--- a/zathura/shortcuts.c
+++ b/zathura/shortcuts.c
@@ -1215,7 +1215,7 @@ bool sc_toggle_index(girara_session_t* session, girara_argument_t* UNUSED(argume
   }
 
   if (gtk_widget_get_visible(GTK_WIDGET(zathura->ui.index))) {
-    girara_set_view(session, zathura->ui.page_widget);
+    girara_set_view(session, zathura->ui.document_widget);
     gtk_widget_hide(GTK_WIDGET(zathura->ui.index));
     girara_mode_set(zathura->ui.session, zathura->modes.normal);
 

--- a/zathura/types.h
+++ b/zathura/types.h
@@ -13,6 +13,11 @@
  */
 typedef struct zathura_document_s zathura_document_t;
 /**
+ * Document widget
+ */
+typedef struct zathura_document_widget_s ZathuraDocument;
+typedef struct zathura_document_widget_class_s ZathuraDocumentClass;
+/**
  * Page
  */
 typedef struct zathura_page_s zathura_page_t;

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -253,7 +253,7 @@ static bool init_ui(zathura_t* zathura) {
   zathura->signals.monitors_changed_handler = 0;
 
   /* page view */
-  zathura->ui.document_widget = zathura_document_widget_new(zathura);
+  zathura->ui.document_widget = zathura_document_widget_new();
   if (zathura->ui.document_widget == NULL) {
     girara_error("Failed to create document widget.");
     return false;
@@ -1158,7 +1158,7 @@ bool document_open(zathura_t* zathura, const char* path, const char* uri, const 
 
   page_right_to_left = file_info.page_right_to_left;
 
-  page_widget_set_mode(zathura, page_padding, pages_per_row, first_page_column, page_right_to_left);
+  zathura_document_widget_set_mode(zathura, page_padding, pages_per_row, first_page_column, page_right_to_left);
   zathura_document_set_page_layout(document, page_padding, pages_per_row, first_page_column);
 
   girara_set_view(zathura->ui.session, zathura->ui.document_widget);
@@ -1594,37 +1594,6 @@ void statusbar_page_number_update(zathura_t* zathura) {
   } else {
     girara_statusbar_item_set_text(zathura->ui.session, zathura->ui.statusbar.page_number, "");
   }
-}
-
-void page_widget_set_mode(zathura_t* zathura, unsigned int page_padding, unsigned int pages_per_row,
-                          unsigned int first_page_column, bool page_right_to_left) {
-  zathura_document_t* document = zathura_get_document(zathura);
-  if (document == NULL) {
-    return;
-  }
-
-  /* show at least one page */
-  if (pages_per_row == 0) {
-    pages_per_row = 1;
-  }
-
-  /* ensure: 0 < first_page_column <= pages_per_row */
-  if (first_page_column < 1) {
-    first_page_column = 1;
-  }
-  if (first_page_column > pages_per_row) {
-    first_page_column = ((first_page_column - 1) % pages_per_row) + 1;
-  }
-
-  g_object_set(G_OBJECT(zathura->ui.document_widget), 
-               "first-page-column", first_page_column, 
-               "spacing", page_padding, 
-               "page-right-to-left", page_right_to_left, 
-               "pages-per-row", pages_per_row,
-               NULL);
-
-  zathura_document_widget_update_pages(zathura->ui.document_widget);
-  gtk_widget_show_all(zathura->ui.document_widget);
 }
 
 bool position_set(zathura_t* zathura, double position_x, double position_y) {

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -1,5 +1,8 @@
 /* SPDX-License-Identifier: Zlib */
 
+#include "glib-object.h"
+#include "glib.h"
+#include "zathura/document-widget.h"
 #include <errno.h>
 #include <stdlib.h>
 #include <math.h>
@@ -31,6 +34,7 @@
 #include "commands.h"
 #include "database-sqlite.h"
 #include "document.h"
+#include "document-widget.h"
 #include "shortcuts.h"
 #include "zathura.h"
 #include "utils.h"
@@ -249,11 +253,9 @@ static bool init_ui(zathura_t* zathura) {
   zathura->signals.monitors_changed_handler = 0;
 
   /* page view */
-  zathura->ui.page_widget = gtk_grid_new();
-  gtk_grid_set_row_homogeneous(GTK_GRID(zathura->ui.page_widget), TRUE);
-  gtk_grid_set_column_homogeneous(GTK_GRID(zathura->ui.page_widget), TRUE);
-  if (zathura->ui.page_widget == NULL) {
-    girara_error("Failed to create page widget.");
+  zathura->ui.document_widget = zathura_document_widget_new(zathura);
+  if (zathura->ui.document_widget == NULL) {
+    girara_error("Failed to create document widget.");
     return false;
   }
 
@@ -272,15 +274,7 @@ static bool init_ui(zathura_t* zathura) {
   g_signal_connect(G_OBJECT(vadjustment), "changed", G_CALLBACK(cb_view_vadjustment_changed), zathura);
 
   /* page view alignment */
-  gtk_widget_set_halign(zathura->ui.page_widget, GTK_ALIGN_CENTER);
-  gtk_widget_set_valign(zathura->ui.page_widget, GTK_ALIGN_CENTER);
-
-  gtk_widget_set_hexpand_set(zathura->ui.page_widget, TRUE);
-  gtk_widget_set_hexpand(zathura->ui.page_widget, FALSE);
-  gtk_widget_set_vexpand_set(zathura->ui.page_widget, TRUE);
-  gtk_widget_set_vexpand(zathura->ui.page_widget, FALSE);
-
-  gtk_widget_show(zathura->ui.page_widget);
+  gtk_widget_show(zathura->ui.document_widget);
 
   /* statusbar */
   zathura->ui.statusbar.file = girara_statusbar_item_add(zathura->ui.session, TRUE, TRUE, TRUE, NULL);
@@ -455,8 +449,8 @@ bool zathura_init(zathura_t* zathura) {
 
 error_free:
 
-  if (zathura->ui.page_widget != NULL) {
-    g_object_unref(zathura->ui.page_widget);
+  if (zathura->ui.document_widget != NULL) {
+    g_object_unref(zathura->ui.document_widget);
   }
 
   return false;
@@ -1167,7 +1161,7 @@ bool document_open(zathura_t* zathura, const char* path, const char* uri, const 
   page_widget_set_mode(zathura, page_padding, pages_per_row, first_page_column, page_right_to_left);
   zathura_document_set_page_layout(document, page_padding, pages_per_row, first_page_column);
 
-  girara_set_view(zathura->ui.session, zathura->ui.page_widget);
+  girara_set_view(zathura->ui.session, zathura->ui.document_widget);
 
   /* bookmarks */
   if (zathura->database != NULL) {
@@ -1338,10 +1332,6 @@ bool document_save(zathura_t* zathura, const char* path, bool overwrite) {
   return true;
 }
 
-static void remove_page_from_table(GtkWidget* page, gpointer UNUSED(permanent)) {
-  gtk_container_remove(GTK_CONTAINER(gtk_widget_get_parent(page)), page);
-}
-
 static zathura_fileinfo_t zathura_get_document_fileinfo(zathura_t* zathura, zathura_document_t* document) {
   /* Caller needs to g_free(file_info.first_page_column_list) */
 
@@ -1482,7 +1472,7 @@ bool document_close(zathura_t* zathura, bool keep_monitor) {
 #endif
 
   /* remove widgets */
-  gtk_container_foreach(GTK_CONTAINER(zathura->ui.page_widget), remove_page_from_table, NULL);
+  zathura_document_widget_clear_pages(zathura->ui.document_widget);
 
   if (!override_predecessor) {
     for (unsigned int i = 0; i < zathura_document_get_number_of_pages(document); i++) {
@@ -1514,7 +1504,7 @@ bool document_close(zathura_t* zathura, bool keep_monitor) {
     zathura->global.current_index_path = NULL;
   }
 
-  gtk_widget_hide(zathura->ui.page_widget);
+  gtk_widget_hide(zathura->ui.document_widget);
 
   statusbar_page_number_update(zathura);
 
@@ -1626,26 +1616,15 @@ void page_widget_set_mode(zathura_t* zathura, unsigned int page_padding, unsigne
     first_page_column = ((first_page_column - 1) % pages_per_row) + 1;
   }
 
-  gtk_container_foreach(GTK_CONTAINER(zathura->ui.page_widget), remove_page_from_table, NULL);
+  g_object_set(G_OBJECT(zathura->ui.document_widget), 
+               "first-page-column", first_page_column, 
+               "spacing", page_padding, 
+               "page-right-to-left", page_right_to_left, 
+               "pages-per-row", pages_per_row,
+               NULL);
 
-  unsigned int number_of_pages = zathura_document_get_number_of_pages(document);
-
-  gtk_grid_set_row_spacing(GTK_GRID(zathura->ui.page_widget), page_padding);
-  gtk_grid_set_column_spacing(GTK_GRID(zathura->ui.page_widget), page_padding);
-
-  for (unsigned int i = 0; i < number_of_pages; i++) {
-    int x = (i + first_page_column - 1) % pages_per_row;
-    int y = (i + first_page_column - 1) / pages_per_row;
-
-    GtkWidget* page_widget = zathura->pages[i];
-    if (page_right_to_left) {
-      x = pages_per_row - 1 - x;
-    }
-
-    gtk_grid_attach(GTK_GRID(zathura->ui.page_widget), page_widget, x, y, 1, 1);
-  }
-
-  gtk_widget_show_all(zathura->ui.page_widget);
+  zathura_document_widget_update_pages(zathura->ui.document_widget);
+  gtk_widget_show_all(zathura->ui.document_widget);
 }
 
 bool position_set(zathura_t* zathura, double position_x, double position_y) {
@@ -1708,7 +1687,7 @@ void refresh_view(zathura_t* zathura) {
 bool adjust_view(zathura_t* zathura) {
   g_return_val_if_fail(zathura != NULL, false);
   zathura_document_t* document = zathura_get_document(zathura);
-  if (zathura->ui.page_widget == NULL || document == NULL) {
+  if (zathura->ui.document_widget == NULL || document == NULL) {
     goto error_ret;
   }
 

--- a/zathura/zathura.h
+++ b/zathura/zathura.h
@@ -112,7 +112,7 @@ struct zathura_s {
       GdkRGBA signature_error;        /**> Color for highlighing invalid signatures */
     } colors;
 
-    GtkWidget* page_widget; /**< Widget that contains all rendered pages */
+    GtkWidget* document_widget; /**< Widget that contains all rendered pages */
     GtkWidget* index;       /**< Widget to show the index of the document */
   } ui;
 

--- a/zathura/zathura.h
+++ b/zathura/zathura.h
@@ -450,18 +450,6 @@ void refresh_view(zathura_t* zathura);
 bool adjust_view(zathura_t* zathura);
 
 /**
- * Builds the box structure to show the rendered pages
- *
- * @param zathura The zathura session
- * @param page_padding padding in pixels between pages
- * @param pages_per_row Number of shown pages per row
- * @param first_page_column Column on which first page start
- * @param page_right_to_left Render pages right to left
- */
-void page_widget_set_mode(zathura_t* zathura, unsigned int page_padding, unsigned int pages_per_row,
-                          unsigned int first_page_column, bool page_right_to_left);
-
-/**
  * Updates the page number in the statusbar. Note that 1 will be added to the
  * displayed number
  *


### PR DESCRIPTION
Implements #719 to resolve in #449, #365, #253, #200, and #65

Tested on the ARM reference manual (15,000 pages) https://developer.arm.com/documentation/ddi0487/latest, and Intel manual (5000 pages) https://developer.arm.com/documentation/ddi0487/latest, and doesn't crash when zooming in to either document. 

I'm not sure if the document widget should stay as a GTK widgt or change to a normal struct, I'm fine with either. 

Care needs to be taken when manually setting the value of the ui viewport, since the document widget changes the grid. `zathura_document_widget_[set_ratio_from_value|get_ratio]` functions wrap `zathura_adjustment_[set_ratio_from_value|get_ratio]` functions to handle the conversion from document ratio to widget ratio.

The canvas size chosen is 32,767 which is the max cairo canvas height (perhaps this can be increased but I don't know how much cairo can handle). `zathura_document_widget_render` updates the pages in the grid when the current page is within 1 page of the current pages shown. There's probably a smarter way to handle this as it doesn't do to well with scrolling in zoomed out documents.