### PR TITLE
Prevent inadvertent forkback when closing parent of open documents

### DIFF
--- a/zathura/main.c
+++ b/zathura/main.c
@@ -14,6 +14,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "zathura.h"
 #include "plugin.h"
@@ -187,9 +188,12 @@ GIRARA_VISIBLE int main(int argc, char* argv[]) {
   const int file_idx_base    = has_double_dash ? 2 : 1;
 
   int file_idx = argc > file_idx_base ? file_idx_base : 0;
-  /* Fork instances for other files. */
+  /* If more than one file, fork an instance for each. */
   if (print_version == false && argc > file_idx_base + 1) {
-    for (int idx = file_idx_base + 1; idx < argc; ++idx) {
+    int file_count         = argc - file_idx_base;
+    const pid_t parent_pid = getpid();
+
+    for (int idx = file_idx_base; idx < argc; ++idx) {
       const pid_t pid = fork();
       if (pid == 0) { /* child */
         file_idx = idx;
@@ -202,6 +206,17 @@ GIRARA_VISIBLE int main(int argc, char* argv[]) {
         girara_error("Could not fork: %s", strerror(errno));
         return -1;
       }
+    }
+
+    if (parent_pid == getpid()) {
+      if (forkback == true) {
+        return 0;
+      }
+      while (file_count != 0) { /* wait for all children */
+        wait(NULL);
+        file_count--;
+      }
+      return 0;
     }
   }
 


### PR DESCRIPTION
Resolves #855.

The issue was traced to the way calls were made to fork() in main.c.

Every file argument after the first argument is opened through a child process spawned through fork(), but the first document is opened in the parent itself.
Hence, closing the first document orphans the children that have not returned, causing an inadvertent forkback.

This patch proposes the following changes:
When there are multiple file arguments, open all of them in child processes (including the first one).

In this case, the parent process no longer opens a document itself, but rather waits for all children to exit before returning. In case --fork was passed, however, the parent simply returns with code 0, and the init process adopts the children.

Thank you.