### PR TITLE
don't focus the tree view in index mode

### DIFF
--- a/zathura/shortcuts.c
+++ b/zathura/shortcuts.c
@@ -1252,8 +1252,8 @@ bool sc_toggle_index(girara_session_t* session, girara_argument_t* UNUSED(argume
     }
 
     girara_set_view(session, zathura->ui.index);
-    GtkTreeView* tree_view = gtk_container_get_children(GTK_CONTAINER(zathura->ui.index))->data;
-    gtk_widget_grab_focus(GTK_WIDGET(tree_view));
+    // GtkTreeView* tree_view = gtk_container_get_children(GTK_CONTAINER(zathura->ui.index))->data;
+    // gtk_widget_grab_focus(GTK_WIDGET(tree_view));
     index_scroll_to_current_page(zathura);
     girara_mode_set(zathura->ui.session, zathura->modes.index);
   }


### PR DESCRIPTION
Resolves #709 .

Its not entirely clear why the tree_view grabbed focus in #677 , but this meant the tree view would consume inputs like arrow keys and by default up and down move in a tree view and left right do nothing.
This meant `sc_navigate_index` would not be called on arrow inputs.

In any case, I think its ok to disable the grab while search is still in development, and I think the key press should come from girara as with other inputs, rather than calling grab focus on the tree view.