### PR TITLE
add command to run a shortcut command

### DIFF
--- a/girara-gtk/commands.c
+++ b/girara-gtk/commands.c
@@ -640,6 +640,70 @@ bool girara_cmd_set(girara_session_t* session, girara_list_t* argument_list) {
   return true;
 }
 
+bool girara_cmd_shortcut(girara_session_t* session, girara_list_t* argument_list) {
+  const size_t number_of_arguments = girara_list_size(argument_list);
+
+  unsigned int limit = 1;
+  if (number_of_arguments < limit) {
+    girara_warning("Invalid number of arguments passed: %zu instead of at least %u", number_of_arguments, limit);
+    girara_notify(session, GIRARA_ERROR, _("Invalid number of arguments passed: %zu instead of at least %u"),
+                  number_of_arguments, limit);
+    return false;
+  }
+
+  int shortcut_argument_n                      = 0;
+  g_autofree char* shortcut_buffer_command     = NULL;
+  girara_shortcut_function_t shortcut_function = NULL;
+
+  size_t current_command = 0;
+  char* tmp              = girara_list_nth(argument_list, current_command);
+
+  girara_session_private_t* session_private = session->private_data;
+
+  /* Check for passed shortcut command */
+  bool found_mapping = false;
+  for (size_t idx = 0; idx != girara_list_size(session_private->config.shortcut_mappings); ++idx) {
+    girara_shortcut_mapping_t* mapping = girara_list_nth(session_private->config.shortcut_mappings, idx);
+    if (!g_strcmp0(tmp, mapping->identifier)) {
+      shortcut_function = mapping->function;
+      found_mapping     = true;
+      break;
+    }
+  }
+
+  if (found_mapping == false) {
+    girara_warning("Not a valid shortcut function: %s", tmp);
+    girara_notify(session, GIRARA_ERROR, _("Not a valid shortcut function: %s"), tmp);
+    return false;
+  }
+
+  /* Check for passed argument */
+  char* shortcut_argument_data = NULL;
+  if (++current_command < number_of_arguments) {
+    tmp = girara_list_nth(argument_list, current_command);
+
+    for (size_t idx = 0; idx != girara_list_size(session_private->config.argument_mappings); ++idx) {
+      girara_argument_mapping_t* mapping = girara_list_nth(session_private->config.argument_mappings, idx);
+      if (!g_strcmp0(tmp, mapping->identifier)) {
+        shortcut_argument_n = mapping->value;
+        break;
+      }
+    }
+
+    /* If no known argument is passed we save it in the data field */
+    if (shortcut_argument_n == 0) {
+      shortcut_argument_data = tmp;
+      /* If a known argument is passed and there are still more arguments,
+       * we save the next one in the data field */
+    } else if (++current_command < number_of_arguments) {
+      shortcut_argument_data = girara_list_nth(argument_list, current_command);
+    }
+  }
+
+  girara_argument_t arg = {.data = shortcut_argument_data, .n = shortcut_argument_n};
+  return shortcut_function(session, &arg, NULL, 1);
+}
+
 bool girara_inputbar_command_add(girara_session_t* session, const char* command, const char* abbreviation,
                                  girara_command_function_t function, girara_completion_function_t completion,
                                  const char* description) {

--- a/girara-gtk/internal.h
+++ b/girara-gtk/internal.h
@@ -75,6 +75,16 @@ bool girara_cmd_unmap(girara_session_t* session, girara_list_t* argument_list);
 bool girara_cmd_set(girara_session_t* session, girara_list_t* argument_list);
 
 /**
+ * Run a shortcut command
+ *
+ * @param session The used girara session
+ * @param argument_list List of passed arguments
+ * @return TRUE No error occurred
+ * @return FALSE An error occurred
+ */
+bool girara_cmd_shortcut(girara_session_t* session, girara_list_t* argument_list);
+
+/**
  * Dump current settings to a JSON file
  *
  * @param session The used girara session

--- a/zathura/config.c
+++ b/zathura/config.c
@@ -761,10 +761,11 @@ void config_load_default(zathura_t* zathura) {
   girara_inputbar_shortcut_add(gsession, GDK_CONTROL_MASK, GDK_KEY_n,            girara_isc_command_history,     GIRARA_NEXT,                 NULL);
 
   /* define default inputbar commands */
-  girara_inputbar_command_add(gsession, "map",   "m",  girara_cmd_map,         NULL,          _("Map a key sequence"));
-  girara_inputbar_command_add(gsession, "set",   "s",  girara_cmd_set,         girara_cc_set, _("Set an option"));
-  girara_inputbar_command_add(gsession, "unmap", NULL, girara_cmd_unmap,       NULL,          _("Unmap a key sequence"));
-  girara_inputbar_command_add(gsession, "dump",  NULL, girara_cmd_dump_config, NULL,          _("Dump settings to a file"));
+  girara_inputbar_command_add(gsession, "map",      "m",  girara_cmd_map,         NULL,          _("Map a key sequence"));
+  girara_inputbar_command_add(gsession, "set",      "s",  girara_cmd_set,         girara_cc_set, _("Set an option"));
+  girara_inputbar_command_add(gsession, "shortcut", "sc", girara_cmd_shortcut,    NULL,          _("Run a shortcut"));
+  girara_inputbar_command_add(gsession, "unmap",    NULL, girara_cmd_unmap,       NULL,          _("Unmap a key sequence"));
+  girara_inputbar_command_add(gsession, "dump",     NULL, girara_cmd_dump_config, NULL,          _("Dump settings to a file"));
 
   girara_inputbar_command_add(gsession, "bmark",      NULL,   cmd_bookmark_create, NULL,         _("Add a bookmark"));
   girara_inputbar_command_add(gsession, "bdelete",    NULL,   cmd_bookmark_delete, cc_bookmarks, _("Delete a bookmark"));


### PR DESCRIPTION
Add a command to enable running a shortcut immediately rather than mapping a key.
`girara_shortcut_function_t` arguments aren't documented, so I'm not sure if passing 1 for unsigned int is correct.

Resolves #728, resolves #848, resolves #418  and resolves #222  (ExecuteCommand handler should be able to call this command). Resolves #225.