### PR TITLE
document widget: custom page drawing

### DIFF
--- a/zathura/adjustment.h
+++ b/zathura/adjustment.h
@@ -38,12 +38,12 @@ void page_calc_position(zathura_document_t* document, double x, double y, double
 /**
  * Converts a relative position within the document to a page number.
  *
- * @param document The document
+ * @param zathura The zathura instance
  * @param pos_x the x position relative to the document
  * @param pos_y the y position relative to the document
  * @return page sitting in that position
  */
-unsigned int position_to_page_number(zathura_document_t* document, double pos_x, double pos_y);
+unsigned int position_to_page_number(zathura_t* zathura, double pos_x, double pos_y);
 
 /**
  * Converts a page number to a position in units relative to the document
@@ -55,23 +55,27 @@ unsigned int position_to_page_number(zathura_document_t* document, double pos_x,
  * The return value is the position in in units relative to the document (0=top
  * 1=bottom) of the point thet will lie at the center of the viewport.
  *
- * @param document The document
+ * @param zathura The zathura instance 
  * @param page_number the given page number
  * @param xalign where to align the viewport and the page
  * @param yalign where to align the viewport and the page
  * @param pos_x position that will lie at the center of the viewport.
  * @param pos_y position that will lie at the center of the viewport.
  */
-void page_number_to_position(zathura_document_t* document, unsigned int page_number, double xalign, double yalign,
+void page_number_to_position(zathura_t* zathura, unsigned int page_number, double xalign, double yalign,
                              double* pos_x, double* pos_y);
 
 /**
  * Checks whether a given page falls within the viewport
  *
- * @param document The document
+ * @param zathura The zathura instance
  * @param page_number the page number
  * @return true if the page intersects the viewport
  */
-bool page_is_visible(zathura_document_t* document, unsigned int page_number);
+bool page_is_visible(zathura_t* zathura, unsigned int page_number);
+
+gdouble zathura_adjustment_get_ratio(GtkAdjustment* adjustment);
+void zathura_adjustment_set_value(GtkAdjustment* adjustment, gdouble value);
+void zathura_adjustment_set_value_from_ratio(GtkAdjustment* adjustment, gdouble ratio);
 
 #endif /* ZATHURA_ADJUSTMENT_H */

--- a/zathura/callbacks.h
+++ b/zathura/callbacks.h
@@ -200,16 +200,6 @@ void cb_file_monitor(ZathuraFileMonitor* monitor, girara_session_t* session);
 gboolean cb_password_dialog(GtkEntry* entry, void* dialog);
 
 /**
- * Emitted when the view has been resized
- *
- * @param widget View
- * @param allocation Allocation
- * @param zathura Zathura session
- * @return true if signal has been handled successfully
- */
-gboolean cb_view_resized(GtkWidget* widget, GtkAllocation* allocation, zathura_t* zathura);
-
-/**
  * Emitted when the 'recolor' setting is changed
  *
  * @param session Girara session

--- a/zathura/document-widget.h
+++ b/zathura/document-widget.h
@@ -7,36 +7,25 @@
 #include "types.h"
 
 /**
- * The document view widget. Places a subset of the pages of
- * the document into a grid. The widget handles updating the
- * grid to contain the pages in view, and as many pages around
- * the view as the cairo surface will allow.
- *
- * zathura_document_widget_[get_ratio|set_value|set_value_from_ratio]
- * functions replace the equivalent ones previously contained in
- * adjustment.c. They wrap these functions and perform the necessary
- * transformations to move between a ratio of [0,1] in the whole document,
- * to a ratio in the subset of the pages contained in the document widgets'
- * grid.
- *
- * */
+ * The document view widget. 
+ */
 struct zathura_document_widget_s {
-  GtkGrid parent;
+  GtkContainer parent;
 };
 
 struct zathura_document_widget_class_s {
-  GtkGridClass parent_class;
+  GtkContainerClass parent_class;
 };
 
-#define ZATHURA_TYPE_DOCUMENT_WIDGET (zathura_document_widget_get_type())
-#define ZATHURA_DOCUMENT_WIDGET(obj)                                                                                   \
-  (G_TYPE_CHECK_INSTANCE_CAST((obj), ZATHURA_TYPE_DOCUMENT_WIDGET, ZathuraDocumentWidget))
-#define ZATHURA_DOCUMENT_WIDGET_CLASS(obj)                                                                             \
-  (G_TYPE_CHECK_CLASS_CAST((obj), ZATHURA_TYPE_DOCUMENT_WIDGET, ZathuraDocumentWidgetClass))
-#define ZATHURA_IS_DOCUMENT_WIDGET(obj) (G_TYPE_CHECK_INSTANCE_TYPE((obj), ZATHURA_TYPE_DOCUMENT_WIDGET))
-#define ZATHURA_IS_DOCUMENT_WIDGET_CLASS(obj) (G_TYPE_CHECK_CLASS_TYPE((obj), ZATHURA_TYPE_DOCUMENT_WIDGET))
-#define ZATHURA_DOCUMENT_WIDGET_GET_CLASS(obj)                                                                         \
-  (G_TYPE_INSTANCE_GET_CLASS((obj), ZATHURA_TYPE_DOCUMENT_WIDGET, ZathuraDocumentWidgetClass))
+#define ZATHURA_TYPE_DOCUMENT (zathura_document_widget_get_type())
+#define ZATHURA_DOCUMENT(obj)                                                                                   \
+  (G_TYPE_CHECK_INSTANCE_CAST((obj), ZATHURA_TYPE_DOCUMENT, ZathuraDocument))
+#define ZATHURA_DOCUMENT_CLASS(obj)                                                                             \
+  (G_TYPE_CHECK_CLASS_CAST((obj), ZATHURA_TYPE_DOCUMENT, ZathuraDocumentClass))
+#define ZATHURA_IS_DOCUMENT(obj) (G_TYPE_CHECK_INSTANCE_TYPE((obj), ZATHURA_TYPE_DOCUMENT))
+#define ZATHURA_IS_DOCUMENT_CLASS(obj) (G_TYPE_CHECK_CLASS_TYPE((obj), ZATHURA_TYPE_DOCUMENT))
+#define ZATHURA_DOCUMENT_GET_CLASS(obj)                                                                         \
+  (G_TYPE_INSTANCE_GET_CLASS((obj), ZATHURA_TYPE_DOCUMENT, ZathuraDocumentClass))
 
 /**
  * Returns the type of the document view widget.
@@ -51,52 +40,90 @@ GType zathura_document_widget_get_type(void) G_GNUC_CONST;
  * @param zathura the zathura instance
  * @return a document view widget
  */
-GtkWidget* zathura_document_widget_new(void);
+GtkWidget* zathura_document_widget_new(zathura_t* zathura);
 
 /**
- * Builds the box structure to show the rendered pages
+ * Update internal layout structures when pages-per-row, 
+ * first page column or document changes.
  *
- * @param zathura The zathura session
- * @param page_right_to_left Render pages right to left
+ * @param document ZathuraDocument
  */
-void zathura_document_widget_set_mode(zathura_t* zathura, bool page_right_to_left);
+void zathura_document_widget_refresh_layout(ZathuraDocument* document);
 
 /**
- * Update the pages in the document view
+ * Calculate the position of each grid cell.
+ * Required when any page size is changed.
  *
- * @param widget the document view widget
+ * @param document ZathuraDocument
  */
-void zathura_document_widget_render(zathura_t* zathura);
+void zathura_document_widget_compute_layout(ZathuraDocument* document);
 
 /**
- * Clear pages from the document view
+ * Return the position of a cell from the document's layout table in pixels. 
+ * It takes the current scale into account.
+ * Valid after a call to zathura_document_widget_compute_layout.
  *
- * @param widget the document view widget
+ * @param document   ZathuraDocument
+ * @param page_index index of the page
+ * @return pos_x     pixel offset in the x direction
+ * @return pos_y     pixel offset in the y direction
  */
-void zathura_document_widget_clear_pages(GtkWidget* widget);
+void zathura_document_widget_get_cell_pos(ZathuraDocument* document, unsigned int page_index, 
+                                          unsigned int* pos_x, unsigned int* pos_y);
 
 /**
- * Compute the adjustment ratio
+ * Return the size of a cell from the document's layout table in pixels. 
+ * It takes the current scale into account.
+ * Valid after a call to zathura_document_widget_compute_layout.
  *
- * That is, the ratio between the length from the lower bound to the middle of
- * the slider, and the total length of the scrollbar.
- *
- * @param adjustment Scrollbar adjustment
- * @param width Is the adjustment for width?
- * @return Adjustment ratio
+ * @param document   ZathuraDocument
+ * @param page_index index of the page
+ * @return height    cell height
+ * @return width     cell width
  */
-gdouble zathura_document_widget_get_ratio(zathura_t* zathura, GtkAdjustment* adjustment, bool width);
+void zathura_document_widget_get_cell_size(ZathuraDocument* document, unsigned int page_index, 
+                                           unsigned int* height, unsigned int* width);
 
 /**
- * Set the adjustment value from ratio
+ * The position and size of a row in the document widget.
+ * Valid after a call to zathura_document_widget_compute_layout.
  *
- * The ratio is usually obtained from a previous call to
- * zathura_document_widget_get_ratio().
- *
- * @param adjustment Adjustment instance
- * @param ratio Ratio from which the adjustment value will be set
- * @param width Is the adjustment for width?
+ * @param document   ZathuraDocument
+ * @param row        row number, indexed from 0.
+ * @return pos       pixel offset
+ * @return size      row size
  */
-void zathura_document_widget_set_value_from_ratio(zathura_t* zathura, GtkAdjustment* adjustment, double ratio,
-                                                  bool width);
+void zathura_document_widget_get_row(ZathuraDocument* document, unsigned int row, 
+                                     unsigned int* pos, unsigned int* size);
+
+/**
+ * The position and size of a column in the document widget.
+ * Valid after a call to zathura_document_widget_compute_layout.
+ *
+ * @param document   ZathuraDocument
+ * @param col        column number, indexed from 0.
+ * @return pos       pixel offset
+ * @return size      col size
+ */
+void zathura_document_widget_get_col(ZathuraDocument* document, unsigned int col, 
+                                     unsigned int* pos, unsigned int* size);
+
+/**
+ * Get the size of the entire document to be displayed in pixels.
+ * Takes into account the scale, layout of the pages, and padding
+ * between them. Valid after a call to zathura_document_widget_compute_layout.
+ *
+ * @param document ZathuraDocument
+ * @return height  document height in pixels
+ * @return width   document width in pixels
+ */
+void zathura_document_widget_get_document_size(ZathuraDocument* document, unsigned int* height, unsigned int* width);
+
+/**
+ * Remove page widgets from document.
+ *
+ * @param document ZathuraDocument
+ */
+void zathura_document_widget_clear_pages(ZathuraDocument* document);
+
 #endif // DOCUMENT_WIDGET_H

--- a/zathura/document.h
+++ b/zathura/document.h
@@ -299,38 +299,6 @@ void ZATHURA_PLUGIN_API zathura_document_set_device_factors(zathura_document_t* 
 ZATHURA_PLUGIN_API zathura_device_factors_t zathura_document_get_device_factors(zathura_document_t* document);
 
 /**
- * Return the size of a cell from the document's layout table in pixels. Assumes
- * that the table is homogeneous (i.e. every cell has the same dimensions). It
- * takes the current scale into account.
- *
- * @param[in]  document     The document instance
- * @param[out] height,width The computed height and width of the cell
- */
-ZATHURA_PLUGIN_API void zathura_document_get_cell_size(zathura_document_t* document, unsigned int* height,
-                                                       unsigned int* width);
-
-/**
- * Compute the size of the entire document to be displayed in pixels. Takes into
- * account the scale, the layout of the pages, and the padding between them. It
- * should be equal to the allocation of zathura->ui.page_widget once it's shown.
- *
- * @param[in]  document               The document
- * @param[out] height,width           The height and width of the document
- */
-ZATHURA_PLUGIN_API void zathura_document_get_document_size(zathura_document_t* document, unsigned int* height,
-                                                           unsigned int* width);
-
-/**
- * Sets the cell height and width of the document
- *
- * @param[in]  document          The document instance
- * @param[in]  cell_height       The desired cell height
- * @param[in]  cell_width        The desired cell width
- */
-ZATHURA_PLUGIN_API void zathura_document_set_cell_size(zathura_document_t* document, unsigned int cell_height,
-                                                       unsigned int cell_width);
-
-/**
  * Sets the layout of the pages in the document
  *
  * @param[in]  document          The document instance

--- a/zathura/links.c
+++ b/zathura/links.c
@@ -10,6 +10,7 @@
 #include "links.h"
 #include "zathura.h"
 #include "document.h"
+#include "document-widget.h"
 #include "utils.h"
 #include "page.h"
 #include "render.h"
@@ -134,17 +135,18 @@ static void link_goto_dest(zathura_t* zathura, const zathura_link_t* link) {
      of the viewport */
   double pos_x = 0;
   double pos_y = 0;
-  page_number_to_position(document, link->target.page_number, 0.0, 0.0, &pos_x, &pos_y);
+  page_number_to_position(zathura, link->target.page_number, 0.0, 0.0, &pos_x, &pos_y);
 
   /* correct to place the target position at the top of the viewport     */
   /* NOTE: link->target is in page units, needs to be scaled and rotated */
   unsigned int cell_height = 0;
   unsigned int cell_width  = 0;
-  zathura_document_get_cell_size(document, &cell_height, &cell_width);
+  zathura_document_widget_get_cell_size(ZATHURA_DOCUMENT(zathura->ui.document_widget), link->target.page_number, 
+                                        &cell_height, &cell_width);
 
   unsigned int doc_height = 0;
   unsigned int doc_width  = 0;
-  zathura_document_get_document_size(document, &doc_height, &doc_width);
+  zathura_document_widget_get_document_size(ZATHURA_DOCUMENT(zathura->ui.document_widget), &doc_height, &doc_width);
 
   bool link_hadjust = true;
   girara_setting_get(zathura->ui.session, "link-hadjust", &link_hadjust);

--- a/zathura/page-widget.c
+++ b/zathura/page-widget.c
@@ -15,6 +15,7 @@
 #include "utils.h"
 #include "shortcuts.h"
 #include "zathura.h"
+#include "document-widget.h"
 
 typedef struct zathura_page_widget_private_s {
   zathura_page_t* page;                 /**< Page object */
@@ -963,7 +964,8 @@ zathura_link_t* zathura_page_widget_link_get(ZathuraPage* widget, unsigned int i
   }
 }
 
-static void rotate_point(zathura_document_t* document, double orig_x, double orig_y, double* x, double* y) {
+static void rotate_point(zathura_t* zathura, unsigned int page, double orig_x, double orig_y, double* x, double* y) {
+  zathura_document_t* document = zathura_get_document(zathura);
   const unsigned int rotation = zathura_document_get_rotation(document);
   if (rotation == 0) {
     *x = orig_x;
@@ -972,7 +974,7 @@ static void rotate_point(zathura_document_t* document, double orig_x, double ori
   }
 
   unsigned int height, width;
-  zathura_document_get_cell_size(document, &height, &width);
+  zathura_document_widget_get_cell_size(ZATHURA_DOCUMENT(zathura->ui.document_widget), page, &height, &width);
   switch (rotation) {
   case 90:
     *x = orig_y;
@@ -1009,7 +1011,6 @@ static gboolean cb_zathura_page_widget_button_press_event(GtkWidget* widget, Gdk
 
   ZathuraPage* page            = ZATHURA_PAGE(widget);
   ZathuraPagePrivate* priv     = zathura_page_widget_get_instance_private(page);
-  zathura_document_t* document = zathura_page_get_document(priv->page);
 
   if (girara_callback_view_button_press_event(widget, button, priv->zathura->ui.session) == true) {
     return true;
@@ -1021,7 +1022,7 @@ static gboolean cb_zathura_page_widget_button_press_event(GtkWidget* widget, Gdk
     if (button->type == GDK_BUTTON_PRESS) {
       /* start the selection */
       double x, y;
-      rotate_point(document, button->x, button->y, &x, &y);
+      rotate_point(priv->zathura, zathura_page_get_index(priv->page), button->x, button->y, &x, &y);
 
       priv->mouse.selection.x1 = x;
       priv->mouse.selection.y1 = y;
@@ -1144,7 +1145,7 @@ static gboolean cb_zathura_page_widget_motion_notify(GtkWidget* widget, GdkEvent
     zathura_page_widget_clear_selection(page);
     if (event->state & priv->zathura->global.highlighter_modmask) {
       double x, y;
-      rotate_point(document, event->x, event->y, &x, &y);
+      rotate_point(priv->zathura, zathura_page_get_index(priv->page), event->x, event->y, &x, &y);
       priv->highlighter.bounds = next_selection_rectangle(priv->mouse.selection.x1, priv->mouse.selection.y1, x, y);
       priv->highlighter.bounds.x1 /= scale;
       priv->highlighter.bounds.y1 /= scale;
@@ -1155,7 +1156,7 @@ static gboolean cb_zathura_page_widget_motion_notify(GtkWidget* widget, GdkEvent
       zathura_page_widget_redraw_canvas(page);
     } else {
       /* calculate next selection */
-      rotate_point(document, event->x, event->y, &priv->mouse.selection.x2, &priv->mouse.selection.y2);
+      rotate_point(priv->zathura, zathura_page_get_index(priv->page), event->x, event->y, &priv->mouse.selection.x2, &priv->mouse.selection.y2);
 
       zathura_rectangle_t selection = priv->mouse.selection;
       selection.x1 /= scale;

--- a/zathura/render.c
+++ b/zathura/render.c
@@ -11,6 +11,7 @@
 #include "adjustment.h"
 #include "zathura.h"
 #include "document.h"
+#include "document-widget.h"
 #include "page.h"
 #include "page-widget.h"
 #include "utils.h"
@@ -903,6 +904,8 @@ void render_all(zathura_t* zathura) {
   if (document == NULL) {
     return;
   }
+
+  zathura_document_widget_compute_layout(ZATHURA_DOCUMENT(zathura->ui.document_widget));
 
   /* unmark all pages */
   const unsigned int number_of_pages = zathura_document_get_number_of_pages(document);

--- a/zathura/synctex.c
+++ b/zathura/synctex.c
@@ -12,6 +12,7 @@
 #include "zathura.h"
 #include "page.h"
 #include "document.h"
+#include "document-widget.h"
 #include "utils.h"
 #include "adjustment.h"
 
@@ -271,17 +272,17 @@ void synctex_highlight_rects(zathura_t* zathura, unsigned int page, girara_list_
   /* compute the position of the center of the page */
   double pos_x = 0;
   double pos_y = 0;
-  page_number_to_position(document, page, 0.5, 0.5, &pos_x, &pos_y);
+  page_number_to_position(zathura, page, 0.5, 0.5, &pos_x, &pos_y);
 
   /* correction to center the current result                          */
   /* NOTE: rectangle is in viewport units, already scaled and rotated */
   unsigned int cell_height = 0;
   unsigned int cell_width  = 0;
-  zathura_document_get_cell_size(document, &cell_height, &cell_width);
+  zathura_document_widget_get_cell_size(ZATHURA_DOCUMENT(zathura->ui.document_widget), page, &cell_height, &cell_width);
 
   unsigned int doc_height = 0;
   unsigned int doc_width  = 0;
-  zathura_document_get_document_size(document, &doc_height, &doc_width);
+  zathura_document_widget_get_document_size(ZATHURA_DOCUMENT(zathura->ui.document_widget), &doc_height, &doc_width);
 
   /* Need to adjust rectangle to page scale and orientation */
   zathura_page_t* doc_page  = zathura_document_get_page(document, page);

--- a/zathura/types.h
+++ b/zathura/types.h
@@ -15,8 +15,8 @@ typedef struct zathura_document_s zathura_document_t;
 /**
  * Document widget
  */
-typedef struct zathura_document_widget_s ZathuraDocumentWidget;
-typedef struct zathura_document_widget_class_s ZathuraDocumentWidgetClass;
+typedef struct zathura_document_widget_s ZathuraDocument;
+typedef struct zathura_document_widget_class_s ZathuraDocumentClass;
 /**
  * Page
  */

--- a/zathura/utils.c
+++ b/zathura/utils.c
@@ -18,6 +18,7 @@
 #include "zathura.h"
 #include "internal.h"
 #include "document.h"
+#include "document-widget.h"
 #include "page.h"
 #include "plugin.h"
 #include "content-type.h"
@@ -690,17 +691,18 @@ bool search_document(zathura_t* zathura, girara_argument_t* argument, bool disab
     /* compute the position of the center of the page */
     double pos_x = 0;
     double pos_y = 0;
-    page_number_to_position(zathura->document, zathura_page_get_index(target_page), 0.5, 0.5, &pos_x, &pos_y);
+    page_number_to_position(zathura, zathura_page_get_index(target_page), 0.5, 0.5, &pos_x, &pos_y);
 
     /* correction to center the current result                          */
     /* NOTE: rectangle is in viewport units, already scaled and rotated */
     unsigned int cell_height = 0;
     unsigned int cell_width  = 0;
-    zathura_document_get_cell_size(zathura->document, &cell_height, &cell_width);
+    zathura_document_widget_get_cell_size(ZATHURA_DOCUMENT(zathura->ui.document_widget),
+                                          zathura_page_get_index(target_page), &cell_height, &cell_width);
 
     unsigned int doc_height = 0;
     unsigned int doc_width  = 0;
-    zathura_document_get_document_size(zathura->document, &doc_height, &doc_width);
+    zathura_document_widget_get_document_size(ZATHURA_DOCUMENT(zathura->ui.document_widget), &doc_height, &doc_width);
 
     /* compute the center of the rectangle, which will be aligned to the center
        of the viewport */


### PR DESCRIPTION
New document widget which draws pages directly rather than using GtkGrid.
Resolves #826, resolves #580, resolves #657, resolves #785, resolves #795, resolves #736, and resolves #797. First step towards implementing per page zooming required for #289, #447, and #724. Implementing #103 is fairly simple with this new widget, but I'll add that separately since this PR is already long.

<img width="1710" height="1380" alt="20251229_20h43m05s_grim" src="https://github.com/user-attachments/assets/f7fbc79d-7102-4f84-beba-9c25ed4c22c5" />

## Implementation

Drawing is broken up into 3 steps.

1. Allocate memory for the document, this handles adding the page widgets to the document widget and reallocating memory if necessary for internal structures. Handled by `zathura_document_widget_refresh_layout` and is called when the document or page layout is changed.
2. Calculate the position of each row and column. Each individual row or column is allocated the maximum height or width of the pages in the row or column respectively. Handled by `zathura_document_widget_compute_layout`. The positions depend on the zoom of the document/pages, so is called whenever the zoom changes. Also required to be called for the get values to be updated (e.g. document widget size). 
3. size allocate signal is when the pages are drawn, using the position calculated previously. Additionally, size allocate is called whenever the adjustment values are changed to update the page positions.

## Issues

There is a minor issue with navigation for documents with non-uniform page sizes. In best-fit mode, when moving between pages with different sizes, the zoom level may change due to the different page sizes and the position doesn't end up at the start of a page. 

This is something that'll need addressing for the best fit per page features. The current approach of storing position as a value from [0, 1] normalised by document size means the position is independent of scale But if we introduce per page scaling, the [0, 1] position now depends on the scale of the pages. E.g. if the scale of the first page changes, the [0, 1] position of the start of the second page changes. Maybe storing the position relative to the current page is the way to handle this? Since that change would touch a wide area for a small issue, I'll leave it for now.