### PR TITLE
add smooth scroll arguments for scroll shortcut

### DIFF
--- a/doc/man/zathurarc.5.rst
+++ b/doc/man/zathurarc.5.rst
@@ -392,6 +392,8 @@ They can also be combined with modifiers:
   * full-up
   * half-down
   * half-up
+  * smooth-down
+  * smooth-up
   * in
   * left
   * next

--- a/zathura/config.c
+++ b/zathura/config.c
@@ -277,6 +277,22 @@ static void cb_guioptions(girara_session_t* session, const char* UNUSED(name), g
   }
 }
 
+static void cb_scroll_step_value_changed(girara_session_t* session, const char* UNUSED(name),
+                                         girara_setting_type_t UNUSED(type), const void* value, void* UNUSED(data)) {
+  g_return_if_fail(session != NULL && value != NULL);
+  zathura_t* zathura = session->global.data;
+  if (zathura->ui.view == NULL) {
+    return;
+  }
+
+  GtkAdjustment* v_adj = gtk_scrolled_window_get_vadjustment(GTK_SCROLLED_WINDOW(zathura->ui.view));
+  if (v_adj == NULL) {
+    return;
+  }
+
+  gtk_adjustment_set_step_increment(v_adj, *(float*)value);
+}
+
 static void add_default_shortcuts(girara_session_t* gsession, girara_mode_t mode) {
   girara_shortcut_add(gsession, 0, GDK_KEY_a, NULL, sc_adjust_window, mode, ZATHURA_ADJUST_BESTFIT, NULL);
   girara_shortcut_add(gsession, 0, GDK_KEY_s, NULL, sc_adjust_window, mode, ZATHURA_ADJUST_WIDTH, NULL);
@@ -510,7 +526,7 @@ void config_load_default(zathura_t* zathura) {
   bool_value = false;
   girara_setting_add(gsession, "page-right-to-left",    &bool_value,  BOOLEAN, false, _("Render pages from right to left"),  cb_page_layout_value_changed, NULL);
   float_value = 40;
-  girara_setting_add(gsession, "scroll-step",           &float_value, FLOAT,  false, _("Scroll step"),              NULL, NULL);
+  girara_setting_add(gsession, "scroll-step",           &float_value, FLOAT,  false, _("Scroll step"),              cb_scroll_step_value_changed, NULL);
   float_value = 40;
   girara_setting_add(gsession, "scroll-hstep",          &float_value, FLOAT,  false, _("Horizontal scroll step"),   NULL, NULL);
   float_value = 0.0;
@@ -861,6 +877,8 @@ void config_load_default(zathura_t* zathura) {
   girara_argument_mapping_add(gsession, "width",              ZATHURA_ADJUST_WIDTH);
   girara_argument_mapping_add(gsession, "rotate-cw",          ROTATE_CW);
   girara_argument_mapping_add(gsession, "rotate-ccw",         ROTATE_CCW);
+  girara_argument_mapping_add(gsession, "smooth-up",          SMOOTH_UP);
+  girara_argument_mapping_add(gsession, "smooth-down",        SMOOTH_DOWN);
   /* clang-format on */
 }
 

--- a/zathura/document-widget.c
+++ b/zathura/document-widget.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: Zlib */
 
 #include "document-widget.h"
+#include "girara-gtk/settings.h"
 #include "girara/log.h"
 
 #include "page.h"
@@ -414,6 +415,11 @@ void zathura_document_widget_compute_layout(ZathuraDocumentWidget* document) {
 
   gtk_adjustment_set_upper(priv->hadjustment, doc_width);
   gtk_adjustment_set_upper(priv->vadjustment, doc_height);
+
+  float scroll_step = 40;
+  girara_setting_get(priv->zathura->ui.session, "scroll-step", &scroll_step);
+
+  gtk_adjustment_set_step_increment(priv->vadjustment, scroll_step);
 }
 
 void zathura_document_widget_get_cell_pos(ZathuraDocumentWidget* document, unsigned int page_index, unsigned int* pos_x,

--- a/zathura/shortcuts.c
+++ b/zathura/shortcuts.c
@@ -572,6 +572,19 @@ bool sc_scroll(girara_session_t* session, girara_argument_t* argument, girara_ev
     return false;
   }
 
+  /* If SMOOTH_(UP|DOWN) , use GtkScrolledWindow signal */
+  if (argument->n == SMOOTH_UP) {
+    gboolean handled = FALSE;
+    g_signal_emit_by_name(G_OBJECT(zathura->ui.view), "scroll-child", GTK_SCROLL_STEP_BACKWARD, FALSE, &handled);
+
+    return false;
+  } else if (argument->n == SMOOTH_DOWN) {
+    gboolean handled = FALSE;
+    g_signal_emit_by_name(G_OBJECT(zathura->ui.view), "scroll-child", GTK_SCROLL_STEP_FORWARD, FALSE, &handled);
+
+    return false;
+  }
+
   if (t == 0) {
     t = 1;
   }

--- a/zathura/zathura.h
+++ b/zathura/zathura.h
@@ -75,6 +75,8 @@ enum {
   PAGE_TOP,
   BIDIRECTIONAL,
   ZOOM_SMOOTH,
+  SMOOTH_UP,
+  SMOOTH_DOWN,
 };
 
 /* unspecified page number */


### PR DESCRIPTION
Resolves #872

Ctrl+Arrow is a default keybind for GtkScrolledWindow which does smooth scrolling. When the focus changed to the GtkStack in https://github.com/pwmt/girara/commit/9d4e4778c72f8d74013d19a173c957e8da134fe9, the GtkScrolledWindow won't receive any keybind events. 

Adds arguments smooth-up and smooth-down for the scroll shortcut, which scrolls smoothly using `scroll-step` for the amount to scroll by. From the gtk documentation (https://docs.gtk.org/gtk3/signal.ScrolledWindow.scroll-child.html), the `scroll-child` signal can be emitted by user code.