### PR TITLE
fix cycling through last sub-item on index

### DIFF
--- a/zathura/shortcuts.c
+++ b/zathura/shortcuts.c
@@ -1067,23 +1067,23 @@ bool sc_navigate_index(girara_session_t* session, girara_argument_t* argument, g
         gtk_tree_path_down(path);
         continue;
       }
+
       gtk_tree_model_get_iter(model, &iter, path);
       if (gtk_tree_model_iter_next(model, &iter)) {
         gtk_tree_path_free(path);
         path = gtk_tree_model_get_path(model, &iter);
         continue;
       }
+
       gtk_tree_model_get_iter(model, &iter, path);
       while (gtk_tree_model_iter_parent(model, &parent_iter, &iter)) {
         iter = parent_iter;
         if (gtk_tree_model_iter_next(model, &parent_iter)) {
-          iter = parent_iter;
+          gtk_tree_path_free(path);
+          path = gtk_tree_model_get_path(model, &parent_iter);
           break;
         }
-        parent_iter = iter;
       }
-      gtk_tree_path_free(path);
-      path = gtk_tree_model_get_path(model, &iter);
     }
     break;
   case HALF_UP:


### PR DESCRIPTION
Fix #731 .

When the current path iter does not have a next iter (last item in the current level), move to the next iter of the first parent of the current iter which has a next iter if it exists, otherwise don't change the current path.

Side note: when looking into this I was confused why it was working for down arrow and not j, what I found is `GDK_KEY_Down` does not call `sc_navigate_index`, nor is it processed by `girara_callback_view_key_press_event`. I'm not sure how that is making changes to the index, using the gtk debugger the key press is counted by the main GtkWindow but nothing else (including the GtkScrolledWindow which is session.gtk->view).