### PR TITLE
Scroll search

### DIFF
--- a/zathura/callbacks.c
+++ b/zathura/callbacks.c
@@ -320,8 +320,8 @@ void cb_page_layout_value_changed(girara_session_t* session, const char* name, g
   bool page_right_to_left = false;
   girara_setting_get(zathura->ui.session, "page-right-to-left", &page_right_to_left);
 
-  zathura_document_widget_set_mode(zathura, page_padding, pages_per_row, first_page_column, page_right_to_left);
   zathura_document_set_page_layout(zathura_get_document(zathura), page_padding, pages_per_row, first_page_column);
+  zathura_document_widget_set_mode(zathura, page_padding, pages_per_row, first_page_column, page_right_to_left);
 }
 
 void cb_index_row_activated(GtkTreeView* tree_view, GtkTreePath* path, GtkTreeViewColumn* UNUSED(column), void* data) {

--- a/zathura/document-widget.c
+++ b/zathura/document-widget.c
@@ -107,13 +107,16 @@ static void zathura_document_widget_get_render_range(zathura_t* zathura, unsigne
   zathura_page_t* page         = zathura_document_get_page(document, current_page);
   double page_height           = zathura_page_get_height(page);
 
-  unsigned int max_pages = MIN(number_of_pages, cairo_max_size * priv->pages_per_row / page_height);
-  if (max_pages < current_page) {
-    *start_index = current_page - max_pages;
-  } else {
+  *page_count = MIN(number_of_pages, cairo_max_size * priv->pages_per_row / page_height);
+  if (number_of_pages < current_page + *page_count / 2) {
+    // current_page is near the end of the document
+    *start_index = number_of_pages - *page_count;
+  } else if (current_page < *page_count / 2) {
+    // current_page is near the start of the document
     *start_index = 0;
+  } else {
+    *start_index = current_page - *page_count / 2;
   }
-  *page_count = MIN(number_of_pages - *start_index, current_page + max_pages);
 }
 
 static void zathura_document_update_grid(zathura_t* zathura) {

--- a/zathura/document-widget.c
+++ b/zathura/document-widget.c
@@ -99,7 +99,10 @@ static void zathura_document_widget_get_render_range(zathura_t* zathura, unsigne
   ZathuraDocumentWidgetPrivate* priv = zathura_document_widget_get_instance_private(widget);
   zathura_document_t* document       = zathura_get_document(zathura);
 
-  unsigned int current_page    = zathura_document_get_current_page_number(document);
+  double pos_x = zathura_document_get_position_x(document);
+  double pos_y = zathura_document_get_position_y(document);
+
+  unsigned int current_page    = position_to_page_number(document, pos_x, pos_y);
   unsigned int number_of_pages = zathura_document_get_number_of_pages(document);
   zathura_page_t* page         = zathura_document_get_page(document, current_page);
   double page_height           = zathura_page_get_height(page);

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -1158,8 +1158,8 @@ bool document_open(zathura_t* zathura, const char* path, const char* uri, const 
 
   page_right_to_left = file_info.page_right_to_left;
 
-  zathura_document_widget_set_mode(zathura, page_padding, pages_per_row, first_page_column, page_right_to_left);
   zathura_document_set_page_layout(document, page_padding, pages_per_row, first_page_column);
+  zathura_document_widget_set_mode(zathura, page_padding, pages_per_row, first_page_column, page_right_to_left);
 
   girara_set_view(zathura->ui.session, zathura->ui.document_widget);
 


### PR DESCRIPTION
Fixes #751 

Scroll bottom doesn't update the current page number before the document widget is rendered, so we use the document position to get the current page number instead.

Search position was more difficult. When searching, if the document grid changes, the vadjustment would not have updated to reflect the current size of the grid resulting in incorrect adjustments. It seems like changing the set adjustment to update on the mainloop using `g_idle_add_once` fixes this. I'm not sure if this is the right way to solve this, or if get adjustment should also be in the mainloop, open to feedback.