### PR TITLE
Add Document open and document close d-bus signals

### DIFF
--- a/zathura/commands.c
+++ b/zathura/commands.c
@@ -221,39 +221,22 @@ bool cmd_info(girara_session_t* session, girara_list_t* UNUSED(argument_list)) {
     return false;
   }
 
-  struct meta_field {
-    const char* name;
-    zathura_document_information_type_t field;
-  };
+  size_t meta_fields_count = 0;
+  struct meta_field_s* meta_fields = zathura_document_get_meta_fields(zathura_get_document(zathura), &meta_fields_count);
 
-  const struct meta_field meta_fields[] = {
-      {_("Title"), ZATHURA_DOCUMENT_INFORMATION_TITLE},
-      {_("Subject"), ZATHURA_DOCUMENT_INFORMATION_SUBJECT},
-      {_("Keywords"), ZATHURA_DOCUMENT_INFORMATION_KEYWORDS},
-      {_("Author"), ZATHURA_DOCUMENT_INFORMATION_AUTHOR},
-      {_("Creator"), ZATHURA_DOCUMENT_INFORMATION_CREATOR},
-      {_("Producer"), ZATHURA_DOCUMENT_INFORMATION_PRODUCER},
-      {_("Creation date"), ZATHURA_DOCUMENT_INFORMATION_CREATION_DATE},
-      {_("Modification date"), ZATHURA_DOCUMENT_INFORMATION_MODIFICATION_DATE},
-      {_("Format"), ZATHURA_DOCUMENT_INFORMATION_FORMAT},
-      {_("Other"), ZATHURA_DOCUMENT_INFORMATION_OTHER},
-  };
-
-  girara_list_t* information = zathura_document_get_information(zathura_get_document(zathura), NULL);
-  if (information == NULL) {
-    girara_notify(session, GIRARA_INFO, _("No information available."));
+  if(meta_fields == NULL){
+      girara_notify(session, GIRARA_ERROR, _("Error during information retrieval."));
     return false;
   }
 
   GString* string = g_string_new(NULL);
 
-  for (size_t i = 0; i < LENGTH(meta_fields); i++) {
-    for (size_t idx = 0; idx != girara_list_size(information); ++idx) {
-      zathura_document_information_entry_t* entry = girara_list_nth(information, idx);
-      if (entry != NULL && meta_fields[i].field == entry->type) {
-        g_string_append_printf(string, "<b>%s:</b> %s\n", meta_fields[i].name, entry->value);
-      }
+  meta_fields_count = 0;
+  for (size_t i = 0; i < meta_fields_count; i++) {
+    if(meta_fields[i].value == NULL){
+      continue;
     }
+      g_string_append_printf(string, "<b>%s:</b> %s\n", meta_fields[i].name, meta_fields[i].value);
   }
 
   if (string->len > 0) {

--- a/zathura/dbus-interface.h
+++ b/zathura/dbus-interface.h
@@ -32,6 +32,22 @@ ZathuraDbus* zathura_dbus_new(zathura_t* zathura);
 const char* zathura_dbus_get_name(zathura_t* zathura);
 
 /**
+ * Emit the 'DocumentOpen' signal on the D-Bus connection.
+ *
+ * @param zathura Zathura session
+ * @param file_name file name
+ */
+void zathura_dbus_document_open(zathura_t* zathura, const char* file_name);
+
+/**
+ * Emit the 'DocumentClose' signal on the D-Bus connection.
+ *
+ * @param zathura Zathura session
+ * @param document_path document path
+ */
+void zathura_dbus_document_close(zathura_t* zathura, const char* document_path);
+
+/**
  * Emit the 'Edit' signal on the D-Bus connection.
  *
  * @param zathura Zathura session

--- a/zathura/document.c
+++ b/zathura/document.c
@@ -5,6 +5,7 @@
 #include <limits.h>
 #include <glib.h>
 #include <gio/gio.h>
+#include <glib/gi18n.h>
 #include <math.h>
 
 #include <girara/datastructures.h>
@@ -17,6 +18,8 @@
 #include "page.h"
 #include "plugin.h"
 #include "content-type.h"
+#include "dbus-interface.h"
+#include "internal.h"
 
 /**
  * Document
@@ -657,6 +660,42 @@ zathura_error_t zathura_document_attachment_save(zathura_document_t* document, c
   }
 
   return functions->document_attachment_save(document, document->data, attachment, file);
+}
+
+struct meta_field_s* zathura_document_get_meta_fields(zathura_document_t* document, size_t* fields_count){
+  if(document == NULL || fields_count == NULL){
+    return NULL;
+  }
+
+  *fields_count = 10;
+  struct meta_field_s* meta_fields = g_new(struct meta_field_s, *fields_count);
+
+  meta_fields[0] = (struct meta_field_s){_("Title"), ZATHURA_DOCUMENT_INFORMATION_TITLE, NULL};
+  meta_fields[1] = (struct meta_field_s){_("Subject"), ZATHURA_DOCUMENT_INFORMATION_SUBJECT, NULL};
+  meta_fields[2] = (struct meta_field_s){_("Keywords"), ZATHURA_DOCUMENT_INFORMATION_KEYWORDS, NULL};
+  meta_fields[3] = (struct meta_field_s){_("Author"), ZATHURA_DOCUMENT_INFORMATION_AUTHOR, NULL};
+  meta_fields[4] = (struct meta_field_s){_("Creator"), ZATHURA_DOCUMENT_INFORMATION_CREATOR, NULL};
+  meta_fields[5] = (struct meta_field_s){_("Producer"), ZATHURA_DOCUMENT_INFORMATION_PRODUCER, NULL};
+  meta_fields[6] = (struct meta_field_s){_("Creation date"), ZATHURA_DOCUMENT_INFORMATION_CREATION_DATE, NULL};
+  meta_fields[7] = (struct meta_field_s){_("Modification date"), ZATHURA_DOCUMENT_INFORMATION_MODIFICATION_DATE, NULL};
+  meta_fields[8] = (struct meta_field_s){_("Format"), ZATHURA_DOCUMENT_INFORMATION_FORMAT, NULL};
+  meta_fields[9] = (struct meta_field_s){_("Other"), ZATHURA_DOCUMENT_INFORMATION_OTHER, NULL};
+
+  girara_list_t* information = zathura_document_get_information(document, NULL);
+  if (information == NULL) {
+    return NULL;
+  }
+
+  for (size_t i = 0; i < *fields_count; i++) {
+    for (size_t idx = 0; idx != girara_list_size(information); ++idx) {
+      zathura_document_information_entry_t* entry = girara_list_nth(information, idx);
+      if (entry != NULL && meta_fields[i].field == entry->type) {
+        meta_fields[i].value = entry->value;
+      }
+    }
+  }
+
+  return meta_fields;
 }
 
 girara_list_t* zathura_document_get_information(zathura_document_t* document, zathura_error_t* error) {

--- a/zathura/document.h
+++ b/zathura/document.h
@@ -410,6 +410,15 @@ ZATHURA_PLUGIN_API zathura_error_t zathura_document_attachment_save(zathura_docu
                                                                     const char* attachment, const char* file);
 
 /**
+ * Returns the available document meta data
+ *
+ * @param document the zathura document
+ * @fields_count the amount of fields present in the meta data
+ * @return The available document meta data or NULL if information could not be retrieved
+ */
+struct meta_field_s* zathura_document_get_meta_fields(zathura_document_t* document, size_t* fields_count);
+
+/**
  * Returns a string of the requested information
  *
  * @param document The zathura document

--- a/zathura/internal.h
+++ b/zathura/internal.h
@@ -26,6 +26,6 @@ struct zathura_document_information_entry_s {
  * @param document The document
  * @return The plugin or NULL
  */
-zathura_plugin_t* zathura_document_get_plugin(zathura_document_t* document);
+const zathura_plugin_t* zathura_document_get_plugin(zathura_document_t* document);
 
 #endif // INTERNAL_H

--- a/zathura/types.h
+++ b/zathura/types.h
@@ -327,4 +327,10 @@ struct zathura_mark_s {
 
 typedef struct zathura_mark_s zathura_mark_t;
 
+struct meta_field_s {
+  const char* name;
+  zathura_document_information_type_t field;
+  const char* value;
+};
+
 #endif // TYPES_H

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -1233,6 +1233,11 @@ bool document_open(zathura_t* zathura, const char* path, const char* uri, const 
   /* call screen-changed callback to connect monitors-changed signal on initial screen */
   cb_widget_screen_changed(zathura->ui.session->gtk.view, NULL, zathura);
 
+  /* emit DocumentOpen signal */
+#ifndef WITH_SANDBOX
+  zathura_dbus_document_open(zathura, file_path);
+#endif
+
   return true;
 
 error_free:
@@ -1473,6 +1478,12 @@ bool document_close(zathura_t* zathura, bool keep_monitor) {
 
   /* remove widgets */
   zathura_document_widget_clear_pages(zathura->ui.document_widget);
+
+  /* emit DocumentClose signal */
+#ifndef WITH_SANDBOX
+  const char* file_path = zathura_document_get_path(document);
+  zathura_dbus_document_close(zathura, file_path);
+#endif
 
   if (!override_predecessor) {
     for (unsigned int i = 0; i < zathura_document_get_number_of_pages(document); i++) {


### PR DESCRIPTION
This PR adds d-bus signals for document open and document close events.

I would like to be able listen for document open and close events. In this PR the document metadata is included in the open event, whilst the close event only contains the filename. Perhaps it would be a better idea to ensure the data sent in the close and open events are identical.

Perhaps a different/external document identifier could be used as the same file can be opened multiple times in the same Zathura process. This would make it hard to track exactly which file got opened/closed,

The first commit contains a refactor for the meta_fields struct retrieval. I added a const contraint to zathura_document_get_plugin in internal.h. This is due to having to import internal.h in document.c as it uses zathura_document_information_type_t. Without this change I got a "conflicting types" error in document.c. I am not that experienced in C so let me know if this change does not make sense.

In the future I would also like to add events for page switches, which would include:
- page number that got switched to
- previous page number
- document identifier (filename ?)

