### PR TITLE
document widget updates

### DIFF
--- a/zathura/adjustment.c
+++ b/zathura/adjustment.c
@@ -140,10 +140,3 @@ bool page_is_visible(zathura_document_t* document, unsigned int page_number) {
   return (fabs(pos_x - page_x) < 0.5 * (double)(view_width + cell_width) / (double)doc_width &&
           fabs(pos_y - page_y) < 0.5 * (double)(view_height + cell_height) / (double)doc_height);
 }
-
-void zathura_adjustment_set_value(GtkAdjustment* adjustment, gdouble value) {
-  const gdouble lower        = gtk_adjustment_get_lower(adjustment);
-  const gdouble upper_m_size = gtk_adjustment_get_upper(adjustment) - gtk_adjustment_get_page_size(adjustment);
-
-  gtk_adjustment_set_value(adjustment, MAX(lower, MIN(upper_m_size, value)));
-}

--- a/zathura/adjustment.h
+++ b/zathura/adjustment.h
@@ -74,12 +74,4 @@ void page_number_to_position(zathura_document_t* document, unsigned int page_num
  */
 bool page_is_visible(zathura_document_t* document, unsigned int page_number);
 
-/**
- * Set the adjustment value while enforcing its limits
- *
- * @param adjustment Adjustment instance
- * @param value Adjustment value
- */
-void zathura_adjustment_set_value(GtkAdjustment* adjustment, gdouble value);
-
 #endif /* ZATHURA_ADJUSTMENT_H */

--- a/zathura/callbacks.c
+++ b/zathura/callbacks.c
@@ -324,7 +324,7 @@ void cb_page_layout_value_changed(girara_session_t* session, const char* name, g
   girara_setting_get(zathura->ui.session, "page-right-to-left", &page_right_to_left);
 
   zathura_document_set_page_layout(zathura_get_document(zathura), page_v_padding, page_h_padding, pages_per_row, first_page_column);
-  zathura_document_widget_set_mode(zathura, page_v_padding, page_h_padding, pages_per_row, first_page_column, page_right_to_left);
+  zathura_document_widget_set_mode(zathura, page_v_padding, page_h_padding, page_right_to_left);
 }
 
 void cb_index_row_activated(GtkTreeView* tree_view, GtkTreePath* path, GtkTreeViewColumn* UNUSED(column), void* data) {

--- a/zathura/document-widget.c
+++ b/zathura/document-widget.c
@@ -86,7 +86,7 @@ static unsigned int zathura_document_row_first_page_index(zathura_t* zathura, un
   unsigned int ncol            = zathura_document_get_pages_per_row(document);
   unsigned int c0              = zathura_document_get_first_page_column(document);
 
-  return row == 0 ? 0 : row * ncol - c0;
+  return row == 0 ? 0 : row * ncol - (c0 - 1);
 }
 
 static void zathura_document_widget_view_range(zathura_t* zathura, unsigned int* start_index, unsigned int* end_index) {
@@ -156,6 +156,14 @@ static void zathura_document_update_grid(zathura_t* zathura) {
   ZathuraDocumentWidgetPrivate* priv = zathura_document_widget_get_instance_private(widget);
   zathura_document_t* document       = zathura_get_document(zathura);
 
+  // set the adjustments back after resizing the grid
+  girara_session_t* session = zathura->ui.session;
+  GtkAdjustment* x_adj = gtk_scrolled_window_get_hadjustment(GTK_SCROLLED_WINDOW(session->gtk.view));
+  GtkAdjustment* y_adj = gtk_scrolled_window_get_vadjustment(GTK_SCROLLED_WINDOW(session->gtk.view));
+
+  const double pos_x = zathura_document_widget_get_ratio(zathura, x_adj, true);
+  const double pos_y = zathura_document_widget_get_ratio(zathura, y_adj, false);
+
   gtk_grid_set_row_spacing(GTK_GRID(widget), priv->v_spacing);
   gtk_grid_set_column_spacing(GTK_GRID(widget), priv->h_spacing);
 
@@ -202,6 +210,8 @@ static void zathura_document_update_grid(zathura_t* zathura) {
   }
 
   priv->do_render = false;
+  zathura_document_widget_set_value_from_ratio(zathura, x_adj, pos_x, true);
+  zathura_document_widget_set_value_from_ratio(zathura, y_adj, pos_y, false);
 }
 
 void zathura_document_widget_render(zathura_t* zathura) {
@@ -211,6 +221,7 @@ void zathura_document_widget_render(zathura_t* zathura) {
 
   ZathuraDocumentWidget* widget      = ZATHURA_DOCUMENT_WIDGET(zathura->ui.document_widget);
   ZathuraDocumentWidgetPrivate* priv = zathura_document_widget_get_instance_private(widget);
+  zathura_document_t* document       = zathura_get_document(zathura);
 
   if (priv->do_render) {
     zathura_document_update_grid(zathura);
@@ -222,11 +233,18 @@ void zathura_document_widget_render(zathura_t* zathura) {
 
   unsigned int start_row = zathura_document_page_index_to_row(zathura, start);
   unsigned int end_row   = zathura_document_page_index_to_row(zathura, end);
+  unsigned int npag      = zathura_document_get_number_of_pages(document);
+  unsigned int ncol      = zathura_document_get_pages_per_row(document);
+  unsigned int nrow      = zathura_document_page_index_to_row(zathura, npag + ncol - 1);
 
-  if (priv->start_row <= start_row && end_row < priv->start_row + priv->row_count) {
+  unsigned char within_document = priv->start_row < start_row && end_row + 1 < priv->start_row + priv->row_count;
+  unsigned char first_grid = priv->start_row == 0 && start_row == 0 && end_row < priv->start_row + priv->row_count;
+  unsigned char last_grid = priv->start_row + priv->row_count == nrow && end_row == nrow - 1 && priv->start_row <= start_row;
+
+  if (within_document || first_grid || last_grid) {
     return;
   }
-
+  
   zathura_document_update_grid(zathura);
 }
 

--- a/zathura/document-widget.c
+++ b/zathura/document-widget.c
@@ -16,8 +16,8 @@ static const unsigned int cairo_max_size = INT16_MAX;
 typedef struct zathura_document_widget_private_s {
   unsigned int v_spacing;
   unsigned int h_spacing;
-  unsigned int page_count;
-  unsigned int start_index;
+  unsigned int row_count;
+  unsigned int start_row;
   bool page_right_to_left;
   bool do_render;
 } ZathuraDocumentWidgetPrivate;
@@ -32,8 +32,8 @@ static void zathura_document_widget_init(ZathuraDocumentWidget* widget) {
 
   priv->v_spacing          = 0;
   priv->h_spacing          = 0;
-  priv->page_count         = 0;
-  priv->start_index        = 0;
+  priv->row_count          = 0;
+  priv->start_row          = 0;
   priv->page_right_to_left = false;
   priv->do_render          = true;
 }
@@ -69,28 +69,57 @@ void zathura_document_widget_clear_pages(GtkWidget* widget) {
   gtk_container_foreach(GTK_CONTAINER(widget), remove_page_from_table, NULL);
 }
 
-static void zathura_document_widget_view_range(zathura_t* zathura, unsigned int* start, unsigned int* end) {
+static unsigned int zathura_document_page_index_to_row(zathura_t* zathura, unsigned int page_index) {
+  g_return_val_if_fail(zathura != NULL && zathura->document != NULL, 0);
+  zathura_document_t* document = zathura_get_document(zathura);
+
+  unsigned int ncol = zathura_document_get_pages_per_row(document);
+  unsigned int c0   = zathura_document_get_first_page_column(document);
+
+  return (page_index + c0 - 1) / ncol;
+}
+
+static unsigned int zathura_document_row_first_page_index(zathura_t* zathura, unsigned int row) {
+  g_return_val_if_fail(zathura != NULL && zathura->document != NULL, 0);
+  zathura_document_t* document = zathura_get_document(zathura);
+
+  unsigned int ncol            = zathura_document_get_pages_per_row(document);
+  unsigned int c0              = zathura_document_get_first_page_column(document);
+
+  return row == 0 ? 0 : row * ncol - c0;
+}
+
+static void zathura_document_widget_view_range(zathura_t* zathura, unsigned int* start_index, unsigned int* end_index) {
+  g_return_if_fail(zathura != NULL && zathura->document != NULL);
   zathura_document_t* document  = zathura_get_document(zathura);
   const unsigned int page_count = zathura_document_get_number_of_pages(document);
 
-  unsigned int internal_start = page_count;
-  unsigned int internal_end   = 0;
+  unsigned int start = page_count;
+  unsigned int end   = 0;
 
   for (unsigned int i = 0; i < page_count; i++) {
     if (!page_is_visible(document, i)) {
       continue;
     }
 
-    internal_start = MIN(internal_start, i);
-    internal_end   = MAX(internal_end, i);
+    start = MIN(start, i);
+    end   = MAX(end, i);
   }
 
-  *start = internal_start;
-  *end   = internal_end;
+  *start_index = start;
+  *end_index   = end;
 }
 
-static void zathura_document_render_range(zathura_t* zathura, unsigned int* start_index, unsigned int* page_count) {
+/*
+ * Calculates the number of rows for the document widget and 
+ * the starting page index. The starting page is chosen so 
+ * that the current page is on the middle of the document widget.
+ */
+static void zathura_document_calculate_render_range(zathura_t* zathura) {
   g_return_if_fail(zathura != NULL && zathura->document != NULL);
+
+  ZathuraDocumentWidget* widget      = ZATHURA_DOCUMENT_WIDGET(zathura->ui.document_widget);
+  ZathuraDocumentWidgetPrivate* priv = zathura_document_widget_get_instance_private(widget);
   zathura_document_t* document       = zathura_get_document(zathura);
 
   double pos_x = zathura_document_get_position_x(document);
@@ -99,18 +128,24 @@ static void zathura_document_render_range(zathura_t* zathura, unsigned int* star
   unsigned int current_page    = position_to_page_number(document, pos_x, pos_y);
   unsigned int npag            = zathura_document_get_number_of_pages(document);
   unsigned int ncol            = zathura_document_get_pages_per_row(document);
+
   zathura_page_t* page         = zathura_document_get_page(document, current_page);
   double page_height           = zathura_page_get_height(page);
 
-  *page_count = MIN(npag, cairo_max_size * ncol / page_height);
-  if (npag < current_page + *page_count / 2) {
+  unsigned int nrow           = cairo_max_size / (page_height + 2 * priv->v_spacing);
+  unsigned int nrow_doc       = zathura_document_page_index_to_row(zathura, npag + ncol - 1);
+  unsigned int current_row    = zathura_document_page_index_to_row(zathura, current_page); 
+
+  priv->row_count = MIN(nrow_doc, nrow);
+
+  if (nrow_doc < current_row + priv->row_count / 2) {
     // current_page is near the end of the document
-    *start_index = npag - *page_count;
-  } else if (current_page < *page_count / 2) {
+    priv->start_row = nrow_doc - priv->row_count;
+  } else if (current_row < priv->row_count / 2) {
     // current_page is near the start of the document
-    *start_index = 0;
+    priv->start_row = 0;
   } else {
-    *start_index = current_page - *page_count / 2;
+    priv->start_row = current_row - priv->row_count / 2;
   }
 }
 
@@ -127,22 +162,43 @@ static void zathura_document_update_grid(zathura_t* zathura) {
   zathura_document_widget_clear_pages(GTK_WIDGET(widget));
 
   unsigned int current_page = zathura_document_get_current_page_number(document);
+  unsigned int npag         = zathura_document_get_number_of_pages(document);
   unsigned int ncol         = zathura_document_get_pages_per_row(document);
   unsigned int c0           = zathura_document_get_first_page_column(document);
 
-  zathura_document_render_range(zathura, &priv->start_index, &priv->page_count);
-  girara_debug("updating grid: start %u current %d page count %u", priv->start_index, current_page, priv->page_count);
+  zathura_document_calculate_render_range(zathura);
+  unsigned int page_index = zathura_document_row_first_page_index(zathura, priv->start_row);
+  unsigned int start_col = (priv->start_row == 0) ? c0 - 1 : 0;
 
-  for (unsigned int i = 0; i < priv->page_count; i++) {
-    unsigned int x = (i + c0 - 1) % ncol;
-    unsigned int y = (i + c0 - 1) / ncol;
+  girara_debug("start row %u, row count %u, start index %u, current page %d", 
+               priv->start_row, priv->row_count, page_index, current_page);
 
-    GtkWidget* page_widget = zathura->pages[priv->start_index + i];
+  // first row to handle first_page_column
+  for (unsigned int col = start_col; col < ncol && page_index < npag; col++) {
+    unsigned int x = col;
+    GtkWidget* page_widget = zathura->pages[page_index];
     if (priv->page_right_to_left) {
       x = ncol - 1 - x;
     }
 
-    gtk_grid_attach(GTK_GRID(widget), page_widget, x, y, 1, 1);
+    gtk_grid_attach(GTK_GRID(widget), page_widget, x, 0, 1, 1);
+    page_index++;
+  } 
+
+  // remaining rows
+  for (unsigned int row = 1; row < priv->row_count; row++) {
+    for (unsigned int col = 0; col < ncol && page_index < npag; col++) {
+      unsigned int x = col;
+      unsigned int y = row;
+
+      GtkWidget* page_widget = zathura->pages[page_index];
+      if (priv->page_right_to_left) {
+        x = ncol - 1 - x;
+      }
+
+      gtk_grid_attach(GTK_GRID(widget), page_widget, x, y, 1, 1);
+      page_index++;
+    }
   }
 
   priv->do_render = false;
@@ -163,7 +219,11 @@ void zathura_document_widget_render(zathura_t* zathura) {
 
   unsigned int start, end;
   zathura_document_widget_view_range(zathura, &start, &end);
-  if (priv->start_index <= start && end < priv->start_index + priv->page_count) {
+
+  unsigned int start_row = zathura_document_page_index_to_row(zathura, start);
+  unsigned int end_row   = zathura_document_page_index_to_row(zathura, end);
+
+  if (priv->start_row <= start_row && end_row < priv->start_row + priv->row_count) {
     return;
   }
 
@@ -197,15 +257,8 @@ static void zathura_document_widget_get_size(zathura_t* zathura, unsigned int* h
 
   g_return_if_fail(document != NULL && height != NULL && width != NULL);
 
-  const unsigned int npag = priv->page_count;
+  const unsigned int nrow = priv->row_count;
   const unsigned int ncol = zathura_document_get_pages_per_row(document);
-
-  if (npag == 0 || ncol == 0) {
-    return;
-  }
-
-  const unsigned int c0   = zathura_document_get_first_page_column(document);
-  const unsigned int nrow = (npag + c0 - 1 + ncol - 1) / ncol; /* number of rows */
   const unsigned int pad  = zathura_document_get_page_padding(document);
 
   unsigned int cell_height = 0;
@@ -227,7 +280,8 @@ static void zathura_document_widget_get_offset(zathura_t* zathura, double* pos_x
   page_number_to_position(document, 0, 0.0, 0.0, &zero_x, &zero_y);
 
   double start_x, start_y;
-  page_number_to_position(document, priv->start_index, 0.0, 0.0, &start_x, &start_y);
+  unsigned int start_index = zathura_document_row_first_page_index(zathura, priv->start_row);
+  page_number_to_position(document, start_index, 0.0, 0.0, &start_x, &start_y);
 
   *pos_x = start_x - zero_x;
   *pos_y = start_y - zero_y;

--- a/zathura/document-widget.h
+++ b/zathura/document-widget.h
@@ -102,5 +102,4 @@ gdouble zathura_document_widget_get_ratio(zathura_t* zathura, GtkAdjustment* adj
  */
 void zathura_document_widget_set_value_from_ratio(zathura_t* zathura, GtkAdjustment* adjustment, double ratio,
                                                   bool width);
-
 #endif // DOCUMENT_WIDGET_H

--- a/zathura/document-widget.h
+++ b/zathura/document-widget.h
@@ -59,12 +59,10 @@ GtkWidget* zathura_document_widget_new(void);
  * @param zathura The zathura session
  * @param page_v_padding vertical padding in pixels between pages
  * @param page_h_padding horizontal padding in pixels between pages
- * @param pages_per_row Number of shown pages per row
- * @param first_page_column Column on which first page start
  * @param page_right_to_left Render pages right to left
  */
-void zathura_document_widget_set_mode(zathura_t* zathura, unsigned int page_v_padding, unsigned int page_h_padding, 
-                                      unsigned int pages_per_row, unsigned int first_page_column, bool page_right_to_left);
+void zathura_document_widget_set_mode(zathura_t* zathura, 
+    unsigned int page_v_padding, unsigned int page_h_padding, bool page_right_to_left);
 
 /**
  * Update the pages in the document view

--- a/zathura/shortcuts.c
+++ b/zathura/shortcuts.c
@@ -21,6 +21,7 @@
 #include "page-widget.h"
 #include "adjustment.h"
 #include "database.h"
+#include "document-widget.h"
 #include <math.h>
 
 /* Helper function for highlighting the links */
@@ -352,6 +353,8 @@ bool sc_mouse_scroll(girara_session_t* session, girara_argument_t* argument, gir
 
     zathura_adjustment_set_value(x_adj, gtk_adjustment_get_value(x_adj) - (event->x - zathura->shortcut.mouse.x));
     zathura_adjustment_set_value(y_adj, gtk_adjustment_get_value(y_adj) - (event->y - zathura->shortcut.mouse.y));
+
+    zathura_document_widget_render(zathura);
     break;
 
     /* unhandled events */

--- a/zathura/shortcuts.c
+++ b/zathura/shortcuts.c
@@ -351,10 +351,17 @@ bool sc_mouse_scroll(girara_session_t* session, girara_argument_t* argument, gir
       return false;
     }
 
-    zathura_adjustment_set_value(x_adj, gtk_adjustment_get_value(x_adj) - (event->x - zathura->shortcut.mouse.x));
-    zathura_adjustment_set_value(y_adj, gtk_adjustment_get_value(y_adj) - (event->y - zathura->shortcut.mouse.y));
+    unsigned int doc_height, doc_width;
+    zathura_document_get_document_size(zathura->document, &doc_height, &doc_width);
 
-    zathura_document_widget_render(zathura);
+    const double pos_x = zathura_document_widget_get_ratio(zathura, x_adj, true);
+    const double pos_y = zathura_document_widget_get_ratio(zathura, y_adj, false);
+
+    const double ratio_x = pos_x - (event->x - zathura->shortcut.mouse.x) / doc_width;
+    const double ratio_y = pos_y - (event->y - zathura->shortcut.mouse.y) / doc_height;
+
+    zathura_document_widget_set_value_from_ratio(zathura, x_adj, ratio_x, true);
+    zathura_document_widget_set_value_from_ratio(zathura, y_adj, ratio_y, false);
     break;
 
     /* unhandled events */

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -1163,7 +1163,7 @@ bool document_open(zathura_t* zathura, const char* path, const char* uri, const 
   page_right_to_left = file_info.page_right_to_left;
 
   zathura_document_set_page_layout(document, page_v_padding, page_h_padding, pages_per_row, first_page_column);
-  zathura_document_widget_set_mode(zathura, page_v_padding, page_h_padding, pages_per_row, first_page_column, page_right_to_left);
+  zathura_document_widget_set_mode(zathura, page_v_padding, page_h_padding, page_right_to_left);
 
   girara_set_view(zathura->ui.session, zathura->ui.document_widget);
 


### PR DESCRIPTION
Resolves #766 

Document widget previously didn't calculate the x and y position for the grid correctly.
Compute a set of rows to place in the grid, and fill each row with pages to avoid partially filled rows.

Smooth scrolling wouldn't trigger a document widget render causing scrolling to get stuck at the end of grid. 

Updated the render range calculation to be calculated directly from current document position rather than checking every page for visibility which may cause issues with large documents.