### PR TITLE
Initialise variable to fix build

### DIFF
--- a/zathura/document-widget.c
+++ b/zathura/document-widget.c
@@ -277,7 +277,7 @@ static void document_adjustment(ZathuraDocumentWidget* document, int height, int
   const unsigned int value_v = gtk_adjustment_get_value(priv->vadjustment);
   const unsigned int value_h = gtk_adjustment_get_value(priv->hadjustment);
 
-  unsigned int doc_height, doc_width;
+  unsigned int doc_height = 0, doc_width = 0;
   zathura_document_widget_get_document_size(document, &doc_height, &doc_width);
 
   const int center_v = (height - doc_height) / 2;
@@ -505,7 +505,7 @@ void zathura_document_widget_compute_layout(ZathuraDocumentWidget* document) {
   zathura_document_widget_arrange_grid(document);
 
   /* update allocation values */
-  unsigned int doc_height, doc_width;
+  unsigned int doc_height = 0, doc_width = 0;
   zathura_document_widget_get_document_size(document, &doc_height, &doc_width);
 
   gtk_adjustment_set_upper(priv->hadjustment, doc_width);


### PR DESCRIPTION
`zathura` is failing to build in Ubuntu for ppc64el with the following error:
```
In function ‘document_adjustment’,
    inlined from ‘size_allocate_grid’ at ../zathura/document-widget.c:337:3,
    inlined from ‘zathura_document_widget_size_allocate’ at ../zathura/document-widget.c:405:5:
../zathura/document-widget.c:284:13: error: ‘doc_height’ may be used uninitialized [-Werror=maybe-uninitialized]
  284 |   *adj_v = ((int)doc_height < height) ? -center_v : (int)value_v;
      |             ^~~~~~~~~~~~~~~
../zathura/document-widget.c: In function ‘zathura_document_widget_size_allocate’:
../zathura/document-widget.c:277:16: note: ‘doc_height’ was declared here
  277 |   unsigned int doc_height, doc_width;
      |                ^~~~~~~~~~
In function ‘document_adjustment’,
    inlined from ‘size_allocate_grid’ at ../zathura/document-widget.c:337:3,
    inlined from ‘zathura_document_widget_size_allocate’ at ../zathura/document-widget.c:405:5:
../zathura/document-widget.c:285:13: error: ‘doc_width’ may be used uninitialized [-Werror=maybe-uninitialized]
  285 |   *adj_h = ((int)doc_width < width) ? -center_h : (int)value_h;
      |             ^~~~~~~~~~~~~~
../zathura/document-widget.c: In function ‘zathura_document_widget_size_allocate’:
../zathura/document-widget.c:277:28: note: ‘doc_width’ was declared here
  277 |   unsigned int doc_height, doc_width;
      |                            ^~~~~~~~~
../zathura/document-widget.c: In function ‘zathura_document_widget_compute_layout’:
../zathura/document-widget.c:508:3: error: ‘doc_height’ may be used uninitialized [-Werror=maybe-uninitialized]
  508 |   gtk_adjustment_set_upper(priv->vadjustment, doc_height);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../zathura/document-widget.c:504:16: note: ‘doc_height’ was declared here
  504 |   unsigned int doc_height, doc_width;
      |                ^~~~~~~~~~
../zathura/document-widget.c:507:3: error: ‘doc_width’ may be used uninitialized [-Werror=maybe-uninitialized]
  507 |   gtk_adjustment_set_upper(priv->hadjustment, doc_width);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../zathura/document-widget.c:504:28: note: ‘doc_width’ was declared here
  504 |   unsigned int doc_height, doc_width;
      |                            ^~~~~~~~~
cc1: some warnings being treated as errors
```
