### PR TITLE
add unit test for sandbox session

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -96,26 +96,24 @@ if get_option('tests').allowed()
         'WAYLAND_DISPLAY=zathura-test-weston'
     ]
   )
+  if seccomp.found() or landlock
+    sandbox = executable('test_sandbox', files('test_sandbox.c'),
+      dependencies: build_dependencies + [libzathura_sandbox_dep] + sandbox_dependencies,
+      include_directories: include_directories,
+      c_args: defines + sandbox_defines + flags
+    )
+    
+    test('weston_sandbox', weston_session,
+      args: [sandbox],
+      timeout: 60*60,
+      protocol: 'tap',
+      env: [
+        'G_TEST_SRCDIR=@0@'.format(meson.current_source_dir()),
+        'G_TEST_BUILDDIR=@0@'.format(meson.current_build_dir()),
+        'NO_AT_BRIDGE=1',
+        'WAYLAND_DISPLAY=zathura-test-weston'
       ]
     )
-    if seccomp.found() or landlock
-      sandbox = executable('test_sandbox', files('test_sandbox.c'),
-        dependencies: build_dependencies + [libzathura_sandbox_dep] + sandbox_dependencies,
-        include_directories: include_directories,
-        c_args: defines + sandbox_defines + flags
-      )
-      
-      test('weston_sandbox', weston_session,
-        args: [sandbox],
-        timeout: 60*60,
-        protocol: 'tap',
-        env: [
-          'G_TEST_SRCDIR=@0@'.format(meson.current_source_dir()),
-          'G_TEST_BUILDDIR=@0@'.format(meson.current_build_dir()),
-          'NO_AT_BRIDGE=1',
-          'WAYLAND_DISPLAY=zathura-test-weston'
-        ]
-      )
     endif
   endif
 endif

--- a/tests/test_sandbox.c
+++ b/tests/test_sandbox.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: Zlib */
 
 #include "zathura.h"
+#include "document.h"
 #ifdef WITH_SECCOMP
 #include "seccomp-filters.h"
 #endif
@@ -26,6 +27,7 @@ static void test_create(void) {
   g_assert_nonnull(zathura);
   g_assert_nonnull(g_getenv("G_TEST_SRCDIR"));
   zathura_set_config_dir(zathura, g_getenv("G_TEST_SRCDIR"));
+  g_assert_true(zathura_init(zathura));
 
 #ifdef WITH_LANDLOCK
   landlock_drop_write();
@@ -34,7 +36,11 @@ static void test_create(void) {
   g_assert_cmpint(seccomp_enable_strict_filter(zathura), ==, 0);
 #endif
 
-  g_assert_true(zathura_init(zathura));
+  g_assert_null(zathura_document_open(zathura, NULL, NULL, NULL, NULL));
+  g_assert_null(zathura_document_open(zathura, "fl", NULL, NULL, NULL));
+  g_assert_null(zathura_document_open(zathura, "fl", "ur", NULL, NULL));
+  g_assert_null(zathura_document_open(zathura, "fl", NULL, "pw", NULL));
+
   zathura_free(zathura);
 }
 

--- a/zathura/seccomp-filters.c
+++ b/zathura/seccomp-filters.c
@@ -223,6 +223,7 @@ int seccomp_enable_strict_filter(zathura_t* zathura) {
   /* Prevent the creation of executeable memory */
   ADD_RULE("allow", SCMP_ACT_ALLOW, mprotect, 1,
            SCMP_CMP(2, SCMP_CMP_MASKED_EQ, PROT_READ | PROT_WRITE | PROT_NONE, PROT_READ | PROT_WRITE | PROT_NONE));
+  
 
   /* open syscall to be removed? openat is used instead */
   /* special restrictions for open, prevent opening files for writing */


### PR DESCRIPTION
The test currently fails on arch because the newest release of the gdk-pixbuf2 package on arch includes glycin, which in turn runs its own sandbox using bwrap, which in turn requires a whole bunch of capabilities and syscalls that aren't allowed in our seccomp filter.

Still working on a solution