### PR TITLE
Revert "update view when session view size changes"

### DIFF
--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -260,7 +260,6 @@ static bool init_ui(zathura_t* zathura) {
   }
 
   g_signal_connect(G_OBJECT(zathura->ui.session->gtk.window), "size-allocate", G_CALLBACK(cb_view_resized), zathura);
-  g_signal_connect(G_OBJECT(zathura->ui.session->gtk.view), "size-allocate", G_CALLBACK(cb_view_resized), zathura);
 
   GtkAdjustment* hadjustment = gtk_scrolled_window_get_hadjustment(GTK_SCROLLED_WINDOW(zathura->ui.session->gtk.view));
 


### PR DESCRIPTION
Reverts pwmt/zathura#788

The `gtk_widget_queue_resize`'s in `cb_view_resized` for `gtk.view` are queued but don't get executed until after the next gtk event for some reason. Since we have already called `cb_view_resized`, when it is called again on `gtk.window`, it doesn't call `render_all` and so the pages don't update.
Causes #795 and #816 , probably better to revert this for now and look at a different way of doing the refresh to handle #785 .