### PR TITLE
Add user feedback to copy_filepath

### DIFF
--- a/doc/man/zathurarc.5.rst
+++ b/doc/man/zathurarc.5.rst
@@ -244,6 +244,14 @@ They can also be combined with modifiers:
 
     Change current mode. Pass the desired mode as argument.
 
+  * ``copy_filepath``
+
+    Copy the full path of the currently opened document to the clipboard
+
+  * ``copy_link``
+
+    Copy a link target to the clipboard.
+
   * ``cycle_first_column``
 
     In multiple page layout, cycle the column in which the first page is displayed.
@@ -294,8 +302,8 @@ They can also be combined with modifiers:
 
   * ``page_mode``
 
-    Set the page sizing mode. Default is ``equal_none``, which doesn't resize 
-    individual pages. ``equal_width`` and ``equal_height`` resizes each page to 
+    Set the page sizing mode. Default is ``equal_none``, which doesn't resize
+    individual pages. ``equal_width`` and ``equal_height`` resizes each page to
     have the same width and height respectively.
 
   * ``quit``

--- a/zathura/shortcuts.c
+++ b/zathura/shortcuts.c
@@ -201,12 +201,18 @@ bool sc_copy_filepath(girara_session_t* session, girara_argument_t* UNUSED(argum
   g_return_val_if_fail(session->global.data != NULL, false);
   zathura_t* zathura = session->global.data;
 
+  zathura_document_t* document = zathura_get_document(zathura);
+  if (document == NULL) {
+    girara_notify(session, GIRARA_ERROR, _("No document opened."));
+    return false;
+  }
+
   g_autofree GdkAtom* selection = get_selection(zathura);
   if (selection == NULL) {
     return false;
   }
 
-  const char* file_path = zathura_document_get_path(zathura->document);
+  const char* file_path = zathura_document_get_path(document);
   if (file_path == NULL) {
     girara_debug("Could not get file path for copying");
     return false;
@@ -214,6 +220,15 @@ bool sc_copy_filepath(girara_session_t* session, girara_argument_t* UNUSED(argum
 
   girara_debug("Copying file path to clipboard");
   gtk_clipboard_set_text(gtk_clipboard_get(*selection), file_path, -1);
+
+  bool notification = true;
+  girara_setting_get(session, "selection-notification", &notification);
+  if (notification == true) {
+    g_autofree char* target = NULL;
+    girara_setting_get(session, "selection-clipboard", &target);
+    g_autofree char* escaped = g_markup_printf_escaped(_("Copied file path to selection %s: %s"), target, file_path);
+    girara_notify(session, GIRARA_INFO, "%s", escaped);
+  }
 
   return true;
 }


### PR DESCRIPTION
# Motivation

`copy_filepath` (bound to `Y` by default) was added in #39. It works but it's *not* documented and there is no **feedback** at all, so you also can't tell it exists.

Background: I searched for this and found ["Copying the filename to clipboard in zathura"](https://unix.stackexchange.com/questions/524360/copying-the-filename-to-clipboard-in-zathura) which triggers the sandbox protection and zathura quits.

# Changes

- **Error** notification (`No document opened.`) when invoked with no document open, instead of failing silently.
- Standard selection notification on success (as seen in text and image copying in `callbacks.c`)
- Document **both** `copy_filepath` and the previously-undocumented `copy_link` in the manpage as I also stumbled over `copy_link` (which also has no feedback if there is no link, so not very discoverable)
