### PR TITLE
zathura-sandbox: Initial OpenBSD Support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -163,7 +163,7 @@ libzathura = static_library('zathura',
 libzathura_dep = declare_dependency(link_with: libzathura)
 
 # zathura-sandbox executable
-if seccomp.found() or landlock
+if seccomp.found() or landlock or target_machine.system() == 'openbsd'
   sandbox_sources = files()
   sandbox_defines = ['-DWITH_SANDBOX']
   sandbox_dependencies = []

--- a/zathura/main-sandbox.c
+++ b/zathura/main-sandbox.c
@@ -53,6 +53,13 @@ static zathura_t* init_zathura(const char* config_dir, const char* data_dir, con
     return NULL;
   }
 #endif
+#ifdef __OpenBSD__
+  if (pledge("stdio rpath", "") != 0) {
+    girara_error("Failed to pledge: %s", strerror(errno));
+    zathura_free(zathura);
+    return NULL;
+  }
+#endif
   /* unset the input method to avoid communication with external services */
   unsetenv("GTK_IM_MODULE");
 


### PR DESCRIPTION
The zathura-sandbox now builds on OpenBSD and has essential pledge(2) support, effectively restricting system calls to the bare minimum.

In its prior state, the zathura-sandbox only supported Linux. This made a change of build requirements necessary, which now also checks if the target machine is OpenBSD.

Within the init_zathura function of the sandbox, a new ifdef for OpenBSD has been introduced, reducing the available system calls to a bare minimum using pledge(2). After that, files can still be opened, but nothing more.

Fortunately, due to the architecture of the sandbox, this is sufficient, as the PDF libraries and UI were already rendered. Suspicious PDF files loaded afterwards should do no harm.

The patched zathura-sandbox version was tested against multiple PDF files using the mupdf plugin.