### PR TITLE
fix(render): apply correct scaling when recoloring

### DIFF
--- a/zathura/render.c
+++ b/zathura/render.c
@@ -694,7 +694,7 @@ static void recolor_fast(ZathuraRendererPrivate* priv, unsigned int page_width, 
 }
 
 static void recolor(ZathuraRendererPrivate* priv, zathura_page_t* page, unsigned int page_width,
-                    unsigned int page_height, cairo_surface_t* surface) {
+                    unsigned int page_height, cairo_surface_t* surface, zathura_device_factors_t device_factors) {
   /* uses a representation of a rgb color as follows:
      - a lightness scalar (between 0,1), which is a weighted average of r, g, b,
      - a hue vector, which indicates a radian direction from the grey axis,
@@ -743,6 +743,11 @@ static void recolor(ZathuraRendererPrivate* priv, zathura_page_t* page, unsigned
           break;
         }
         *rect = recalc_rectangle(page, image_it->position);
+        /* Scale rectangle coordinates by device factors to match surface pixel coordinates */
+        rect->x1 *= device_factors.x;
+        rect->x2 *= device_factors.x;
+        rect->y1 *= device_factors.y;
+        rect->y2 *= device_factors.y;
         girara_list_append(rectangles, rect);
       }
     }
@@ -858,7 +863,7 @@ static bool render(render_job_t* job, ZathuraRenderRequest* request, ZathuraRend
 
   /* recolor */
   if (request_priv->render_plain == false && priv->recolor.enabled == true) {
-    recolor(priv, page, page_width, page_height, surface);
+    recolor(priv, page, page_width, page_height, surface, device_factors);
   }
 
   if (!invoke_completed_signal(job, surface)) {


### PR DESCRIPTION
Fixes the issue described here: https://github.com/pwmt/zathura/issues/836

Previously, images would not be recolored correctly with the original image colors when using a configuration like this:
```
set recolor "true"
set recolor-keephue "true"
set recolor-reverse-video "true"
```
This PR fixes that by properly scaling the recoloring.

I've tested the bug on Hyprland (running Arch Linux) with monitor scaling set to 1.5, confirmed the bug only occurs with scaling enabled, and ensured the bug is no longer present with the changes in this commit.

Here's an image to show it works, using the above configuration with 1.5 scaling:
<img width="1917" height="2118" alt="image" src="https://github.com/user-attachments/assets/102aacb5-8983-4928-81cf-7bd37fef0d68" />
