### PR TITLE
Config option to set mode

### DIFF
--- a/doc/man/zathura.1.rst
+++ b/doc/man/zathura.1.rst
@@ -61,7 +61,7 @@ Options
   correct file open or does not exist, no new instance will be spanned.
 
 --mode=mode
-  Start in a non-default mode
+  Start in a non-default mode. Overrides the mode setting.
 
 --fork
   Fork into background

--- a/doc/man/zathurarc.5.rst
+++ b/doc/man/zathurarc.5.rst
@@ -524,6 +524,16 @@ girara
   * Value type: String
   * Default value: #9FBC00
 
+*mode*
+  Defines mode to open documents with.
+
+  Possible values are "fullscreen" and "presentation".
+
+  All other string combinations enable normal mode.
+
+  * Value type: String
+  * Default value:
+
 *notification-bg*
   Defines the background color for a notification
 

--- a/zathura/config.c
+++ b/zathura/config.c
@@ -346,6 +346,7 @@ void config_load_default(zathura_t* zathura) {
   girara_setting_add(gsession, "show-signature-information", &bool_value, BOOLEAN, false,
                      _("Disable additional information for signatures embedded in the document."),
                      cb_show_signature_info, NULL);
+  girara_setting_add(gsession, "mode",                   NULL,         STRING,  true,  _("Default mode"),             NULL, NULL);
 
 #define DEFAULT_SHORTCUTS(mode)                                                                                        \
   girara_shortcut_add(gsession, 0, GDK_KEY_a, NULL, sc_adjust_window, (mode), ZATHURA_ADJUST_BESTFIT, NULL);           \

--- a/zathura/main-sandbox.c
+++ b/zathura/main-sandbox.c
@@ -206,6 +206,10 @@ GIRARA_VISIBLE int main(int argc, char* argv[]) {
     goto free_and_ret;
   }
 
+  if (mode == NULL) {
+    girara_setting_get(zathura->ui.session, "mode", &mode);
+  }
+
   /* open document if passed */
   if (file_idx != 0) {
     if (page_number > 0) {

--- a/zathura/main.c
+++ b/zathura/main.c
@@ -264,6 +264,10 @@ GIRARA_VISIBLE int main(int argc, char* argv[]) {
     goto free_and_ret;
   }
 
+  if (mode == NULL) {
+    girara_setting_get(zathura->ui.session, "mode", &mode);
+  }
+
   /* open document if passed */
   if (file_idx != 0) {
     if (page_number > 0) {


### PR DESCRIPTION
Adds ability to specify `fullscreen` or `presentation` mode in `zathurarc`. Option will be overriden by `--mode` parameter.
Closes #119 and its duplicate #317.