### PR TITLE
remove page visiblity update from document widget size allocate

### DIFF
--- a/zathura/document-widget.c
+++ b/zathura/document-widget.c
@@ -316,19 +316,6 @@ static void zathura_document_widget_size_allocate(GtkWidget* widget, GtkAllocati
         .height = row_line.size,
     };
 
-    /*
-     * Check if 'page_alloc' and 'allocation' overlap,
-     * which occurs iff the x-range and y-range for the
-     * allocations overlap. For two intervals [a1, a2],
-     * [b1, b2], they overlap iff (a1 <= b2) && (b1 <= a2)
-     */
-    bool x_overlap =
-        (page_alloc.x <= allocation->x + allocation->width) && (allocation->x <= page_alloc.x + page_alloc.width);
-    bool y_overlap =
-        (page_alloc.y <= allocation->y + allocation->height) && (allocation->y <= page_alloc.y + page_alloc.height);
-
-    zathura_page_set_visibility(page, x_overlap && y_overlap);
-    gtk_widget_set_visible(page_widget, x_overlap && y_overlap);
     gtk_widget_size_allocate(page_widget, &page_alloc);
   }
 


### PR DESCRIPTION
Resolves #864 , resolves #860 .

Updating visible pages is already handled by `update_visible_pages` in `callbacks.c`, and it seems the updates happening in the document widget size allocate was conflicting with that. 