### PR TITLE
Fix reload/render race on document close

### DIFF
--- a/zathura/render.c
+++ b/zathura/render.c
@@ -76,6 +76,7 @@ static bool page_cache_is_full(ZathuraRenderer* renderer, bool* result);
 /* job description for render thread */
 typedef struct render_job_s {
   ZathuraRenderRequest* request;
+  unsigned int page_index;
   atomic_bool aborted;
 } render_job_t;
 
@@ -142,10 +143,6 @@ static void renderer_finalize(GObject* object) {
   ZathuraRendererPrivate* priv = zathura_renderer_get_instance_private(renderer);
 
   zathura_renderer_stop(renderer);
-  if (priv->pool != NULL) {
-    girara_debug("Waiting for thread pool to finish.");
-    g_thread_pool_free(priv->pool, TRUE, TRUE);
-  }
   g_mutex_clear(&(priv->mutex));
 
   g_free(priv->page_cache.cache);
@@ -367,8 +364,16 @@ void zathura_renderer_unlock(ZathuraRenderer* renderer) {
 void zathura_renderer_stop(ZathuraRenderer* renderer) {
   g_return_if_fail(ZATHURA_IS_RENDERER(renderer));
   ZathuraRendererPrivate* priv = zathura_renderer_get_instance_private(renderer);
-  girara_debug("Setting about-to-close flag for renderer");
+  if (priv->about_to_close == false) {
+    girara_debug("Setting about-to-close flag for renderer");
+  }
   priv->about_to_close = true;
+
+  if (priv->pool != NULL) {
+    girara_debug("Waiting for thread pool to finish.");
+    g_thread_pool_free(priv->pool, FALSE, TRUE);
+    priv->pool = NULL;
+  }
 }
 
 /* ZathuraRenderRequest methods */
@@ -391,6 +396,17 @@ void zathura_render_request(ZathuraRenderRequest* request, gint64 last_view_time
 
   /* only add a new job if there are no active ones left */
   if (unfinished_jobs == false) {
+    if (request_priv->renderer == NULL) {
+      g_mutex_unlock(&request_priv->jobs_mutex);
+      return;
+    }
+
+    ZathuraRendererPrivate* priv = zathura_renderer_get_instance_private(request_priv->renderer);
+    if (priv->about_to_close == true || priv->pool == NULL) {
+      g_mutex_unlock(&request_priv->jobs_mutex);
+      return;
+    }
+
     request_priv->last_view_time = last_view_time;
 
     render_job_t* job = g_try_malloc0(sizeof(render_job_t));
@@ -399,11 +415,11 @@ void zathura_render_request(ZathuraRenderRequest* request, gint64 last_view_time
       return;
     }
 
-    job->request = g_object_ref(request);
-    job->aborted = false;
+    job->request    = g_object_ref(request);
+    job->page_index = zathura_page_get_index(request_priv->page);
+    job->aborted    = false;
     girara_list_append(request_priv->active_jobs, job);
 
-    ZathuraRendererPrivate* priv = zathura_renderer_get_instance_private(request_priv->renderer);
     g_thread_pool_push(priv->pool, job, NULL);
   }
 
@@ -455,10 +471,10 @@ static gboolean emit_completed_signal(void* data) {
 
   if (priv->about_to_close == false && job->aborted == false) {
     /* emit the signal */
-    girara_debug("Emitting signal for page %d", zathura_page_get_index(request_priv->page) + 1);
+    girara_debug("Emitting signal for page %d", job->page_index + 1);
     g_signal_emit(job->request, request_signals[REQUEST_COMPLETED], 0, ecs->surface);
   } else {
-    girara_debug("Rendering of page %d aborted", zathura_page_get_index(request_priv->page) + 1);
+    girara_debug("Rendering of page %d aborted", job->page_index + 1);
   }
   /* mark the request as done */
   remove_job_and_free(job);
@@ -856,7 +872,7 @@ static bool render(render_job_t* job, ZathuraRenderRequest* request, ZathuraRend
 
   /* before recoloring, check if we've been aborted */
   if (priv->about_to_close == true || job->aborted == true) {
-    girara_debug("Rendering of page %d aborted", zathura_page_get_index(request_priv->page) + 1);
+    girara_debug("Rendering of page %d aborted", job->page_index + 1);
     remove_job_and_free(job);
     cairo_surface_destroy(surface);
     return true;
@@ -891,10 +907,9 @@ static void render_job(void* data, void* user_data) {
     return;
   }
 
-  ZathuraRenderRequestPrivate* request_priv = zathura_render_request_get_instance_private(request);
-  girara_debug("Rendering page %d ...", zathura_page_get_index(request_priv->page) + 1);
+  girara_debug("Rendering page %d ...", job->page_index + 1);
   if (render(job, request, renderer) != true) {
-    girara_error("Rendering failed (page %d)\n", zathura_page_get_index(request_priv->page) + 1);
+    girara_error("Rendering failed (page %d)\n", job->page_index + 1);
     remove_job_and_free(job);
   }
 }

--- a/zathura/render.h
+++ b/zathura/render.h
@@ -108,7 +108,8 @@ void zathura_renderer_set_recolor_colors_str(ZathuraRenderer* renderer, const ch
  */
 void zathura_renderer_get_recolor_colors(ZathuraRenderer* renderer, GdkRGBA* light, GdkRGBA* dark);
 /**
- * Stop rendering.
+ * Stop rendering. This is a terminal operation: after it returns, no more
+ * render jobs will be accepted or executed.
  * @param renderer a render object
  */
 void zathura_renderer_stop(ZathuraRenderer* renderer);


### PR DESCRIPTION
# Fix reload/render lifecycle race

## What lifetimes are involved

There are four related lifetimes involved here: **document/page**, **page widget / render request**, **renderer / thread pool**, and **main-loop callback**.

An open document contains N pages. Usually each page has one page widget, and each page widget owns one render request. There may also be an additional render request for the window icon. The current document has one renderer, and the renderer owns one thread pool. The thread pool can contain multiple queued jobs, but with the current configuration it runs one job at a time. Each job that successfully schedules its completion signal may also have one one-shot main-loop callback.

### document/page

The document/page objects represent the currently open document and its page data. They are the objects the renderer actually reads from. During reload/close, the old document/page objects are released.

### page widget / render request

The page widget / render request lifetime belongs to the UI layer. Each page widget owns a render request. The request points to the corresponding page and submits the "render this page" work to the renderer.

### renderer / thread pool

The renderer / thread pool lifetime is the execution layer. The renderer manages the background thread pool. Jobs in that pool access page/document indirectly through the request and perform the expensive rendering work.

### main-loop callback

The main-loop callback is scheduled back onto the main thread after a worker finishes rendering. The worker does not update GTK UI directly; instead it emits the completed signal from the main thread. This callback may run after the worker has already finished.

The overall flow is: widget/request submits work, renderer/thread pool executes it, the job reads document/page, and completion returns to the UI through a main-loop callback.

## Previous approach and what goes wrong

The previous code handled render shutdown in two separate places. `document_close()` called `zathura_renderer_stop()`, but the old `stop()` only set `about_to_close = true`. In practice, that only told later render logic not to complete normally. The code that actually waited for the background thread pool was in the renderer's `finalize()` path, so it only ran when the renderer object's reference count reached zero.

The problem appears when reload/close happens while a render job is still queued or running. After setting the close flag, `document_close()` continues releasing the old document/page objects, but the worker may not have stopped yet. A render request holds a reference to the renderer, and a render job holds a reference to the request, so the renderer is not guaranteed to finalize immediately after close. That means the wait in `finalize()` may happen too late. The old document/page objects can already be gone while the worker can still reach their raw pointers through the request, creating the reload/render race.

## How this fixes it

This patch turns `zathura_renderer_stop()` into the real synchronization point. When `document_close()` calls it, it does not only set `about_to_close`; it also waits for all queued/running render jobs in the thread pool to finish, then sets `pool` to `NULL`.

After `stop()` returns, the background worker can no longer access the old page/document objects. `document_close()` can then release the request, renderer, page widgets, and document without leaving a render job running against the old document.

The job also stores `page_index`, so later logging and completion handling do not need to read a potentially invalid page pointer only to print the page number.

## Reproduce script

This script requires `typst`.

To make the race easier to reproduce, the generated PDF intentionally makes the first page expensive to render: it uses a very large single page, draws many vector boxes on that page, alternates the page size between reloads, and enables recoloring in the temporary zathura configuration. This increases the time window where a reload can overlap with an active render job. I can reproduce the crash with this script on two local machines: one with an i5-13490F and one with an i7-10510U.

```bash
#!/usr/bin/env bash
set -euo pipefail

tmp=$(mktemp -d)
zathura_pid=
trap '[[ -n "$zathura_pid" ]] && kill "$zathura_pid" 2>/dev/null || true; rm -rf "$tmp"' EXIT

mkdir -p "$tmp/config" "$tmp/data" "$tmp/cache"
printf 'set database null\nset filemonitor glib\nset recolor true\n' >"$tmp/config/zathurarc"

make_pdf() {
  {
    printf '#set page(width: %smm, height: %smm)\n' "$((420 + $1 % 2 * 20))" "$((1600 + $1 % 2 * 120))"
    printf '#set text(size: 8pt)\n= reload %s\n\n' "$1"
    for line in $(seq 1 900); do
      printf '#box(width: 390mm, height: 0.8mm, fill: rgb("#336699"))\n'
      printf '#v(0.4mm)\n'
      printf 'Line %03d iteration %s abcdefghijklmnopqrstuvwxyz 0123456789\n\n' "$line" "$1"
    done
  } >"$tmp/repro.typ"
  typst compile --format pdf "$tmp/repro.typ" "$2" >/dev/null
}

check_zathura() {
  local iteration=$1
  if kill -0 "$zathura_pid" 2>/dev/null; then
    return
  fi

  set +e
  wait "$zathura_pid"
  local status=$?
  set -e

  printf 'zathura exited during iteration %s with status %s\n' "$iteration" "$status" >&2
  exit "$status"
}

make_pdf 0 "$tmp/repro.pdf"

# 1. Run zathura on a temporary PDF with file monitoring enabled.
./build/zathura -l debug -c "$tmp/config" -d "$tmp/data" --cache-dir "$tmp/cache" -p /usr/lib/zathura "$tmp/repro.pdf" &
zathura_pid=$!
sleep 2

# 2. Keep replacing that watched PDF with new documents to trigger reloads.
for iteration in $(seq 1 200); do
  check_zathura "$iteration"
  make_pdf "$iteration" "$tmp/repro.pdf.tmp"
  mv -f "$tmp/repro.pdf.tmp" "$tmp/repro.pdf"
  sleep 0.05
  check_zathura "$iteration"
done

printf 'No crash observed after 200 reloads.\n'
```

## Related issues

- https://github.com/pwmt/zathura/issues/729
- https://github.com/pwmt/zathura/issues/462
- https://github.com/pwmt/zathura/issues/553
- https://github.com/pwmt/zathura/issues/164
