### PR TITLE
fix various bugs and minor issues

### DIFF
--- a/girara-gtk/shortcuts.c
+++ b/girara-gtk/shortcuts.c
@@ -445,7 +445,7 @@ bool girara_sc_feedkeys(girara_session_t* session, girara_argument_t* argument, 
 
       /* possible special button */
       if ((input_length - i) >= 3 && input[i] == '<') {
-        char* end = strchr(input + i, '>');
+        const char* end = strchr(input + i, '>');
         if (end == NULL) {
           goto single_key;
         }

--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@ version = meson.project_version()
 version_array = version.split('.')
 
 # Rules for plugin API and ABI (non-exhaustive):
-# * zathura_plugin_function_t: If functions are addedd or removed or their
+# * zathura_plugin_function_t: If functions are added or removed or their
 #   signature changes, bump both ABI and API.
 # * zathura_plugin_definition_t: If the struct changes in an ABI-incompatible
 #   way, bump the ABI.

--- a/zathura/bookmarks.c
+++ b/zathura/bookmarks.c
@@ -35,10 +35,8 @@ zathura_bookmark_t* zathura_bookmark_add(zathura_t* zathura, const gchar* id, un
 
     const char* path = zathura_document_get_path(document);
     if (zathura_db_remove_bookmark(zathura->database, path, old->id) == false) {
-      girara_warning("Failed to remove old bookmark from database.");
-    }
-
-    if (zathura_db_add_bookmark(zathura->database, path, old) == false) {
+      girara_warning("Failed to remove old bookmark; skipping re-add to avoid duplicate.");
+    } else if (zathura_db_add_bookmark(zathura->database, path, old) == false) {
       girara_warning("Failed to add new bookmark to database.");
     }
 

--- a/zathura/bookmarks.c
+++ b/zathura/bookmarks.c
@@ -35,8 +35,10 @@ zathura_bookmark_t* zathura_bookmark_add(zathura_t* zathura, const gchar* id, un
 
     const char* path = zathura_document_get_path(document);
     if (zathura_db_remove_bookmark(zathura->database, path, old->id) == false) {
-      girara_warning("Failed to remove old bookmark; skipping re-add to avoid duplicate.");
-    } else if (zathura_db_add_bookmark(zathura->database, path, old) == false) {
+      girara_warning("Failed to remove old bookmark from database.");
+    }
+
+    if (zathura_db_add_bookmark(zathura->database, path, old) == false) {
       girara_warning("Failed to add new bookmark to database.");
     }
 

--- a/zathura/callbacks.c
+++ b/zathura/callbacks.c
@@ -471,16 +471,13 @@ void cb_file_monitor(ZathuraFileMonitor* monitor, girara_session_t* session) {
   g_main_context_invoke(NULL, file_monitor_reload, session);
 }
 
-static void cb_password_dialog_hide(GtkWidget* UNUSED(w), void* data);
-
 static void password_dialog_info_free(zathura_password_dialog_info_t* dialog) {
   if (dialog == NULL) {
     return;
   }
-  if (dialog->zathura != NULL && dialog->zathura->ui.session != NULL &&
-      dialog->zathura->ui.session->gtk.inputbar_dialog != NULL) {
-    g_signal_handlers_disconnect_by_func(dialog->zathura->ui.session->gtk.inputbar_dialog, cb_password_dialog_hide,
-                                         dialog);
+  if (dialog->hide_handler != 0) {
+    g_signal_handler_disconnect(dialog->zathura->ui.session->gtk.inputbar_dialog, dialog->hide_handler);
+    dialog->hide_handler = 0;
   }
   g_free(dialog->path);
   g_free(dialog->uri);
@@ -497,8 +494,8 @@ void password_dialog_arm_hide(void* data) {
       dialog->zathura->ui.session->gtk.inputbar_dialog == NULL) {
     return;
   }
-  g_signal_connect(dialog->zathura->ui.session->gtk.inputbar_dialog, "hide", G_CALLBACK(cb_password_dialog_hide),
-                   dialog);
+  dialog->hide_handler = g_signal_connect(dialog->zathura->ui.session->gtk.inputbar_dialog, "hide",
+                                          G_CALLBACK(cb_password_dialog_hide), dialog);
 }
 
 static gboolean password_dialog(gpointer data) {
@@ -520,9 +517,10 @@ gboolean cb_password_dialog(GtkEntry* entry, void* data) {
     return false;
   }
 
-  /* Disconnect hide so a respawn doesn't trigger a free of dialog. */
-  g_signal_handlers_disconnect_by_func(dialog->zathura->ui.session->gtk.inputbar_dialog, cb_password_dialog_hide,
-                                       dialog);
+  if (dialog->hide_handler != 0) {
+    g_signal_handler_disconnect(dialog->zathura->ui.session->gtk.inputbar_dialog, dialog->hide_handler);
+    dialog->hide_handler = 0;
+  }
 
   g_autofree char* input = gtk_editable_get_chars(GTK_EDITABLE(entry), 0, -1);
 

--- a/zathura/callbacks.c
+++ b/zathura/callbacks.c
@@ -44,7 +44,7 @@ void cb_buffer_changed(girara_session_t* session) {
   char* buffer = girara_buffer_get(session);
   if (buffer != NULL) {
     girara_statusbar_item_set_text(session, zathura->ui.statusbar.buffer, buffer);
-    free(buffer);
+    g_free(buffer);
   } else {
     girara_statusbar_item_set_text(session, zathura->ui.statusbar.buffer, "");
   }
@@ -302,13 +302,13 @@ void cb_page_layout_value_changed(girara_session_t* session, const char* name, g
   g_return_if_fail(session->global.data != NULL);
   zathura_t* zathura = session->global.data;
 
-  /* pages-per-row must not be 0 */
+  /* pages-per-row is INT; reject non-positive to prevent uint reinterpret. */
   if (g_strcmp0(name, "pages-per-row") == 0) {
     unsigned int pages_per_row = *((const unsigned int*)value);
-    if (pages_per_row == 0) {
+    if ((int)pages_per_row <= 0) {
       pages_per_row = 1;
       girara_setting_set(session, name, &pages_per_row);
-      girara_notify(session, GIRARA_WARNING, _("'%s' must not be 0. Set to 1."), name);
+      girara_notify(session, GIRARA_WARNING, _("'%s' must be > 0. Set to 1."), name);
       return;
     }
   }
@@ -471,10 +471,41 @@ void cb_file_monitor(ZathuraFileMonitor* monitor, girara_session_t* session) {
   g_main_context_invoke(NULL, file_monitor_reload, session);
 }
 
+static void cb_password_dialog_hide(GtkWidget* UNUSED(w), void* data);
+
+static void password_dialog_info_free(zathura_password_dialog_info_t* dialog) {
+  if (dialog == NULL) {
+    return;
+  }
+  if (dialog->zathura != NULL && dialog->zathura->ui.session != NULL &&
+      dialog->zathura->ui.session->gtk.inputbar_dialog != NULL) {
+    g_signal_handlers_disconnect_by_func(dialog->zathura->ui.session->gtk.inputbar_dialog, cb_password_dialog_hide,
+                                         dialog);
+  }
+  g_free(dialog->path);
+  g_free(dialog->uri);
+  g_free(dialog);
+}
+
+static void cb_password_dialog_hide(GtkWidget* UNUSED(w), void* data) {
+  password_dialog_info_free(data);
+}
+
+void password_dialog_arm_hide(void* data) {
+  zathura_password_dialog_info_t* dialog = data;
+  if (dialog == NULL || dialog->zathura == NULL || dialog->zathura->ui.session == NULL ||
+      dialog->zathura->ui.session->gtk.inputbar_dialog == NULL) {
+    return;
+  }
+  g_signal_connect(dialog->zathura->ui.session->gtk.inputbar_dialog, "hide", G_CALLBACK(cb_password_dialog_hide),
+                   dialog);
+}
+
 static gboolean password_dialog(gpointer data) {
   zathura_password_dialog_info_t* dialog = data;
 
   if (dialog != NULL) {
+    password_dialog_arm_hide(dialog);
     girara_dialog(dialog->zathura->ui.session, "Incorrect password. Enter password:", true, NULL, cb_password_dialog,
                   dialog);
   }
@@ -483,20 +514,20 @@ static gboolean password_dialog(gpointer data) {
 }
 
 gboolean cb_password_dialog(GtkEntry* entry, void* data) {
-  if (entry == NULL || data == NULL) {
-    goto error_ret;
-  }
-
   zathura_password_dialog_info_t* dialog = data;
-  if (dialog->path == NULL || dialog->zathura == NULL) {
-    goto error_free;
+  if (entry == NULL || dialog == NULL || dialog->path == NULL || dialog->zathura == NULL) {
+    password_dialog_info_free(dialog);
+    return false;
   }
 
-  char* input = gtk_editable_get_chars(GTK_EDITABLE(entry), 0, -1);
+  /* Disconnect hide so a respawn doesn't trigger a free of dialog. */
+  g_signal_handlers_disconnect_by_func(dialog->zathura->ui.session->gtk.inputbar_dialog, cb_password_dialog_hide,
+                                       dialog);
+
+  g_autofree char* input = gtk_editable_get_chars(GTK_EDITABLE(entry), 0, -1);
 
   /* no or empty password: ask again */
   if (input == NULL || strlen(input) == 0) {
-    g_free(input);
     gdk_threads_add_idle(password_dialog, dialog);
     return false;
   }
@@ -506,20 +537,10 @@ gboolean cb_password_dialog(GtkEntry* entry, void* data) {
       false) {
     gdk_threads_add_idle(password_dialog, dialog);
   } else {
-    g_free(dialog->path);
-    g_free(dialog->uri);
-    g_free(dialog);
+    password_dialog_info_free(dialog);
   }
-  g_free(input);
 
   return true;
-
-error_free:
-  g_free(dialog->path);
-  g_free(dialog);
-
-error_ret:
-  return false;
 }
 
 void cb_setting_recolor_change(girara_session_t* session, const char* name, girara_setting_type_t UNUSED(type),

--- a/zathura/callbacks.c
+++ b/zathura/callbacks.c
@@ -301,13 +301,13 @@ void cb_page_layout_value_changed(girara_session_t* session, const char* name, g
   g_return_if_fail(session->global.data != NULL);
   zathura_t* zathura = session->global.data;
 
-  /* pages-per-row is INT; reject non-positive to prevent uint reinterpret. */
+  /* pages-per-row must not be 0 */
   if (g_strcmp0(name, "pages-per-row") == 0) {
     unsigned int pages_per_row = *((const unsigned int*)value);
-    if ((int)pages_per_row <= 0) {
+    if (pages_per_row == 0) {
       pages_per_row = 1;
       girara_setting_set(session, name, &pages_per_row);
-      girara_notify(session, GIRARA_WARNING, _("'%s' must be > 0. Set to 1."), name);
+      girara_notify(session, GIRARA_WARNING, _("'%s' must not be 0. Set to 1."), name);
       return;
     }
   }
@@ -487,14 +487,21 @@ static void cb_password_dialog_hide(GtkWidget* UNUSED(w), void* data) {
   password_dialog_info_free(data);
 }
 
-void password_dialog_arm_hide(void* data) {
-  zathura_password_dialog_info_t* dialog = data;
+static void password_dialog_arm_hide(zathura_password_dialog_info_t* dialog) {
   if (dialog == NULL || dialog->zathura == NULL || dialog->zathura->ui.session == NULL ||
       dialog->zathura->ui.session->gtk.inputbar_dialog == NULL) {
     return;
   }
   dialog->hide_handler = g_signal_connect(dialog->zathura->ui.session->gtk.inputbar_dialog, "hide",
                                           G_CALLBACK(cb_password_dialog_hide), dialog);
+}
+
+gboolean document_open_password_dialog(gpointer data) {
+  zathura_password_dialog_info_t* dialog = data;
+
+  password_dialog_arm_hide(dialog);
+  girara_dialog(dialog->zathura->ui.session, _("Enter password:"), true, NULL, cb_password_dialog, dialog);
+  return FALSE;
 }
 
 static gboolean password_dialog(gpointer data) {

--- a/zathura/callbacks.c
+++ b/zathura/callbacks.c
@@ -41,10 +41,9 @@ void cb_buffer_changed(girara_session_t* session) {
 
   zathura_t* zathura = session->global.data;
 
-  char* buffer = girara_buffer_get(session);
+  g_autofree char* buffer = girara_buffer_get(session);
   if (buffer != NULL) {
     girara_statusbar_item_set_text(session, zathura->ui.statusbar.buffer, buffer);
-    g_free(buffer);
   } else {
     girara_statusbar_item_set_text(session, zathura->ui.statusbar.buffer, "");
   }

--- a/zathura/callbacks.h
+++ b/zathura/callbacks.h
@@ -199,6 +199,8 @@ void cb_file_monitor(ZathuraFileMonitor* monitor, girara_session_t* session);
  */
 gboolean cb_password_dialog(GtkEntry* entry, void* dialog);
 
+void password_dialog_arm_hide(void* dialog);
+
 /**
  * Emitted when the 'recolor' setting is changed
  *

--- a/zathura/callbacks.h
+++ b/zathura/callbacks.h
@@ -199,7 +199,7 @@ void cb_file_monitor(ZathuraFileMonitor* monitor, girara_session_t* session);
  */
 gboolean cb_password_dialog(GtkEntry* entry, void* dialog);
 
-void password_dialog_arm_hide(void* dialog);
+gboolean document_open_password_dialog(gpointer data);
 
 /**
  * Emitted when the 'recolor' setting is changed

--- a/zathura/commands.c
+++ b/zathura/commands.c
@@ -510,8 +510,8 @@ bool cmd_export(girara_session_t* session, girara_list_t* argument_list) {
     return false;
   }
 
-  static const size_t attachment_len = 11; // length of attachment-
-  static const size_t image_len      = 7;  // length of image-p
+  static const size_t attachment_len = sizeof("attachment-") - 1;
+  static const size_t image_len      = sizeof("image-p") - 1;
 
   /* attachment */
   if (strncmp(file_identifier, "attachment-", attachment_len) == 0) {
@@ -567,6 +567,7 @@ bool cmd_export(girara_session_t* session, girara_list_t* argument_list) {
       girara_notify(session, GIRARA_ERROR, _("Couldn't write image '%s' to '%s'."), file_identifier, file_name);
     }
 
+    cairo_surface_destroy(surface);
     return true;
 
   image_error:

--- a/zathura/content-type.c
+++ b/zathura/content-type.c
@@ -21,7 +21,7 @@ zathura_content_type_context_t* zathura_content_type_new(void) {
     return NULL;
   }
 
-  /* creat magic cookie */
+  /* create magic cookie */
   static const int flags = MAGIC_ERROR | MAGIC_MIME_TYPE | MAGIC_SYMLINK | MAGIC_NO_CHECK_APPTYPE | MAGIC_NO_CHECK_CDF |
                            MAGIC_NO_CHECK_ELF | MAGIC_NO_CHECK_ENCODING;
   magic_t magic = magic_open(flags);

--- a/zathura/database-sqlite.c
+++ b/zathura/database-sqlite.c
@@ -337,9 +337,7 @@ static void sqlite_db_check_layout(sqlite3* session, const int database_version,
     }
   }
   if (database_version < 2) {
-    bool has_sha = false;
-    if (check_column(session, "fileinfo", "sha256", &has_sha) == false ||
-        (has_sha == false && sqlite3_exec(session, SQL_FILEINFO_ALTER6, NULL, 0, NULL) != SQLITE_OK)) {
+    if (sqlite3_exec(session, SQL_FILEINFO_ALTER6, NULL, 0, NULL) != SQLITE_OK) {
       girara_warning("failed to update database table layout: sha256");
       all_updates_ok = false;
     }

--- a/zathura/database-sqlite.c
+++ b/zathura/database-sqlite.c
@@ -104,6 +104,7 @@ static bool check_column(sqlite3* session, const char* table, const char* col, b
 
   sqlite3_stmt* stmt = prepare_statement(session, query);
   if (stmt == NULL) {
+    sqlite3_free(query);
     return false;
   }
 
@@ -136,6 +137,7 @@ static bool check_column_type(sqlite3* session, const char* table, const char* c
 
   sqlite3_stmt* stmt = prepare_statement(session, query);
   if (stmt == NULL) {
+    sqlite3_free(query);
     return false;
   }
 
@@ -306,7 +308,7 @@ static void sqlite_db_check_layout(sqlite3* session, const int database_version,
 
     if (ret1 == true && res1 == false) {
       if (sqlite3_exec(session, SQL_BOOKMARK_ALTER, NULL, 0, NULL) != SQLITE_OK) {
-        girara_warning("failed to update database table layout: hadj_ration, vadj_ratio");
+        girara_warning("failed to update database table layout: hadj_ratio, vadj_ratio");
         all_updates_ok = false;
       }
     }
@@ -335,7 +337,9 @@ static void sqlite_db_check_layout(sqlite3* session, const int database_version,
     }
   }
   if (database_version < 2) {
-    if (sqlite3_exec(session, SQL_FILEINFO_ALTER6, NULL, 0, NULL) != SQLITE_OK) {
+    bool has_sha = false;
+    if (check_column(session, "fileinfo", "sha256", &has_sha) == false ||
+        (has_sha == false && sqlite3_exec(session, SQL_FILEINFO_ALTER6, NULL, 0, NULL) != SQLITE_OK)) {
       girara_warning("failed to update database table layout: sha256");
       all_updates_ok = false;
     }

--- a/zathura/dbus-interface.c
+++ b/zathura/dbus-interface.c
@@ -238,11 +238,10 @@ typedef struct {
 static gboolean synctex_highlight_rects_impl(gpointer ptr) {
   highlights_rect_data_t* data = ptr;
 
+  /* synctex_highlight_rects transfers ownership of each rectangles[i] to the
+   * page widget via g_object_set "search-results"; only free the array. */
   synctex_highlight_rects(data->zathura, data->page, data->rectangles);
 
-  for (unsigned int i = 0; i != data->number_of_pages; ++i) {
-    girara_list_free(data->rectangles[i]);
-  }
   g_free(data->rectangles);
   g_free(data);
   return false;
@@ -258,10 +257,10 @@ static void synctex_highlight_rects_idle(zathura_t* zathura, girara_list_t** rec
     g_free(rectangles);
     return;
   }
-  data->zathura                = zathura;
-  data->rectangles             = rectangles;
-  data->page                   = page;
-  data->number_of_pages        = number_of_pages;
+  data->zathura         = zathura;
+  data->rectangles      = rectangles;
+  data->page            = page;
+  data->number_of_pages = number_of_pages;
 
   gdk_threads_add_idle(synctex_highlight_rects_impl, data);
 }
@@ -372,10 +371,10 @@ static void synctex_view_idle(zathura_t* zathura, gchar* input_file, unsigned in
     g_free(input_file);
     return;
   }
-  data->zathura     = zathura;
-  data->input_file  = input_file;
-  data->line        = line;
-  data->column      = column;
+  data->zathura    = zathura;
+  data->input_file = input_file;
+  data->line       = line;
+  data->column     = column;
 
   gdk_threads_add_idle(synctex_view_impl, data);
 }

--- a/zathura/dbus-interface.c
+++ b/zathura/dbus-interface.c
@@ -251,6 +251,13 @@ static gboolean synctex_highlight_rects_impl(gpointer ptr) {
 static void synctex_highlight_rects_idle(zathura_t* zathura, girara_list_t** rectangles, unsigned int page,
                                          unsigned number_of_pages) {
   highlights_rect_data_t* data = g_try_malloc0(sizeof(highlights_rect_data_t));
+  if (data == NULL) {
+    for (unsigned int i = 0; i != number_of_pages; ++i) {
+      girara_list_free(rectangles[i]);
+    }
+    g_free(rectangles);
+    return;
+  }
   data->zathura                = zathura;
   data->rectangles             = rectangles;
   data->page                   = page;
@@ -361,6 +368,10 @@ static gboolean synctex_view_impl(gpointer ptr) {
 
 static void synctex_view_idle(zathura_t* zathura, gchar* input_file, unsigned int line, unsigned int column) {
   view_data_t* data = g_try_malloc0(sizeof(view_data_t));
+  if (data == NULL) {
+    g_free(input_file);
+    return;
+  }
   data->zathura     = zathura;
   data->input_file  = input_file;
   data->line        = line;

--- a/zathura/document-widget.c
+++ b/zathura/document-widget.c
@@ -491,8 +491,18 @@ void zathura_document_widget_refresh_layout(ZathuraDocumentWidget* document) {
   const unsigned int npag = zathura_document_get_number_of_pages(z_document);
   const unsigned int nrow = (npag + c0 - 1 + ncol - 1) / ncol;
 
-  priv->col_widths  = g_try_realloc_n(priv->col_widths, ncol, sizeof(document_widget_line_s));
-  priv->row_heights = g_try_realloc_n(priv->row_heights, nrow, sizeof(document_widget_line_s));
+  document_widget_line_s* tmp = g_try_realloc_n(priv->col_widths, ncol, sizeof(document_widget_line_s));
+  if (tmp == NULL) {
+    girara_error("Failed to allocate document grid (%u columns, %u rows)", ncol, nrow);
+    return;
+  }
+  priv->col_widths = tmp;
+  tmp              = g_try_realloc_n(priv->row_heights, nrow, sizeof(document_widget_line_s));
+  if (tmp == NULL) {
+    girara_error("Failed to allocate document grid (%u columns, %u rows)", ncol, nrow);
+    return;
+  }
+  priv->row_heights = tmp;
 
   priv->ncol = ncol;
   priv->nrow = nrow;

--- a/zathura/document.c
+++ b/zathura/document.c
@@ -135,7 +135,9 @@ zathura_document_t* zathura_document_open(zathura_t* zathura, const char* path, 
     g_autoptr(GFile) gf = g_file_new_for_uri(document->uri);
     document->basename  = g_file_get_basename(gf);
   }
-  hash_file_sha256(document->hash_sha256, document->file_path);
+  if (hash_file_sha256(document->hash_sha256, document->file_path) == false) {
+    girara_warning("Failed to hash file '%s'; fileinfo lookup may be unreliable.", document->file_path);
+  }
   document->password         = password;
   document->zoom             = 1.0;
   document->plugin           = plugin;

--- a/zathura/internal.h
+++ b/zathura/internal.h
@@ -10,9 +10,10 @@
  * Zathura password dialog
  */
 typedef struct zathura_password_dialog_info_s {
-  char* path;         /**< Path to the file */
-  char* uri;          /**< URI to the file */
-  zathura_t* zathura; /**< Zathura session */
+  char* path;          /**< Path to the file */
+  char* uri;           /**< URI to the file */
+  zathura_t* zathura;  /**< Zathura session */
+  gulong hide_handler; /**< id of inputbar "hide" handler, 0 if none */
 } zathura_password_dialog_info_t;
 
 struct zathura_document_information_entry_s {

--- a/zathura/jumplist.c
+++ b/zathura/jumplist.c
@@ -164,7 +164,7 @@ void zathura_jumplist_init(zathura_t* zathura, size_t max_size) {
   zathura->jumplist.cur      = NULL;
 }
 
-bool zathura_jumplist_is_initalized(zathura_t* zathura) {
+bool zathura_jumplist_is_initialized(zathura_t* zathura) {
   return zathura->jumplist.list != NULL;
 }
 

--- a/zathura/jumplist.h
+++ b/zathura/jumplist.h
@@ -92,11 +92,11 @@ bool zathura_jumplist_load(zathura_t* zathura, const char* file);
 void zathura_jumplist_init(zathura_t* zathura, size_t max_size);
 
 /**
- * Check if the jumplist is initalized
+ * Check if the jumplist is initialized
  *
  * @param zathura The zathura session
  */
-bool zathura_jumplist_is_initalized(zathura_t* zathura);
+bool zathura_jumplist_is_initialized(zathura_t* zathura);
 
 /**
  * Clear jumplist

--- a/zathura/links.c
+++ b/zathura/links.c
@@ -283,8 +283,8 @@ static gboolean link_confirm_spawn(void* data) {
   g_autofree gchar* escaped = g_markup_escape_text(ctx->value, -1);
   g_autofree gchar* prompt  = g_strdup_printf(_("Open external link <b>%s</b>? [Y/n]"), escaped);
 
-  ctx->hide_handler = g_signal_connect(ctx->zathura->ui.session->gtk.inputbar_dialog, "hide",
-                                       G_CALLBACK(cb_link_confirm_hide), ctx);
+  ctx->hide_handler =
+      g_signal_connect(ctx->zathura->ui.session->gtk.inputbar_dialog, "hide", G_CALLBACK(cb_link_confirm_hide), ctx);
   girara_dialog(ctx->zathura->ui.session, prompt, false, NULL, cb_link_confirm, ctx);
   return FALSE;
 }

--- a/zathura/links.c
+++ b/zathura/links.c
@@ -220,11 +220,19 @@ typedef struct {
   char* value; /**< Owned copy of the link target */
 } link_confirm_data_t;
 
+static void cb_link_confirm_hide(GtkWidget* UNUSED(w), void* data);
+
 static void link_confirm_data_free(link_confirm_data_t* data) {
-  if (data != NULL) {
-    g_free(data->value);
-    g_free(data);
+  if (data == NULL) {
+    return;
   }
+  g_signal_handlers_disconnect_by_func(data->zathura->ui.session->gtk.inputbar_dialog, cb_link_confirm_hide, data);
+  g_free(data->value);
+  g_free(data);
+}
+
+static void cb_link_confirm_hide(GtkWidget* UNUSED(w), void* data) {
+  link_confirm_data_free(data);
 }
 
 /**
@@ -274,6 +282,7 @@ static gboolean link_confirm_spawn(void* data) {
   g_autofree gchar* escaped = g_markup_escape_text(ctx->value, -1);
   g_autofree gchar* prompt  = g_strdup_printf(_("Open external link <b>%s</b>? [Y/n]"), escaped);
 
+  g_signal_connect(ctx->zathura->ui.session->gtk.inputbar_dialog, "hide", G_CALLBACK(cb_link_confirm_hide), ctx);
   girara_dialog(ctx->zathura->ui.session, prompt, false, NULL, cb_link_confirm, ctx);
   return FALSE;
 }

--- a/zathura/links.c
+++ b/zathura/links.c
@@ -217,16 +217,17 @@ static void link_launch(zathura_t* zathura, const char* link) {
 typedef struct {
   zathura_t* zathura;
   zathura_link_type_t type;
-  char* value; /**< Owned copy of the link target */
+  char* value;         /**< Owned copy of the link target */
+  gulong hide_handler; /**< id of inputbar "hide" handler, 0 if none */
 } link_confirm_data_t;
-
-static void cb_link_confirm_hide(GtkWidget* UNUSED(w), void* data);
 
 static void link_confirm_data_free(link_confirm_data_t* data) {
   if (data == NULL) {
     return;
   }
-  g_signal_handlers_disconnect_by_func(data->zathura->ui.session->gtk.inputbar_dialog, cb_link_confirm_hide, data);
+  if (data->hide_handler != 0) {
+    g_signal_handler_disconnect(data->zathura->ui.session->gtk.inputbar_dialog, data->hide_handler);
+  }
   g_free(data->value);
   g_free(data);
 }
@@ -282,7 +283,8 @@ static gboolean link_confirm_spawn(void* data) {
   g_autofree gchar* escaped = g_markup_escape_text(ctx->value, -1);
   g_autofree gchar* prompt  = g_strdup_printf(_("Open external link <b>%s</b>? [Y/n]"), escaped);
 
-  g_signal_connect(ctx->zathura->ui.session->gtk.inputbar_dialog, "hide", G_CALLBACK(cb_link_confirm_hide), ctx);
+  ctx->hide_handler = g_signal_connect(ctx->zathura->ui.session->gtk.inputbar_dialog, "hide",
+                                       G_CALLBACK(cb_link_confirm_hide), ctx);
   girara_dialog(ctx->zathura->ui.session, prompt, false, NULL, cb_link_confirm, ctx);
   return FALSE;
 }

--- a/zathura/marks.c
+++ b/zathura/marks.c
@@ -113,7 +113,7 @@ bool cmd_marks_add(girara_session_t* session, girara_list_t* argument_list) {
 
   mark_add(zathura, key);
 
-  return false;
+  return true;
 }
 
 bool cmd_marks_delete(girara_session_t* session, girara_list_t* argument_list) {

--- a/zathura/page-widget.c
+++ b/zathura/page-widget.c
@@ -272,6 +272,7 @@ static void zathura_page_widget_finalize(GObject* object) {
   cairo_surface_destroy(priv->thumbnail);
   girara_list_free(priv->search.list);
   girara_list_free(priv->links.list);
+  girara_list_free(priv->signatures.list);
 
   G_OBJECT_CLASS(zathura_page_widget_parent_class)->finalize(object);
 }

--- a/zathura/page-widget.c
+++ b/zathura/page-widget.c
@@ -395,8 +395,8 @@ static void zathura_page_widget_set_property(GObject* object, guint prop_id, con
   case PROP_SEARCH_RESULTS:
     if (priv->search.list != NULL && priv->search.draw) {
       redraw_all_rects(pageview, priv->search.list);
-      girara_list_free(priv->search.list);
     }
+    girara_list_free(priv->search.list);
     priv->search.list = g_value_get_pointer(value);
     if (priv->search.list != NULL && priv->search.draw) {
       priv->links.draw = FALSE;
@@ -1266,8 +1266,10 @@ static void cb_menu_image_copy(GtkMenuItem* item, ZathuraPageWidget* page) {
   const int height = cairo_image_surface_get_height(surface);
 
   GdkPixbuf* pixbuf = gdk_pixbuf_get_from_surface(surface, 0, 0, width, height);
-  g_signal_emit(page, signals[IMAGE_SELECTED], 0, pixbuf);
-  g_object_unref(pixbuf);
+  if (pixbuf != NULL) {
+    g_signal_emit(page, signals[IMAGE_SELECTED], 0, pixbuf);
+    g_object_unref(pixbuf);
+  }
   cairo_surface_destroy(surface);
 
   /* reset */

--- a/zathura/page.c
+++ b/zathura/page.c
@@ -71,8 +71,9 @@ zathura_page_t* zathura_page_new(zathura_document_t* document, unsigned int inde
     }
 
     if (page->label != NULL) {
-      g_autofree char* page_number_string = g_strdup_printf("%u", index + 1);
-      page->label_is_number               = strcmp(page->label, page_number_string) == 0;
+      char page_number_string[G_ASCII_DTOSTR_BUF_SIZE];
+      g_ascii_dtostr(page_number_string, G_ASCII_DTOSTR_BUF_SIZE, index + 1);
+      page->label_is_number = strcmp(page->label, page_number_string) == 0;
     }
   }
 

--- a/zathura/page.c
+++ b/zathura/page.c
@@ -71,9 +71,8 @@ zathura_page_t* zathura_page_new(zathura_document_t* document, unsigned int inde
     }
 
     if (page->label != NULL) {
-      char page_number_string[G_ASCII_DTOSTR_BUF_SIZE];
-      g_ascii_dtostr(page_number_string, G_ASCII_DTOSTR_BUF_SIZE, index + 1);
-      page->label_is_number = strcmp(page->label, page_number_string) == 0;
+      g_autofree char* page_number_string = g_strdup_printf("%u", index + 1);
+      page->label_is_number               = strcmp(page->label, page_number_string) == 0;
     }
   }
 

--- a/zathura/plugin.h
+++ b/zathura/plugin.h
@@ -28,10 +28,10 @@ void zathura_plugin_manager_free(zathura_plugin_manager_t* plugin_manager);
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(zathura_plugin_manager_t, zathura_plugin_manager_free)
 
 /**
- * Add colon-seperated list of directories to the plugin manager's plugin search path
+ * Add colon-separated list of directories to the plugin manager's plugin search path
  *
  * @param plugin_manager  The plain manager
- * @param dir Colon-seperated list of directories
+ * @param dir Colon-separated list of directories
  */
 void zathura_plugin_manager_set_dir(zathura_plugin_manager_t* plugin_manager, const char* dir);
 

--- a/zathura/print.c
+++ b/zathura/print.c
@@ -36,14 +36,13 @@ static bool draw_page_image(cairo_t* cairo, GtkPrintContext* context, zathura_t*
   const double width  = gtk_print_context_get_width(context);
   const double height = gtk_print_context_get_height(context);
 
-  const double scale_height = 5;
-  const double scale_width  = 5;
-
-  /* Render to a surface that is 5 times larger to workaround quality issues. */
-  const double page_height = zathura_page_get_height(page) * scale_height;
-  const double page_width  = zathura_page_get_width(page) * scale_width;
+  /* Render to a surface up to 5x larger; clamp to cairo's 32767 px limit. */
+  const double page_height = MIN(32767.0, zathura_page_get_height(page) * 5.0);
+  const double page_width  = MIN(32767.0, zathura_page_get_width(page) * 5.0);
   cairo_surface_t* surface = cairo_image_surface_create(CAIRO_FORMAT_RGB24, page_width, page_height);
   if (cairo_surface_status(surface) != CAIRO_STATUS_SUCCESS) {
+    girara_warning("Failed to allocate %dx%d cairo surface for printing.", (int)page_width, (int)page_height);
+    cairo_surface_destroy(surface);
     return false;
   }
 
@@ -92,7 +91,7 @@ static void cb_print_draw_page(GtkPrintOperation* print_operation, GtkPrintConte
   }
 
   /* Update statusbar. */
-  g_autofree char* tmp = g_strdup_printf(_("Printing page %d ..."), page_number);
+  g_autofree char* tmp = g_strdup_printf(_("Printing page %d ..."), page_number + 1);
   girara_statusbar_item_set_text(zathura->ui.session, zathura->ui.statusbar.file, tmp);
 
   /* Get the page and cairo handle.  */

--- a/zathura/render.c
+++ b/zathura/render.c
@@ -73,7 +73,7 @@ static ssize_t page_cache_lru_invalidate(ZathuraRenderer* renderer);
 static void page_cache_invalidate_all(ZathuraRenderer* renderer);
 static bool page_cache_is_full(ZathuraRenderer* renderer, bool* result);
 
-/* job descritption for render thread */
+/* job description for render thread */
 typedef struct render_job_s {
   ZathuraRenderRequest* request;
   atomic_bool aborted;
@@ -729,7 +729,7 @@ static void recolor(ZathuraRendererPrivate* priv, zathura_page_t* page, unsigned
     g_autoptr(girara_list_t) images = zathura_page_images_get(page, NULL);
     found_images                    = (images != NULL);
 
-    rectangles = girara_list_new();
+    rectangles = girara_list_new_with_free(g_free);
     if (rectangles == NULL) {
       found_images = false;
       girara_warning("Failed to retrieve images.");

--- a/zathura/seccomp-filters.c
+++ b/zathura/seccomp-filters.c
@@ -251,11 +251,11 @@ int seccomp_enable_strict_filter(zathura_t* zathura) {
   ADD_RULE("allow", SCMP_ACT_ALLOW, prctl, 1, SCMP_CMP(0, SCMP_CMP_EQ, PR_SET_PDEATHSIG));
 
   /* This wont work yet, because PROT_EXEC is used after seccomp is called - fix by second filter? */
-  /* Prevent the creation of executeable memory */
+  /* Prevent the creation of executable memory */
   /* ADD_RULE("allow", SCMP_ACT_ALLOW, mmap, 1,  SCMP_CMP(2, SCMP_CMP_MASKED_EQ, PROT_READ | PROT_WRITE |
               PROT_NONE, PROT_READ | PROT_WRITE | PROT_NONE)); */
 
-  /* Prevent the creation of executeable memory - required by some files */
+  /* Prevent the creation of executable memory - required by some files */
   /*ADD_RULE("allow", SCMP_ACT_ALLOW, mprotect, 1,
    *         SCMP_CMP(2, SCMP_CMP_MASKED_EQ, PROT_READ | PROT_WRITE | PROT_NONE, PROT_READ | PROT_WRITE | PROT_NONE));
    */
@@ -274,7 +274,7 @@ int seccomp_enable_strict_filter(zathura_t* zathura) {
   /* Gracefully fail syscalls that may be used by dependencies in the future
      These rules will still block the syscalls but since there usually is fallback code
      for new syscalls, it will not shut down zathura and give us more time to
-     analyse the newly required syscall before potentionally allowing it.
+     analyse the newly required syscall before potentially allowing it.
   */
 
   ERRNO_RULE(openat2);
@@ -337,7 +337,7 @@ int seccomp_enable_strict_filter(zathura_t* zathura) {
    * Apply second filter after the file has been opened but before it is parsed
    * This may allow the removal of additional syscalls
    * Additional restrictions of commands such as open may be required since it won't allow opening new files
-   * Note: during rendering zathura still openes fonts, which makes this infeasible
+   * Note: during rendering zathura still opens fonts, which makes this infeasible
    * - a second landlock filter would be an alternative solution to restrict read access to /usr/share/fonts only.
    *
    * Alternative sandbox approach:

--- a/zathura/shortcuts.c
+++ b/zathura/shortcuts.c
@@ -950,10 +950,12 @@ bool sc_navigate_index(girara_session_t* session, girara_argument_t* argument, g
     return false;
   }
 
-  GtkTreeView* tree_view = gtk_container_get_children(GTK_CONTAINER(zathura->ui.index))->data;
-  GtkTreePath* path;
-  GtkTreePath* start_path;
-  GtkTreePath* end_path;
+  GList* tree_children   = gtk_container_get_children(GTK_CONTAINER(zathura->ui.index));
+  GtkTreeView* tree_view = tree_children->data;
+  g_list_free(tree_children);
+  GtkTreePath* path       = NULL;
+  GtkTreePath* start_path = NULL;
+  GtkTreePath* end_path   = NULL;
 
   gtk_tree_view_get_cursor(tree_view, &path, NULL);
   if (path == NULL) {
@@ -1419,7 +1421,7 @@ bool sc_zoom(girara_session_t* session, girara_argument_t* argument, girara_even
   girara_setting_get(zathura->ui.session, "zoom-step", &value);
 
   const int nt           = (t == 0) ? 1 : t;
-  const double zoom_step = 1.0 + value / 100.0 * nt;
+  const double zoom_step = MAX(DBL_EPSILON, 1.0 + value / 100.0 * nt);
   const double old_zoom  = zathura_document_get_zoom(zathura->document);
 
   /* specify new zoom value */
@@ -1544,7 +1546,7 @@ bool sc_zoom_page(girara_session_t* session, girara_argument_t* argument, girara
   zathura_page_t* page      = zathura_document_get_page(zathura->document, current_page);
 
   const int nt           = (t == 0) ? 1 : t;
-  const double zoom_step = 1.0 + value / 100.0 * nt;
+  const double zoom_step = MAX(DBL_EPSILON, 1.0 + value / 100.0 * nt);
   const double old_zoom  = zathura_page_get_zoom(page);
 
   /* specify new zoom value */

--- a/zathura/synctex.c
+++ b/zathura/synctex.c
@@ -220,9 +220,9 @@ bool synctex_parse_input(const char* synctex, char** input_file, int* line, int*
     return false;
   }
 
-  char** split_fwd = g_strsplit(synctex, ":", 0);
-  if (split_fwd == NULL || split_fwd[0] == NULL || split_fwd[1] == NULL || split_fwd[2] == NULL ||
-      split_fwd[3] != NULL) {
+  /* "line:column:path"; path may contain colons (Windows drive letters). */
+  char** split_fwd = g_strsplit(synctex, ":", 3);
+  if (split_fwd == NULL || split_fwd[0] == NULL || split_fwd[1] == NULL || split_fwd[2] == NULL) {
     g_strfreev(split_fwd);
     return false;
   }

--- a/zathura/utils.c
+++ b/zathura/utils.c
@@ -450,7 +450,7 @@ char* increment_first_page_column(const char* first_page_column_list, const unsi
     for (unsigned int i = size; i < pages_per_row - 1; i++) {
       /* The value of the last set cell is normally used for all largers pages_per_row,
        * so duplicate it to the newly created cells. */
-      settings[i] = settings[size - 1];
+      settings[i] = size > 0 ? settings[size - 1] : 1;
     }
     settings[pages_per_row - 1] = column;
     size                        = pages_per_row;

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -115,9 +115,6 @@ zathura_t* zathura_create(void) {
     goto error_out;
   }
 
-  /* set default icon */
-  girara_setting_set(zathura->ui.session, "window-icon", "org.pwmt.zathura");
-
 #ifdef G_OS_UNIX
   /* signal handler */
   zathura->signals.sigterm = g_unix_signal_add(SIGTERM, zathura_signal_sigterm, zathura);
@@ -424,6 +421,7 @@ bool zathura_init(zathura_t* zathura) {
 
   /* configuration */
   config_load_default(zathura);
+  girara_setting_set(zathura->ui.session, "window-icon", "org.pwmt.zathura");
   config_load_files(zathura);
 
   /* UI */
@@ -482,6 +480,7 @@ void zathura_free(zathura_t* zathura) {
   }
 
   document_close(zathura, false);
+  document_predecessor_free(zathura);
 
   /* MIME type detection */
   zathura_content_type_free(zathura->content_type_context);
@@ -639,7 +638,7 @@ static gchar* prepare_document_open_from_stdin(const char* path) {
     infileno = fileno(stdin);
   } else if (g_str_has_prefix(path, "/proc/self/fd/") == true) {
     char* begin = g_strrstr(path, "/") + 1;
-    gint64 temp = g_ascii_strtoll(begin, NULL, 0);
+    gint64 temp = g_ascii_strtoll(begin, NULL, 10);
     if (temp > INT_MAX || temp < 0) {
       return NULL;
     }
@@ -833,6 +832,7 @@ char* get_formatted_filename(zathura_t* zathura, bool statusbar) {
 static gboolean document_open_password_dialog(gpointer data) {
   zathura_password_dialog_info_t* password_dialog_info = data;
 
+  password_dialog_arm_hide(password_dialog_info);
   girara_dialog(password_dialog_info->zathura->ui.session, _("Enter password:"), true, NULL, cb_password_dialog,
                 password_dialog_info);
   return FALSE;
@@ -892,7 +892,7 @@ bool document_open(zathura_t* zathura, const char* path, const char* uri, const 
   zathura->document = document;
 
   /* read history file */
-  girara_debug("checking for exsiting file info");
+  girara_debug("checking for existing file info");
   zathura_fileinfo_t file_info = {
       .current_page           = 0,
       .page_offset            = 0,
@@ -975,6 +975,9 @@ bool document_open(zathura_t* zathura, const char* path, const char* uri, const 
   /* bookmarks */
   if (zathura_bookmarks_load(zathura, file_path) == false) {
     girara_debug("Failed to load bookmarks.");
+    girara_list_free(zathura->bookmarks.bookmarks);
+    zathura->bookmarks.bookmarks = girara_sorted_list_new_with_free(
+        (girara_compare_function_t)zathura_bookmarks_compare, (girara_free_function_t)zathura_bookmark_free);
   }
 
   /* jumplist */
@@ -988,7 +991,7 @@ bool document_open(zathura_t* zathura, const char* path, const char* uri, const 
     zathura->global.marks = girara_list_new_with_free(g_free);
   }
 
-  if (zathura_jumplist_is_initalized(zathura) == false || zathura->global.marks == NULL) {
+  if (zathura_jumplist_is_initialized(zathura) == false || zathura->global.marks == NULL) {
     girara_error("No jumplist or no marks");
     goto error_free;
   }
@@ -1187,7 +1190,7 @@ error_out:
 
 bool document_open_synctex(zathura_t* zathura, const char* path, const char* uri, const char* password,
                            const char* synctex) {
-  bool ret = document_open(zathura, path, password, uri, ZATHURA_PAGE_NUMBER_UNSPECIFIED, NULL);
+  bool ret = document_open(zathura, path, uri, password, ZATHURA_PAGE_NUMBER_UNSPECIFIED, NULL);
   if (ret == false) {
     return false;
   }

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -837,15 +837,6 @@ char* get_formatted_filename(zathura_t* zathura, bool statusbar) {
   }
 }
 
-static gboolean document_open_password_dialog(gpointer data) {
-  zathura_password_dialog_info_t* password_dialog_info = data;
-
-  password_dialog_arm_hide(password_dialog_info);
-  girara_dialog(password_dialog_info->zathura->ui.session, _("Enter password:"), true, NULL, cb_password_dialog,
-                password_dialog_info);
-  return FALSE;
-}
-
 bool document_open(zathura_t* zathura, const char* path, const char* uri, const char* password, int page_number,
                    zathura_fileinfo_t* file_info_p) {
   if (zathura == NULL || zathura->plugins.manager == NULL || path == NULL) {

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -858,7 +858,7 @@ bool document_open(zathura_t* zathura, const char* path, const char* uri, const 
   if (document == NULL) {
     if (error == ZATHURA_ERROR_INVALID_PASSWORD) {
       girara_debug("Invalid or no password.");
-      zathura_password_dialog_info_t* password_dialog_info = g_try_malloc(sizeof(zathura_password_dialog_info_t));
+      zathura_password_dialog_info_t* password_dialog_info = g_try_malloc0(sizeof(zathura_password_dialog_info_t));
       if (password_dialog_info == NULL) {
         goto error_out;
       }

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -725,6 +725,10 @@ static gboolean document_info_open(gpointer data) {
         girara_notify(document_info->zathura->ui.session, GIRARA_ERROR,
                       _("Could not read file from stdin and write it to a temporary file."));
       } else {
+        if (document_info->zathura->stdin_support.file != NULL) {
+          g_unlink(document_info->zathura->stdin_support.file);
+          g_free(document_info->zathura->stdin_support.file);
+        }
         document_info->zathura->stdin_support.file = g_strdup(file);
       }
     } else {
@@ -743,6 +747,10 @@ static gboolean document_info_open(gpointer data) {
           girara_notify(document_info->zathura->ui.session, GIRARA_ERROR,
                         _("Could not read file from GIO and copy it to a temporary file."));
         } else {
+          if (document_info->zathura->stdin_support.file != NULL) {
+            g_unlink(document_info->zathura->stdin_support.file);
+            g_free(document_info->zathura->stdin_support.file);
+          }
           document_info->zathura->stdin_support.file = g_strdup(file);
         }
       }


### PR DESCRIPTION
fix various bugs, leaks and typos

- synctex path parsing
- /proc/self/fd handling
- pages-per-row input validation
- zoom division-by-zero
- index navigation: leak and uninitialised frees
- document grid layout under allocation failure
- print surface size limits
- swapped uri/password in synctex document open
- duplicate bookmark rows on database errors
- marks and print page numbering
- window-icon at startup
- search, dialog, recolor, export and shutdown leaks
- error checks in database, dbus and document hashing
- comment and log-message typos