### PR TITLE
Apply correct adjust mode after quickmark jump

### DIFF
--- a/zathura/marks.c
+++ b/zathura/marks.c
@@ -206,6 +206,8 @@ static void mark_evaluate(zathura_t* zathura, int key) {
     if (mark != NULL && mark->key == key) {
       zathura_document_set_zoom(zathura_get_document(zathura),
                                 zathura_correct_zoom_value(zathura->ui.session, mark->zoom));
+
+      adjust_view(zathura);
       render_all(zathura);
 
       zathura_jumplist_add(zathura);


### PR DESCRIPTION
Resolves #761 

It was observed that during quickmark evaluation, the document's zoom value was set to what was saved in the quickmark, without regard for the currently set adjust mode.

This became obvious when it was observed that changing the viewport size after encountering this bug solved the issue, since this causes a call to adjust_view().

Hence, this patch adds a call to adjust_view() before render_all() in marks.c to solve the issue.

Thank you.