### PR TITLE
sandbox improvements

### DIFF
--- a/zathura/landlock.c
+++ b/zathura/landlock.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <errno.h>
 #include <girara/log.h>
 #include <girara/utils.h>
 
@@ -32,21 +33,28 @@ static inline int landlock_restrict_self(const int ruleset_fd, const __u32 flags
 }
 #endif
 
-static void landlock_drop(__u64 fs_access) {
+static int landlock_drop(__u64 fs_access) {
   const struct landlock_ruleset_attr ruleset_attr = {
       .handled_access_fs = fs_access,
   };
 
   int ruleset_fd = landlock_create_ruleset(&ruleset_attr, sizeof(ruleset_attr), 0);
   if (ruleset_fd < 0) {
-    girara_error("Failed to create a landlock ruleset");
-    return;
+    girara_error("landlock_create_ruleset failed: %s", g_strerror(errno));
+    return -1;
   }
-  prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
+  if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0) {
+    girara_error("prctl(PR_SET_NO_NEW_PRIVS) failed: %s", g_strerror(errno));
+    close(ruleset_fd);
+    return -1;
+  }
   if (landlock_restrict_self(ruleset_fd, 0)) {
-    girara_error("landlock_restrict_self");
+    girara_error("landlock_restrict_self failed: %s", g_strerror(errno));
+    close(ruleset_fd);
+    return -1;
   }
   close(ruleset_fd);
+  return 0;
 }
 
 #define _LANDLOCK_ACCESS_FS_WRITE                                                                                      \
