### PR TITLE
fix loading message

### DIFF
--- a/zathura/callbacks.c
+++ b/zathura/callbacks.c
@@ -63,8 +63,17 @@ void update_visible_pages(zathura_t* zathura) {
       /* make page visible */
       if (zathura_page_get_visibility(page) == false) {
         zathura_page_set_visibility(page, true);
-        zathura_page_widget_update_view_time(zathura_page_widget);
         zathura_renderer_page_cache_add(zathura->sync.render_thread, zathura_page_get_index(page));
+      }
+      zathura_page_widget_update_view_time(zathura_page_widget);
+      /* keep adjacent pages rendered so scrolling lands on ready content */
+      if (page_id > 0) {
+        zathura_page_widget_update_view_time(
+            ZATHURA_PAGE_WIDGET(zathura_page_get_widget_by_number(zathura, page_id - 1)));
+      }
+      if (page_id + 1 < number_of_pages) {
+        zathura_page_widget_update_view_time(
+            ZATHURA_PAGE_WIDGET(zathura_page_get_widget_by_number(zathura, page_id + 1)));
       }
 
     } else {

--- a/zathura/page-widget.c
+++ b/zathura/page-widget.c
@@ -1308,6 +1308,9 @@ void zathura_page_widget_update_view_time(ZathuraPageWidget* widget) {
   if (zathura_page_get_visibility(priv->page) == true) {
     zathura_render_request_update_view_time(priv->render_request);
   }
+  if (priv->surface == NULL) {
+    zathura_render_request(priv->render_request, g_get_real_time());
+  }
 }
 
 bool zathura_page_widget_have_surface(ZathuraPageWidget* widget) {


### PR DESCRIPTION
fixes #864

~~To avoid showing the loading message, this patch just waits 500ms before showing the "Loading..." text. During that wait it just shows a blank page. Since most pages finish rendering well before 500ms, you never see the text during normal scrolling. If a page genuinely takes a long time to render, the text still shows up after half a second~~