### PR TITLE
Remove sandboxed xvfb test 

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -76,8 +76,14 @@ if get_option('tests').allowed()
       ]
     )
 
+    test_env = environment()
+    x11_session = false
+    if run_command('sh', '-c', 'test -n "$DISPLAY"', check: false).returncode() == 0
+      x11_session = true
+    endif
+
     # need the equivalent of xvfb for wayland
-    if seccomp.found() or landlock
+    if (seccomp.found() or landlock) and x11_session
       sandbox = executable('test_sandbox', files('test_sandbox.c'),
         dependencies: build_dependencies + [libzathura_sandbox_dep] + sandbox_dependencies,
         include_directories: include_directories,

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -75,32 +75,5 @@ if get_option('tests').allowed()
         'LIBGL_DEBUG=quiet'
       ]
     )
-
-    test_env = environment()
-    x11_session = false
-    if run_command('sh', '-c', 'test -n "$DISPLAY"', check: false).returncode() == 0
-      x11_session = true
-    endif
-
-    # need the equivalent of xvfb for wayland
-    if (seccomp.found() or landlock) and x11_session
-      sandbox = executable('test_sandbox', files('test_sandbox.c'),
-        dependencies: build_dependencies + [libzathura_sandbox_dep] + sandbox_dependencies,
-        include_directories: include_directories,
-        c_args: defines + sandbox_defines + flags
-      )
-      test('sandbox', xvfb,
-        args: xvfb_args + [sandbox],
-        timeout: 60*60,
-        protocol: 'tap',
-        env: [
-          'G_TEST_SRCDIR=@0@'.format(meson.current_source_dir()),
-          'G_TEST_BUILDDIR=@0@'.format(meson.current_build_dir()),
-          'NO_AT_BRIDGE=1',
-          'MESA_LOG=null',
-          'LIBGL_DEBUG=quiet'
-        ]
-      )
-    endif
   endif
 endif

--- a/zathura/seccomp-filters.c
+++ b/zathura/seccomp-filters.c
@@ -165,7 +165,6 @@ int seccomp_enable_strict_filter(zathura_t* zathura) {
     ADD_RULE("allow", SCMP_ACT_ALLOW, socket, 1, SCMP_CMP(0, SCMP_CMP_EQ, AF_UNIX));
 
     ALLOW_RULE(mkdir); /* mkdirat */
-    ALLOW_RULE(mprotect);
     ALLOW_RULE(setsockopt);
     ALLOW_RULE(getsockopt);
     ALLOW_RULE(getsockname);

--- a/zathura/seccomp-filters.c
+++ b/zathura/seccomp-filters.c
@@ -165,6 +165,7 @@ int seccomp_enable_strict_filter(zathura_t* zathura) {
     ADD_RULE("allow", SCMP_ACT_ALLOW, socket, 1, SCMP_CMP(0, SCMP_CMP_EQ, AF_UNIX));
 
     ALLOW_RULE(mkdir); /* mkdirat */
+    ALLOW_RULE(mprotect);
     ALLOW_RULE(setsockopt);
     ALLOW_RULE(getsockopt);
     ALLOW_RULE(getsockname);


### PR DESCRIPTION
The second xvfb test that runs sandboxed appears to ignore the runtime check https://github.com/pwmt/zathura/blob/0ff313ffdfee6eaa733ba7b9f911115c7f777c38/zathura/seccomp-filters.c#L156 when running under wayland

Without this check the test fails when running under wayland because xvfb wants the mprotect syscall with executable memory permissions 