### PR TITLE
remove page widget surface on size request, not on size allocate

### DIFF
--- a/zathura/page-widget.c
+++ b/zathura/page-widget.c
@@ -75,7 +75,6 @@ static void zathura_page_widget_finalize(GObject* object);
 static void zathura_page_widget_dispose(GObject* object);
 static void zathura_page_widget_set_property(GObject* object, guint prop_id, const GValue* value, GParamSpec* pspec);
 static void zathura_page_widget_get_property(GObject* object, guint prop_id, GValue* value, GParamSpec* pspec);
-static void zathura_page_widget_size_allocate(GtkWidget* widget, GdkRectangle* allocation);
 static void redraw_rect(ZathuraPageWidget* widget, zathura_rectangle_t* rectangle);
 static void redraw_all_rects(ZathuraPageWidget* widget, girara_list_t* rectangles);
 static void evaluate_link_at_mouse_position(ZathuraPageWidget* widget, int oldx, int oldy);
@@ -123,7 +122,6 @@ static void zathura_page_widget_class_init(ZathuraPageWidgetClass* class) {
   /* overwrite methods */
   GtkWidgetClass* widget_class       = GTK_WIDGET_CLASS(class);
   widget_class->draw                 = zathura_page_widget_draw;
-  widget_class->size_allocate        = zathura_page_widget_size_allocate;
   widget_class->button_press_event   = cb_zathura_page_widget_button_press_event;
   widget_class->button_release_event = cb_zathura_page_widget_button_release_event;
   widget_class->motion_notify_event  = cb_zathura_page_widget_motion_notify;
@@ -902,14 +900,6 @@ static void cb_cache_invalidated(ZathuraRenderRequest* UNUSED(request), void* da
   priv->cached = false;
 }
 
-static void zathura_page_widget_size_allocate(GtkWidget* widget, GdkRectangle* allocation) {
-  GTK_WIDGET_CLASS(zathura_page_widget_parent_class)->size_allocate(widget, allocation);
-
-  ZathuraPageWidget* page = ZATHURA_PAGE_WIDGET(widget);
-  zathura_page_widget_abort_render_request(page);
-  zathura_page_widget_update_surface(page, NULL, true);
-}
-
 static void redraw_rect(ZathuraPageWidget* widget, zathura_rectangle_t* rectangle) {
   /* cause the rect to be drawn */
   GdkRectangle grect;
@@ -1368,4 +1358,12 @@ zathura_page_t* zathura_page_widget_get_page(ZathuraPageWidget* widget) {
   ZathuraPageWidgetPrivate* priv = zathura_page_widget_get_instance_private(widget);
 
   return priv->page;
+}
+
+void zathura_page_widget_set_size_request(ZathuraPageWidget* widget, int width, int height) {
+  g_return_if_fail(widget != NULL);
+  gtk_widget_set_size_request(GTK_WIDGET(widget), width, height);
+
+  zathura_page_widget_abort_render_request(widget);
+  zathura_page_widget_update_surface(widget, NULL, true);
 }

--- a/zathura/page-widget.h
+++ b/zathura/page-widget.h
@@ -90,4 +90,13 @@ void zathura_page_widget_abort_render_request(ZathuraPageWidget* widget);
  */
 zathura_page_t* zathura_page_widget_get_page(ZathuraPageWidget* widget);
 
+/**
+ * Set size request for the page widget
+ *
+ * @param widget the widget
+ * @param width  page width
+ * @param height page height
+ */
+void zathura_page_widget_set_size_request(ZathuraPageWidget* widget, int width, int height);
+
 #endif

--- a/zathura/render.c
+++ b/zathura/render.c
@@ -918,7 +918,7 @@ void render_all(zathura_t* zathura) {
     girara_debug("Queuing resize for page %u to %u x %u.", page_id, page_width, page_height);
     GtkWidget* widget = zathura_page_get_widget(zathura, page);
     if (widget != NULL) {
-      gtk_widget_set_size_request(widget, page_width, page_height);
+      zathura_page_widget_set_size_request(ZATHURA_PAGE_WIDGET(widget), page_width, page_height);
       gtk_widget_queue_resize(widget);
     }
   }

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -1193,7 +1193,7 @@ bool document_open(zathura_t* zathura, const char* path, const char* uri, const 
      * gtk_widget_set_size_request. To be sure that it's really called, do it
      * here once again. */
     page_calc_height_width(zathura->document, page, &page_height, &page_width, true);
-    gtk_widget_set_size_request(widget, page_width, page_height);
+    zathura_page_widget_set_size_request(ZATHURA_PAGE_WIDGET(widget), page_width, page_height);
 
     /* show widget */
     gtk_widget_show(widget);


### PR DESCRIPTION
Document widget uses size allocate to position the page widgets, which conflicts with the previous use of size allocate to invalidate the surface cache.

This should resolve:
- [ ]  #876 ,
- [ ] #877 , 
- [ ] #879 , 
- [ ] #877. 
- [ ] #886 . 

Transparency doesn't really work on my machine, and its fast enough that I didn't have lag scrolling so it would be good to have people that can reproduce those issue test.

`zathura_page_widget_update_surface` should only be called from the render thread, is this also the case for where I've changed `gtk_widget_set_size_request` to `zathura_page_widget_set_size_request`? If not, whats the correct way to queue this function to be called in the render thread at some point?