### PR TITLE
avoid dconf warnings

### DIFF
--- a/zathura/main-sandbox.c
+++ b/zathura/main-sandbox.c
@@ -195,6 +195,9 @@ GIRARA_VISIBLE int main(int argc, char* argv[]) {
   /* Prevent default gtk dbus connection */
   g_setenv("DBUS_SESSION_BUS_ADDRESS", "disabled:", TRUE);
 
+  /* disable dconf writing - uses /var/empty as alternative to /dev/null to avoid ioctl call */
+  g_setenv("DCONF_PROFILE", "/var/empty", TRUE);
+
   /* Initialize GTK+ */
   gtk_init(&argc, &argv);
 


### PR DESCRIPTION
Dconf complains about not being able to write to XDG_RUNTIME_DIR

This avoids the error message for zathura-sandbox