### PR TITLE
add sandbox thread synchronization

### DIFF
--- a/zathura/landlock.c
+++ b/zathura/landlock.c
@@ -33,7 +33,11 @@ static inline int landlock_restrict_self(const int ruleset_fd, const __u32 flags
 }
 #endif
 
-static int landlock_drop(__u64 fs_access) {
+#ifndef LANDLOCK_RESTRICT_SELF_TSYNC
+#define LANDLOCK_RESTRICT_SELF_TSYNC (1U << 3)
+#endif
+
+static int landlock_drop(__u64 fs_access, int abi) {
   const struct landlock_ruleset_attr ruleset_attr = {
       .handled_access_fs = fs_access,
   };
@@ -48,7 +52,12 @@ static int landlock_drop(__u64 fs_access) {
     close(ruleset_fd);
     return -1;
   }
-  if (landlock_restrict_self(ruleset_fd, 0)) {
+  /* TSYNC propagates the landlock domain to all threads of the process; without
+   * it, the domain only applies to the calling thread, leaving worker threads
+   * created during zathura_init (e.g. the renderer pool) outside the sandbox.
+   * Available since landlock ABI v8 (linux 7.0). */
+  const __u32 flags = (abi >= 8) ? LANDLOCK_RESTRICT_SELF_TSYNC : 0;
+  if (landlock_restrict_self(ruleset_fd, flags)) {
     girara_error("landlock_restrict_self failed: %s", g_strerror(errno));
     close(ruleset_fd);
     return -1;
@@ -65,11 +74,11 @@ static int landlock_drop(__u64 fs_access) {
 
 #define _LANDLOCK_ACCESS_FS_READ (LANDLOCK_ACCESS_FS_READ_FILE | LANDLOCK_ACCESS_FS_READ_DIR)
 
-/* returns 1 if landlock is supported, 0 if not, -1 on unexpected probe error */
+/* returns landlock ABI version (>=1) if supported, 0 if not, -1 on unexpected probe error */
 static int landlock_check_kernel(void) {
   int abi = landlock_create_ruleset(NULL, 0, LANDLOCK_CREATE_RULESET_VERSION);
   if (abi >= 1) {
-    return 1;
+    return abi;
   }
   if (abi == -1 && (errno == ENOSYS || errno == EOPNOTSUPP)) {
     /*
@@ -92,7 +101,7 @@ int landlock_drop_write(void) {
   if (kernel < 0) {
     return -1;
   }
-  return landlock_drop(_LANDLOCK_ACCESS_FS_WRITE | LANDLOCK_ACCESS_FS_EXECUTE);
+  return landlock_drop(_LANDLOCK_ACCESS_FS_WRITE | LANDLOCK_ACCESS_FS_EXECUTE, kernel);
 }
 
 #if 0

--- a/zathura/seccomp-filters.c
+++ b/zathura/seccomp-filters.c
@@ -324,6 +324,14 @@ int seccomp_enable_strict_filter(zathura_t* zathura) {
   /* otherwise it will try to connect to X11 using inet socket protocol */
 
   /* applying filter... */
+  /* synchronize the filter across all threads of the process; without this
+   * the filter would only apply to the calling thread, leaving worker
+   * threads created during zathura_init (e.g. the renderer pool) unsandboxed */
+  const int tsync_err = seccomp_attr_set(ctx, SCMP_FLTATR_CTL_TSYNC, 1);
+  if (tsync_err < 0) {
+    girara_error("seccomp_attr_set(TSYNC) failed: %s", g_strerror(-tsync_err));
+    goto out;
+  }
   const int load_err = seccomp_load(ctx);
   if (load_err < 0) {
     girara_error("seccomp_load failed: %s", g_strerror(-load_err));


### PR DESCRIPTION
With SCMP_FLTATR_CTL_TSYNC for seccomp and LANDLOCK_RESTRICT_SELF_TSYNC for landlock (supported since Linux 7.0) the sandbox restrictions can be applied on all threads, even those created before the sandbox was initialized.
This addresses the main concerns that would motivate a multi process architecture and enforces the process isolation on both parser and renderer.