### PR TITLE
feat: add signed releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,68 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: Build, sign, and publish release artifacts
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pwmt/github-actions-debian:forky
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6
+        with:
+          repository: pwmt/girara
+          path: girara
+
+      - name: Install girara
+        run: |
+          mkdir girara/build
+          meson setup --prefix /usr --libdir=lib/x86_64-linux-gnu girara/build girara
+          ninja --verbose -C girara/build install
+          rm -rf girara
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4
+
+      - name: Set SOURCE_DATE_EPOCH from tag commit
+        run: |
+          echo "SOURCE_DATE_EPOCH=$(git log -1 --format=%ct HEAD)" >> "$GITHUB_ENV"
+
+      - name: Build distribution tarball
+        run: |
+          mkdir build
+          meson setup --prefix /usr --libdir=lib/x86_64-linux-gnu build .
+          meson dist -C build --no-tests --formats xztar
+          mkdir -p dist
+          cp build/meson-dist/zathura-*.tar.xz dist/
+
+      - name: Generate SHA-256 checksum and sign artifacts
+        working-directory: dist
+        run: |
+          sha256sum zathura-*.tar.xz > SHA256SUMS
+          for f in zathura-*.tar.xz SHA256SUMS; do
+            cosign sign-blob --yes --bundle "${f}.sigstore.json" "${f}"
+          done
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          gh release create "$TAG" \
+            --title "zathura $TAG" \
+            --generate-notes \
+            dist/*


### PR DESCRIPTION
This adds github releases and adds sigstore signing to new releases.
https://www.sigstore.dev/

tldr:
Sigstore enables automated signing through githubs ci without the need for persistent key management. Keys are short lived and bound to the authentication process. Verification is handled through transparency logs and can be done in a single step:

```
  cosign verify-blob \
    --certificate-identity \
      https://github.com/pwmt/zathura/.github/workflows/release.yaml@refs/tags/<TAG> \
    --certificate-oidc-issuer https://token.actions.githubusercontent.com \
    --bundle zathura-<VERSION>.tar.xz.sigstore.json \
    zathura-<VERSION>.tar.xz
```

Most importantly, it causes no additional work during the release process

@sebastinas I am curious about your take on this approach and sigstore in general.
