### PR TITLE
update to use new girara view

### DIFF
--- a/data/zathura.css_t
+++ b/data/zathura.css_t
@@ -9,3 +9,13 @@
   color: @index-active-fg@;
   background-color: @index-active-bg@;
 }
+
+/* Scrollbar */
+#@session@ scrolledwindow scrollbar {
+  background-color: @scrollbar-bg@;
+}
+
+#@session@ scrolledwindow scrollbar > slider {
+  background-color: @scrollbar-fg@;
+}
+

--- a/zathura/callbacks.c
+++ b/zathura/callbacks.c
@@ -199,8 +199,8 @@ void cb_refresh_view(GtkWidget* GIRARA_UNUSED(view), gpointer data) {
     }
   }
 
-  GtkAdjustment* vadj = gtk_scrolled_window_get_vadjustment(GTK_SCROLLED_WINDOW(zathura->ui.session->gtk.view));
-  GtkAdjustment* hadj = gtk_scrolled_window_get_hadjustment(GTK_SCROLLED_WINDOW(zathura->ui.session->gtk.view));
+  GtkAdjustment* vadj = gtk_scrolled_window_get_vadjustment(GTK_SCROLLED_WINDOW(zathura->ui.view));
+  GtkAdjustment* hadj = gtk_scrolled_window_get_hadjustment(GTK_SCROLLED_WINDOW(zathura->ui.view));
 
   const double position_x = zathura_document_get_position_x(document);
   const double position_y = zathura_document_get_position_y(document);

--- a/zathura/config.c
+++ b/zathura/config.c
@@ -195,6 +195,37 @@ static void cb_setting_recolor_adjust_lightness_change(girara_session_t* session
   }
 }
 
