### PR TITLE
fix various issues

### DIFF
--- a/zathura/commands.c
+++ b/zathura/commands.c
@@ -250,7 +250,8 @@ bool cmd_info(girara_session_t* session, girara_list_t* UNUSED(argument_list)) {
     for (size_t idx = 0; idx != girara_list_size(information); ++idx) {
       zathura_document_information_entry_t* entry = girara_list_nth(information, idx);
       if (entry != NULL && meta_fields[i].field == entry->type) {
-        g_string_append_printf(string, "<b>%s:</b> %s\n", meta_fields[i].name, entry->value);
+        g_autofree gchar* escaped_value = g_markup_escape_text(entry->value, -1);
+        g_string_append_printf(string, "<b>%s:</b> %s\n", meta_fields[i].name, escaped_value);
       }
     }
   }

--- a/zathura/commands.c
+++ b/zathura/commands.c
@@ -105,7 +105,8 @@ bool cmd_bookmark_list(girara_session_t* session, girara_list_t* GIRARA_UNUSED(a
   g_autoptr(GString) string = g_string_new(NULL);
   for (size_t idx = 0; idx != girara_list_size(zathura->bookmarks.bookmarks); ++idx) {
     zathura_bookmark_t* bookmark = girara_list_nth(zathura->bookmarks.bookmarks, idx);
-    g_string_append_printf(string, "<b>%s</b>: %u\n", bookmark->id, bookmark->page);
+    g_autofree gchar* escaped_id = g_markup_escape_text(bookmark->id, -1);
+    g_string_append_printf(string, "<b>%s</b>: %u\n", escaped_id, bookmark->page);
   }
 
   if (string->len > 0) {

--- a/zathura/links.c
+++ b/zathura/links.c
@@ -261,9 +261,11 @@ void zathura_link_display(zathura_t* zathura, zathura_link_t* link) {
   case ZATHURA_LINK_GOTO_REMOTE:
   case ZATHURA_LINK_URI:
   case ZATHURA_LINK_LAUNCH:
-  case ZATHURA_LINK_NAMED:
-    girara_notify(zathura->ui.session, GIRARA_INFO, _("Link: %s"), target.value);
+  case ZATHURA_LINK_NAMED: {
+    g_autofree gchar* escaped_value = g_markup_escape_text(target.value, -1);
+    girara_notify(zathura->ui.session, GIRARA_INFO, _("Link: %s"), escaped_value);
     break;
+  }
   default:
     girara_notify(zathura->ui.session, GIRARA_ERROR, _("Link: Invalid"));
   }
@@ -282,10 +284,12 @@ void zathura_link_copy(zathura_t* zathura, zathura_link_t* link, GdkAtom* select
   case ZATHURA_LINK_GOTO_REMOTE:
   case ZATHURA_LINK_URI:
   case ZATHURA_LINK_LAUNCH:
-  case ZATHURA_LINK_NAMED:
+  case ZATHURA_LINK_NAMED: {
     gtk_clipboard_set_text(gtk_clipboard_get(*selection), target.value, -1);
-    girara_notify(zathura->ui.session, GIRARA_INFO, _("Copied link: %s"), target.value);
+    g_autofree gchar* escaped_value = g_markup_escape_text(target.value, -1);
+    girara_notify(zathura->ui.session, GIRARA_INFO, _("Copied link: %s"), escaped_value);
     break;
+  }
   default:
     girara_notify(zathura->ui.session, GIRARA_ERROR, _("Link: Invalid"));
   }

--- a/zathura/page.c
+++ b/zathura/page.c
@@ -137,7 +137,7 @@ void zathura_page_set_width(zathura_page_t* page, double width) {
     return;
   }
 
-  if (!isfinite(width) || width <= 0.0 || width > 1e7) {
+  if (!isfinite(width) || width < DBL_EPSILON) {
     girara_warning("Invalid page width: %f, falling back to default", width);
     width = 1.0;
   }
@@ -158,7 +158,7 @@ void zathura_page_set_height(zathura_page_t* page, double height) {
     return;
   }
 
-  if (!isfinite(height) || height <= 0.0 || height > 1e7) {
+  if (!isfinite(height) || height < DBL_EPSILON) {
     girara_warning("Invalid page height: %f, falling back to default", height);
     height = 1.0;
   }

--- a/zathura/page.c
+++ b/zathura/page.c
@@ -2,6 +2,7 @@
 
 #include "page.h"
 
+#include <math.h>
 #include <girara-gtk/session.h>
 #include <girara/utils.h>
 #include <glib/gi18n.h>
@@ -136,6 +137,11 @@ void zathura_page_set_width(zathura_page_t* page, double width) {
     return;
   }
 
+  if (!isfinite(width) || width <= 0.0 || width > 1e7) {
+    girara_warning("Invalid page width: %f, falling back to default", width);
+    width = 1.0;
+  }
+
   page->width = width;
 }
 
@@ -150,6 +156,11 @@ double zathura_page_get_height(zathura_page_t* page) {
 void zathura_page_set_height(zathura_page_t* page, double height) {
   if (page == NULL) {
     return;
+  }
+
+  if (!isfinite(height) || height <= 0.0 || height > 1e7) {
+    girara_warning("Invalid page height: %f, falling back to default", height);
+    height = 1.0;
   }
 
   page->height = height;


### PR DESCRIPTION
Document info text (title, author) can contain special characters that mess up the notification display. The same issue exists for link targets and link copy.

Fixed by added escaping

Also added a check for large page sizes that would break rendering