### PR TITLE
feat: keep the highlighting even when falling of the view

### DIFF
--- a/zathura/config.c
+++ b/zathura/config.c
@@ -635,6 +635,8 @@ void config_load_default(zathura_t* zathura) {
   girara_setting_add(gsession, "show-signature-information", &bool_value, BOOLEAN, false,
                      _("Disable additional information for signatures embedded in the document."),
                      cb_show_signature_info, NULL);
+  bool_value = false;
+  girara_setting_add(gsession, "selection-keep-highlight", &bool_value, BOOLEAN, false, _("Keep selection highlighted after mouse release"), NULL, NULL);
 
 
   /* Define mode-less shortcuts

--- a/zathura/page-widget.c
+++ b/zathura/page-widget.c
@@ -986,10 +986,24 @@ static gboolean cb_zathura_page_widget_button_press_event(GtkWidget* widget, Gdk
     return true;
   }
 
-  zathura_page_widget_clear_selection(page);
-
   if (button->button == GDK_BUTTON_PRIMARY) { /* left click */
     if (button->type == GDK_BUTTON_PRESS) {
+      /* clear pages with a selection already */
+      if (priv->zathura != NULL && priv->zathura->pages != NULL) {
+        zathura_document_t* document = zathura_page_get_document(priv->page);
+        if (document != NULL) {
+          unsigned int number_of_pages = zathura_document_get_number_of_pages(document);
+          for (unsigned int i = 0; i < number_of_pages; i++) {
+            ZathuraPageWidget* other_page        = ZATHURA_PAGE_WIDGET(priv->zathura->pages[i]);
+            ZathuraPageWidgetPrivate* other_priv = zathura_page_widget_get_instance_private(other_page);
+
+            if (other_priv->selection.draw == true || other_priv->highlighter.draw == true) {
+              zathura_page_widget_clear_selection(other_page);
+            }
+          }
+        }
+      }
+
       /* start the selection */
       double x, y;
       rotate_point(priv->zathura, zathura_page_get_index(priv->page), button->x, button->y, &x, &y);
@@ -1177,7 +1191,14 @@ static gboolean cb_zathura_page_widget_leave_notify(GtkWidget* widget, GdkEventC
 
   ZathuraPageWidget* page        = ZATHURA_PAGE_WIDGET(widget);
   ZathuraPageWidgetPrivate* priv = zathura_page_widget_get_instance_private(page);
-  zathura_page_widget_clear_selection(page);
+
+  bool keep_selection = false;
+  girara_setting_get(priv->zathura->ui.session, "selection-keep-highlight", &keep_selection);
+
+  if (keep_selection == false) {
+    zathura_page_widget_clear_selection(page);
+  }
+
   if (priv->mouse.over_link == true) {
     g_signal_emit(page, signals[LEAVE_LINK], 0);
     priv->mouse.over_link = false;


### PR DESCRIPTION
[UPDATED] added a `selection-keep-highlight` configuration option

When the cursor leaves the pdf page, the selection gets cleared. However for some (see issue #693 ) this behavior is unwanted. Simply adding the configuration seting  and clearing all highlights on a left click seems to be the logical change to me.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0096912e-b10b-477c-8944-4ceac61cf2f0" />

@sebastinas  feel free to review this code please :) This would be my first contribution so please feel free to educate me where necessary XD

closes #693 