### PR TITLE
Refactor: Pass page object to page_calc_height_width

### DIFF
--- a/zathura/adjustment.c
+++ b/zathura/adjustment.c
@@ -5,14 +5,15 @@
 
 #include <math.h>
 
-double page_calc_height_width(zathura_document_t* document, double height, double width, unsigned int* page_height,
+double page_calc_height_width(zathura_document_t* document, zathura_page_t* page, unsigned int* page_height,
                               unsigned int* page_width, bool rotate) {
   g_return_val_if_fail(document != NULL && page_height != NULL && page_width != NULL, 0.0);
 
   double scale = zathura_document_get_scale(document);
 
-  // TODO this just set all pages to the maximum.
-  // needs to adjust cell size based on the page size itself.
+  const double height = zathura_page_get_height(page);
+  const double width = zathura_page_get_width(page);
+
   if (rotate == true && zathura_document_get_rotation(document) % 180 != 0) {
     *page_width  = round(height * scale);
     *page_height = round(width * scale);

--- a/zathura/adjustment.h
+++ b/zathura/adjustment.h
@@ -6,20 +6,20 @@
 #include <gtk/gtk.h>
 #include <stdbool.h>
 #include "document.h"
+#include "page.h"
 
 /**
  * Calculate the page size according to the current scaling and rotation if
  * desired.
  *
  * @param document the document
- * @param height the original height
- * @param width the original width
+ * @param page the original page 
  * @param page_height the scaled and rotated height
  * @param page_width the scaled and rotated width
  * @param rotate honor page's rotation
  * @return real scale after rounding
  */
-double page_calc_height_width(zathura_document_t* document, double height, double width, unsigned int* page_height,
+double page_calc_height_width(zathura_document_t* document, zathura_page_t* page, unsigned int* page_height,
                               unsigned int* page_width, bool rotate);
 
 /**

--- a/zathura/document.c
+++ b/zathura/document.c
@@ -536,7 +536,7 @@ zathura_device_factors_t zathura_document_get_device_factors(zathura_document_t*
 void zathura_document_get_cell_size(zathura_document_t* document, unsigned int* height, unsigned int* width) {
   g_return_if_fail(document != NULL && height != NULL && width != NULL);
 
-  page_calc_height_width(document, document->cell_height, document->cell_width, height, width, true);
+  page_calc_height_width(document, document->pages[document->current_page_number], height, width, true);
 }
 
 void zathura_document_get_document_size(zathura_document_t* document, unsigned int* height, unsigned int* width) {

--- a/zathura/render.c
+++ b/zathura/render.c
@@ -824,7 +824,7 @@ static bool render(render_job_t* job, ZathuraRenderRequest* request, ZathuraRend
     /* page size in user pixels based on document zoom: if PPI information is
      * correct, 100% zoom will result in 72 documents points per inch of screen
      * (i.e. document size on screen matching the physical paper size). */
-    real_scale = page_calc_height_width(document, height, width, &page_height, &page_width, false);
+    real_scale = page_calc_height_width(document, page, &page_height, &page_width, false);
 
     device_factors = zathura_document_get_device_factors(document);
     page_width *= device_factors.x;
@@ -914,7 +914,7 @@ void render_all(zathura_t* zathura) {
     unsigned int page_height = 0, page_width = 0;
     const double height = zathura_page_get_height(page);
     const double width  = zathura_page_get_width(page);
-    page_calc_height_width(document, height, width, &page_height, &page_width, true);
+    page_calc_height_width(document, page, &page_height, &page_width, true);
 
     girara_debug("Queuing resize for page %u to %u x %u (%0.2f x %0.2f).", page_id, page_width, page_height, width,
                  height);

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -1206,9 +1206,7 @@ bool document_open(zathura_t* zathura, const char* path, const char* uri, const 
     /* adjust_view calls render_all in some cases and render_all calls
      * gtk_widget_set_size_request. To be sure that it's really called, do it
      * here once again. */
-    const double height = zathura_page_get_height(page);
-    const double width  = zathura_page_get_width(page);
-    page_calc_height_width(zathura->document, height, width, &page_height, &page_width, true);
+    page_calc_height_width(zathura->document, page, &page_height, &page_width, true);
     gtk_widget_set_size_request(zathura->pages[page_id], page_width, page_height);
 
     /* show widget */


### PR DESCRIPTION
This change refactors `page_calc_height_width()` to accept a `zathura_page_t*` object instead of the raw height and width.
This resolves the `TODO` in the function and is a necessary first step towards implementing page-specific rotation, as the function can now query the page for its own attributes.