### PR TITLE
fix page grid attaching

### DIFF
--- a/zathura/callbacks.c
+++ b/zathura/callbacks.c
@@ -324,7 +324,7 @@ void cb_page_layout_value_changed(girara_session_t* session, const char* name, g
   girara_setting_get(zathura->ui.session, "page-right-to-left", &page_right_to_left);
 
   zathura_document_set_page_layout(zathura_get_document(zathura), page_v_padding, page_h_padding, pages_per_row, first_page_column);
-  zathura_document_widget_set_mode(zathura, page_v_padding, page_h_padding, pages_per_row, first_page_column, page_right_to_left);
+  zathura_document_widget_set_mode(zathura, page_v_padding, page_h_padding, page_right_to_left);
 }
 
 void cb_index_row_activated(GtkTreeView* tree_view, GtkTreePath* path, GtkTreeViewColumn* UNUSED(column), void* data) {

--- a/zathura/document-widget.h
+++ b/zathura/document-widget.h
@@ -64,7 +64,7 @@ GtkWidget* zathura_document_widget_new(void);
  * @param page_right_to_left Render pages right to left
  */
 void zathura_document_widget_set_mode(zathura_t* zathura, unsigned int page_v_padding, unsigned int page_h_padding, 
-                                      unsigned int pages_per_row, unsigned int first_page_column, bool page_right_to_left);
+                                      bool page_right_to_left);
 
 /**
  * Update the pages in the document view

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -1163,7 +1163,7 @@ bool document_open(zathura_t* zathura, const char* path, const char* uri, const 
   page_right_to_left = file_info.page_right_to_left;
 
   zathura_document_set_page_layout(document, page_v_padding, page_h_padding, pages_per_row, first_page_column);
-  zathura_document_widget_set_mode(zathura, page_v_padding, page_h_padding, pages_per_row, first_page_column, page_right_to_left);
+  zathura_document_widget_set_mode(zathura, page_v_padding, page_h_padding, page_right_to_left);
 
   girara_set_view(zathura->ui.session, zathura->ui.document_widget);
 


### PR DESCRIPTION
resolves #766 

Grid attaching of pages didn't correctly account for the first page column. 
Modified the document widget to render a number of page rows, and every page in the given rows.