### PR TITLE
Fix smooth scrolling on macOS

### DIFF
--- a/girara-gtk/callbacks.c
+++ b/girara-gtk/callbacks.c
@@ -324,6 +324,11 @@ gboolean girara_callback_view_scroll_event(GtkWidget* UNUSED(widget), GdkEventSc
     event.type = GIRARA_EVENT_SCROLL_BIDIRECTIONAL;
     /* We abuse x and y here. We really need more fields in girara_event_t. */
     gdk_event_get_scroll_deltas((GdkEvent*)scroll, &event.x, &event.y);
+#ifdef __APPLE__
+    /* Apple has much higher deltas */
+    event.x /= 50;
+    event.y /= 50;
+#endif
     break;
   default:
     return false;


### PR DESCRIPTION
MacOS seems to send higher smooth scrolling deltas than Linux as dividing them by ~50 seems to solve the issue.

Tested using trackpad/magic mouse and a normal mouse wheel (which is unaffected).

Only affects the Apple build.