+static void cb_view_options(girara_session_t* session, const char* UNUSED(name), girara_setting_type_t UNUSED(type),
+                          const void* value, void* UNUSED(data)) {
+  g_return_if_fail(session != NULL && value != NULL);
+  zathura_t* zathura = session->global.data;
+
+  /* set default values */
+  bool show_hscrollbar  = false;
+  bool show_vscrollbar  = false;
+
+  /* evaluate input */
+  const char* input         = value;
+  const size_t input_length = strlen(input);
+
+  for (size_t i = 0; i < input_length; i++) {
+    switch (input[i]) {
+    case 'h':
+      show_hscrollbar = true;
+      break;
+    case 'v':
+      show_vscrollbar = true;
+      break;
+    }
+  }
+
+  /* apply settings */
+  GtkPolicyType hpolicy = show_hscrollbar ? GTK_POLICY_AUTOMATIC : GTK_POLICY_EXTERNAL;
+  GtkPolicyType vpolicy = show_vscrollbar ? GTK_POLICY_AUTOMATIC : GTK_POLICY_EXTERNAL;
+
+  gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(zathura->ui.view), hpolicy, vpolicy);
+}
+
 void config_load_default(zathura_t* zathura) {
   if (zathura == NULL || zathura->ui.session == NULL) {
     return;
@@ -360,6 +391,9 @@ void config_load_default(zathura_t* zathura) {
   girara_setting_add(gsession, "show-signature-information", &bool_value, BOOLEAN, false,
                      _("Disable additional information for signatures embedded in the document."),
                      cb_show_signature_info, NULL);
+  girara_setting_add(gsession, "scrollbar-fg", "#DDDDDD", STRING, FALSE, _("Scrollbar foreground color"), cb_color, NULL);
+  girara_setting_add(gsession, "scrollbar-bg", "#000000", STRING, FALSE, _("Scrollbar background color"), cb_color, NULL);
+  girara_setting_add(gsession, "view-options", "", STRING, FALSE, _("Show or hide view UI elements"), cb_view_options, NULL);
 
 #define DEFAULT_SHORTCUTS(mode)                                                                                        \
   girara_shortcut_add(gsession, 0, GDK_KEY_a, NULL, sc_adjust_window, (mode), ZATHURA_ADJUST_BESTFIT, NULL);           \

--- a/zathura/shortcuts.c
+++ b/zathura/shortcuts.c
@@ -344,8 +344,8 @@ bool sc_mouse_scroll(girara_session_t* session, girara_argument_t* argument, gir
     zathura->shortcut.mouse.y = 0;
     break;
   case GIRARA_EVENT_MOTION_NOTIFY:
-    x_adj = gtk_scrolled_window_get_hadjustment(GTK_SCROLLED_WINDOW(session->gtk.view));
-    y_adj = gtk_scrolled_window_get_vadjustment(GTK_SCROLLED_WINDOW(session->gtk.view));
+    x_adj = gtk_scrolled_window_get_hadjustment(GTK_SCROLLED_WINDOW(zathura->ui.view));
+    y_adj = gtk_scrolled_window_get_vadjustment(GTK_SCROLLED_WINDOW(zathura->ui.view));
 
     if (x_adj == NULL || y_adj == NULL) {
       return false;
@@ -1243,12 +1243,12 @@ bool sc_toggle_index(girara_session_t* session, girara_argument_t* UNUSED(argume
     gtk_tree_view_set_enable_search(GTK_TREE_VIEW(treeview), FALSE);
     g_signal_connect(G_OBJECT(treeview), "row-activated", G_CALLBACK(cb_index_row_activated), zathura);
 
+    gtk_widget_set_visible(treeview, true);
     gtk_container_add(GTK_CONTAINER(zathura->ui.index), treeview);
   }
 
-  if (gtk_widget_get_visible(GTK_WIDGET(zathura->ui.index))) {
-    girara_set_view(session, zathura->ui.document_widget);
-    gtk_widget_hide(GTK_WIDGET(zathura->ui.index));
+  if (girara_mode_get(session) == zathura->modes.index) {
+    girara_set_view(session, zathura->ui.view);
     girara_mode_set(zathura->ui.session, zathura->modes.normal);
 
     /* refresh view */

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -252,21 +252,39 @@ static bool init_ui(zathura_t* zathura) {
   zathura->signals.monitors_changed_handler = 0;
 
   /* page view */
+  zathura->ui.view = gtk_scrolled_window_new(NULL, NULL);
+  gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(zathura->ui.view), GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
+
+  /* load scrollbar settings */
+  g_autofree char* view_options = NULL;
+  girara_setting_get(zathura->ui.session, "view-options", &view_options);
+
+  const bool show_hscrollbar = view_options != NULL && strchr(view_options, 'h') != NULL;
+  const bool show_vscrollbar = view_options != NULL && strchr(view_options, 'v') != NULL;
+
+  GtkPolicyType hpolicy = show_hscrollbar ? GTK_POLICY_AUTOMATIC : GTK_POLICY_EXTERNAL;
+  GtkPolicyType vpolicy = show_vscrollbar ? GTK_POLICY_AUTOMATIC : GTK_POLICY_EXTERNAL;
+
+  gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(zathura->ui.view), hpolicy, vpolicy);
+
   zathura->ui.document_widget = zathura_document_widget_new();
   if (zathura->ui.document_widget == NULL) {
     girara_error("Failed to create document widget.");
     return false;
   }
 
+  gtk_container_add(GTK_CONTAINER(zathura->ui.view), zathura->ui.document_widget);
+  girara_set_view(zathura->ui.session, zathura->ui.view);
+
   g_signal_connect(G_OBJECT(zathura->ui.session->gtk.window), "size-allocate", G_CALLBACK(cb_view_resized), zathura);
 
-  GtkAdjustment* hadjustment = gtk_scrolled_window_get_hadjustment(GTK_SCROLLED_WINDOW(zathura->ui.session->gtk.view));
+  GtkAdjustment* hadjustment = gtk_scrolled_window_get_hadjustment(GTK_SCROLLED_WINDOW(zathura->ui.view));
 
   /* Connect hadjustment signals */
   g_signal_connect(G_OBJECT(hadjustment), "value-changed", G_CALLBACK(cb_view_hadjustment_value_changed), zathura);
   g_signal_connect(G_OBJECT(hadjustment), "changed", G_CALLBACK(cb_view_hadjustment_changed), zathura);
 
-  GtkAdjustment* vadjustment = gtk_scrolled_window_get_vadjustment(GTK_SCROLLED_WINDOW(zathura->ui.session->gtk.view));
+  GtkAdjustment* vadjustment = gtk_scrolled_window_get_vadjustment(GTK_SCROLLED_WINDOW(zathura->ui.view));
 
   /* Connect vadjustment signals */
   g_signal_connect(G_OBJECT(vadjustment), "value-changed", G_CALLBACK(cb_view_vadjustment_value_changed), zathura);
@@ -302,32 +320,34 @@ static bool init_ui(zathura_t* zathura) {
   return true;
 }
 
-static const char index_settings[][16] = {
+static const char color_settings[][16] = {
     "index-fg",
     "index-bg",
     "index-active-fg",
     "index-active-bg",
+    "scrollbar-fg",
+    "scrollbar-bg",
 };
 
 static void init_css(zathura_t* zathura) {
   GiraraTemplate* csstemplate = girara_session_get_template(zathura->ui.session);
-  for (size_t s = 0; s < LENGTH(index_settings); ++s) {
-    girara_template_add_variable(csstemplate, index_settings[s]);
+  for (size_t s = 0; s < LENGTH(color_settings); ++s) {
+    girara_template_add_variable(csstemplate, color_settings[s]);
   }
 }
 
 static bool load_css(zathura_t* zathura) {
   GiraraTemplate* csstemplate = girara_session_get_template(zathura->ui.session);
-  for (size_t s = 0; s < LENGTH(index_settings); ++s) {
+  for (size_t s = 0; s < LENGTH(color_settings); ++s) {
     g_autofree char* tmp_value = NULL;
     GdkRGBA rgba               = {0, 0, 0, 0};
-    girara_setting_get(zathura->ui.session, index_settings[s], &tmp_value);
+    girara_setting_get(zathura->ui.session, color_settings[s], &tmp_value);
     if (tmp_value != NULL) {
       parse_color(&rgba, tmp_value);
     }
 
     g_autofree char* color = gdk_rgba_to_string(&rgba);
-    girara_template_set_variable_value(csstemplate, index_settings[s], color);
+    girara_template_set_variable_value(csstemplate, color_settings[s], color);
   }
 
   GResource* css_resource = zathura_resources_get_resource();
@@ -1056,8 +1076,8 @@ bool document_open(zathura_t* zathura, const char* path, const char* uri, const 
   }
 
   /* get view port size */
-  GtkAdjustment* hadjustment = gtk_scrolled_window_get_hadjustment(GTK_SCROLLED_WINDOW(zathura->ui.session->gtk.view));
-  GtkAdjustment* vadjustment = gtk_scrolled_window_get_vadjustment(GTK_SCROLLED_WINDOW(zathura->ui.session->gtk.view));
+  GtkAdjustment* hadjustment = gtk_scrolled_window_get_hadjustment(GTK_SCROLLED_WINDOW(zathura->ui.view));
+  GtkAdjustment* vadjustment = gtk_scrolled_window_get_vadjustment(GTK_SCROLLED_WINDOW(zathura->ui.view));
 
   const unsigned int view_width = floor(gtk_adjustment_get_page_size(hadjustment));
   zathura_document_set_viewport_width(document, view_width);
@@ -1140,7 +1160,7 @@ bool document_open(zathura_t* zathura, const char* path, const char* uri, const 
   zathura_document_set_page_layout(document, page_v_padding, page_h_padding, pages_per_row, first_page_column);
   zathura_document_widget_set_mode(zathura, page_right_to_left);
 
-  girara_set_view(zathura->ui.session, zathura->ui.document_widget);
+  girara_set_view(zathura->ui.session, zathura->ui.view);
 
   /* bookmarks */
   if (zathura->database != NULL) {

--- a/zathura/zathura.h
+++ b/zathura/zathura.h
@@ -116,8 +116,9 @@ struct zathura_s {
       GdkRGBA signature_error;        /**> Color for highlighing invalid signatures */
     } colors;
 
+    GtkWidget* view;            /**< Scrolled Window */
     GtkWidget* document_widget; /**< Widget that contains all rendered pages */
-    GtkWidget* index;       /**< Widget to show the index of the document */
+    GtkWidget* index;           /**< Widget to show the index of the document */
   } ui;
 
   struct {


### PR DESCRIPTION
patch to handle https://github.com/pwmt/girara/pull/55. 

The zathurarc config is loaded before the UI is initialised, so gtk throws up a warning that it cant set scrollbar policy. The ui init will pull this config so everything works but it means theres an unnecessary warning (maybe ui init should be moved before config loading?)

## Testing

- :set scrollbar-bg "#FFFFFF"
- `set scrollbar-bg "#FFFFFF"` in zathurarc
- :set view-options v
- `set view-options v` in zathurarc
- switching between index mode and normal mode