### PR TITLE
fix zathura-sandbox

### DIFF
--- a/zathura/seccomp-filters.c
+++ b/zathura/seccomp-filters.c
@@ -184,8 +184,7 @@ int seccomp_enable_strict_filter(zathura_t* zathura) {
 
   if (GDK_IS_X11_DISPLAY(display)) {
     girara_debug("On X11, supporting X11 syscalls");
-    girara_warning("Running strict sandbox mode on X11 provides only \
-        incomplete process isolation.");
+    girara_warning("Running strict sandbox mode on X11 provides only incomplete process isolation.");
 
     /* permit the socket syscall for local UNIX domain sockets (required by X11) */
     ADD_RULE("allow", SCMP_ACT_ALLOW, socket, 1, SCMP_CMP(0, SCMP_CMP_EQ, AF_UNIX));
@@ -195,6 +194,9 @@ int seccomp_enable_strict_filter(zathura_t* zathura) {
     ALLOW_RULE(getsockopt);
     ALLOW_RULE(getsockname);
     ALLOW_RULE(connect);
+    ALLOW_RULE(exit);
+    ALLOW_RULE(fchmod);
+    ALLOW_RULE(sendto);
     ALLOW_RULE(umask);
     ALLOW_RULE(uname);
     ALLOW_RULE(shmat);

--- a/zathura/seccomp-filters.c
+++ b/zathura/seccomp-filters.c
@@ -231,7 +231,9 @@ int seccomp_enable_strict_filter(zathura_t* zathura) {
   ERRNO_RULE(clone3);
 
   /* allowed for glycin runtime #928 */
+  ADD_RULE("errno", SCMP_ACT_ERRNO(EPERM), clone, 1, SCMP_CMP(0, SCMP_CMP_MASKED_EQ, CLONE_THREAD, 0));
   ADD_RULE("errno", SCMP_ACT_ERRNO(EPERM), kill, 0);
+  ADD_RULE("errno", SCMP_ACT_ERRNO(EPERM), tgkill, 0);
   ALLOW_RULE(timerfd_create);
   ALLOW_RULE(timerfd_settime);
   ALLOW_RULE(timerfd_gettime);

--- a/zathura/seccomp-filters.c
+++ b/zathura/seccomp-filters.c
@@ -194,7 +194,6 @@ int seccomp_enable_strict_filter(zathura_t* zathura) {
     ALLOW_RULE(getsockopt);
     ALLOW_RULE(getsockname);
     ALLOW_RULE(connect);
-    ALLOW_RULE(exit);
     ALLOW_RULE(fchmod);
     ALLOW_RULE(sendto);
     ALLOW_RULE(umask);
@@ -230,6 +229,13 @@ int seccomp_enable_strict_filter(zathura_t* zathura) {
 
   /* trigger fallback to clone */
   ERRNO_RULE(clone3);
+
+  /* allowed for glycin runtime #928 */
+  ADD_RULE("errno", SCMP_ACT_ERRNO(EPERM), kill, 0);
+  ALLOW_RULE(timerfd_create);
+  ALLOW_RULE(timerfd_settime);
+  ALLOW_RULE(timerfd_gettime);
+  ALLOW_RULE(epoll_pwait);
 
   /* fcntl filter - not yet working */
   /*ADD_RULE("allow", SCMP_ACT_ALLOW, fcntl, 1, SCMP_CMP(0, SCMP_CMP_EQ, \


### PR DESCRIPTION
This fixes the sandbox regression reported in #928

@sebastinas Mayby worth a new release, since zathura-sandbox will always crash after 30 seconds in 2025.05.11