@@ -57,67 +65,110 @@ static void landlock_drop(__u64 fs_access) {
 
 #define _LANDLOCK_ACCESS_FS_READ (LANDLOCK_ACCESS_FS_READ_FILE | LANDLOCK_ACCESS_FS_READ_DIR)
 
-static void landlock_check_kernel(void) {
+/* returns 1 if landlock is supported, 0 if not, -1 on unexpected probe error */
+static int landlock_check_kernel(void) {
   int abi = landlock_create_ruleset(NULL, 0, LANDLOCK_CREATE_RULESET_VERSION);
-  if (abi == -1) {
+  if (abi >= 1) {
+    return 1;
+  }
+  if (abi == -1 && (errno == ENOSYS || errno == EOPNOTSUPP)) {
     /*
      * Kernel too old, not compiled with Landlock,
      * or Landlock was not enabled at boot time.
      */
     girara_warning("Unable to use Landlock: Kernel too old, not compiled with Landlock,\
             or Landlock was not enabled at boot time. Sandbox partly disabled.");
-    return; /* Graceful fallback: Do nothing. */
+    return 0; /* Graceful fallback: Do nothing. */
   }
+  girara_warning("Landlock probe failed: %s", g_strerror(errno));
+  return -1;
 }
 
-void landlock_drop_write(void) {
-  landlock_check_kernel();
-  landlock_drop(_LANDLOCK_ACCESS_FS_WRITE | LANDLOCK_ACCESS_FS_EXECUTE);
+int landlock_drop_write(void) {
+  const int kernel = landlock_check_kernel();
+  if (kernel == 0) {
+    return 1; /* unsupported, graceful fallback */
+  }
+  if (kernel < 0) {
+    return -1;
+  }
+  return landlock_drop(_LANDLOCK_ACCESS_FS_WRITE | LANDLOCK_ACCESS_FS_EXECUTE);
 }
 
 #if 0
-static void landlock_drop_all(void) {
-  landlock_drop(_LANDLOCK_ACCESS_FS_READ | _LANDLOCK_ACCESS_FS_WRITE | LANDLOCK_ACCESS_FS_EXECUTE);
+static int landlock_drop_all(void) {
+  return landlock_drop(_LANDLOCK_ACCESS_FS_READ | _LANDLOCK_ACCESS_FS_WRITE | LANDLOCK_ACCESS_FS_EXECUTE);
 }
 #endif
 
-static void landlock_write_fd(const int dir_fd) {
+static int landlock_write_fd(const int dir_fd) {
   const struct landlock_ruleset_attr ruleset_attr = {
       .handled_access_fs = _LANDLOCK_ACCESS_FS_WRITE | LANDLOCK_ACCESS_FS_EXECUTE,
   };
   struct landlock_path_beneath_attr path_beneath = {
       .allowed_access = _LANDLOCK_ACCESS_FS_WRITE,
+      .parent_fd      = -1,
   };
+  int rc              = -1;
+  int parent_fd_owned = 0;
 
   int ruleset_fd = landlock_create_ruleset(&ruleset_attr, sizeof(ruleset_attr), 0);
   if (ruleset_fd < 0) {
-    return;
+    girara_error("landlock_create_ruleset failed: %s", g_strerror(errno));
+    return -1;
   }
   if (dir_fd == -1) {
     path_beneath.parent_fd = open(".", O_PATH | O_CLOEXEC | O_DIRECTORY);
+    if (path_beneath.parent_fd < 0) {
+      girara_error("open(\".\") for landlock path failed: %s", g_strerror(errno));
+      goto out;
+    }
+    parent_fd_owned = 1;
   } else {
     path_beneath.parent_fd = dir_fd;
   }
 
-  if (!landlock_add_rule(ruleset_fd, LANDLOCK_RULE_PATH_BENEATH, &path_beneath, 0)) {
-    prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
-    if (landlock_restrict_self(ruleset_fd, 0)) {
-      girara_error("landlock_restrict_self");
-    }
-  } else {
-    girara_error("landlock_add_rule");
+  if (landlock_add_rule(ruleset_fd, LANDLOCK_RULE_PATH_BENEATH, &path_beneath, 0) != 0) {
+    girara_error("landlock_add_rule failed: %s", g_strerror(errno));
+    goto out;
   }
+  if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0) {
+    girara_error("prctl(PR_SET_NO_NEW_PRIVS) failed: %s", g_strerror(errno));
+    goto out;
+  }
+  if (landlock_restrict_self(ruleset_fd, 0) != 0) {
+    girara_error("landlock_restrict_self failed: %s", g_strerror(errno));
+    goto out;
+  }
+  rc = 0;
 
-  if (dir_fd == -1) {
+out:
+  if (parent_fd_owned && path_beneath.parent_fd >= 0) {
     close(path_beneath.parent_fd);
   }
   close(ruleset_fd);
+  return rc;
 }
 
-void landlock_restrict_write(void) {
-  landlock_check_kernel();
+int landlock_restrict_write(void) {
+  const int kernel = landlock_check_kernel();
+  if (kernel == 0) {
+    return 1;
+  }
+  if (kernel < 0) {
+    return -1;
+  }
   g_autofree char* data_path = girara_get_xdg_path(XDG_DATA);
-  int fd                     = open(data_path, O_PATH | O_CLOEXEC | O_DIRECTORY);
-  landlock_write_fd(fd);
+  if (data_path == NULL) {
+    girara_error("girara_get_xdg_path(XDG_DATA) returned NULL");
+    return -1;
+  }
+  int fd = open(data_path, O_PATH | O_CLOEXEC | O_DIRECTORY);
+  if (fd < 0) {
+    girara_error("open(\"%s\") for landlock failed: %s", data_path, g_strerror(errno));
+    return -1;
+  }
+  const int rc = landlock_write_fd(fd);
   close(fd);
+  return rc;
 }

--- a/zathura/landlock.h
+++ b/zathura/landlock.h
@@ -5,12 +5,16 @@
 
 /*
 ** Remove write and execute permissions
+**
+** returns 0 on success, 1 if landlock is unsupported, -1 on hard failure
 */
-void landlock_drop_write(void);
+int landlock_drop_write(void);
 
 /*
 ** Restrict write permissions to XDG_DATA
+**
+** returns 0 on success, 1 if landlock is unsupported, -1 on hard failure
 */
-void landlock_restrict_write(void);
+int landlock_restrict_write(void);
 
 #endif

--- a/zathura/main-sandbox.c
+++ b/zathura/main-sandbox.c
@@ -45,7 +45,11 @@ static zathura_t* init_zathura(const char* config_dir, const char* data_dir, con
 
   girara_debug("Strict sandbox preventing write and network access.");
 #ifdef WITH_LANDLOCK
-  landlock_drop_write();
+  if (landlock_drop_write() < 0) {
+    girara_error("Failed to apply landlock write restriction.");
+    zathura_free(zathura);
+    return NULL;
+  }
 #endif
 #ifdef WITH_SECCOMP
   if (seccomp_enable_strict_filter(zathura) != 0) {

--- a/zathura/seccomp-filters.c
+++ b/zathura/seccomp-filters.c
@@ -13,6 +13,8 @@
 #include <linux/sched.h> /* for clone filter */
 #include <unistd.h>      /* for fstat */
 #include <sys/mman.h>    /* for mmap/mprotect arguments */
+#include <sys/ioctl.h>   /* for TIOCSTI */
+#include <termios.h>
 
 #ifdef GDK_WINDOWING_X11
 #include <gtk/gtkx.h>
@@ -23,7 +25,7 @@
     girara_debug("adding rule " str_action " to " G_STRINGIFY(call));                                                  \
     const int err = seccomp_rule_add(ctx, action, SCMP_SYS(call), __VA_ARGS__);                                        \
     if (err < 0) {                                                                                                     \
-      girara_error("failed: %s", g_strerror(-err));                                                                    \
+      girara_error("seccomp_rule_add for " G_STRINGIFY(call) " failed: %s", g_strerror(-err));                         \
       goto out;                                                                                                        \
     }                                                                                                                  \
   } while (0)
@@ -35,13 +37,13 @@
 int seccomp_enable_strict_filter(zathura_t* zathura) {
   /* prevent child processes from getting more priv e.g. via setuid, capabilities, ... */
   if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0)) {
-    girara_error("prctl SET_NO_NEW_PRIVS");
+    girara_error("prctl SET_NO_NEW_PRIVS: %s", g_strerror(errno));
     return -1;
   }
 
   /* prevent escape via ptrace */
   if (prctl(PR_SET_DUMPABLE, 0, 0, 0, 0)) {
-    girara_error("prctl PR_SET_DUMPABLE");
+    girara_error("prctl PR_SET_DUMPABLE: %s", g_strerror(errno));
     return -1;
   }
 
@@ -235,6 +237,8 @@ int seccomp_enable_strict_filter(zathura_t* zathura) {
               FD_CLOEXEC )); */
 
   /* Special requirements for ioctl, allowed on stdout/stderr */
+  /* deny TIOCSTI to prevent keystroke injection into the controlling TTY */
+  ADD_RULE("errno", SCMP_ACT_ERRNO(EPERM), ioctl, 1, SCMP_CMP(1, SCMP_CMP_EQ, (scmp_datum_t)TIOCSTI));
   ADD_RULE("allow", SCMP_ACT_ALLOW, ioctl, 1, SCMP_CMP(0, SCMP_CMP_EQ, 1));
   ADD_RULE("allow", SCMP_ACT_ALLOW, ioctl, 1, SCMP_CMP(0, SCMP_CMP_EQ, 2));
 
@@ -320,11 +324,14 @@ int seccomp_enable_strict_filter(zathura_t* zathura) {
   /* otherwise it will try to connect to X11 using inet socket protocol */
 
   /* applying filter... */
-  if (seccomp_load(ctx) >= 0) {
-    /* free ctx after the filter has been loaded into the kernel */
-    seccomp_release(ctx);
-    return 0;
+  const int load_err = seccomp_load(ctx);
+  if (load_err < 0) {
+    girara_error("seccomp_load failed: %s", g_strerror(-load_err));
+    goto out;
   }
+  /* free ctx after the filter has been loaded into the kernel */
+  seccomp_release(ctx);
+  return 0;
 
 out:
   /* something went wrong */


### PR DESCRIPTION
- Improved error handling in seccomp and landlock 
- Block TIOCSTI ioctl to prevent terminal injection when run on the cli
- improve reliability of landlock functions
- When landlock is supported and enabled, it fails hard when landlock_drop_write fails instead of silently continuing