### PR TITLE
Port to gtk4

### DIFF
--- a/data/girara.css_t
+++ b/data/girara.css_t
@@ -11,6 +11,14 @@
 /* Inputbar */
 #@session@ entry.inputbar {
   background-color: @inputbar-bg@;
+  box-shadow: none;
+  outline: none;
+}
+
+/* gtk4 draws a focus ring on the entry that the generic .inputbar rule cannot override */
+#@session@ entry.inputbar:focus-within {
+  box-shadow: none;
+  outline: none;
 }
 
 #@session@ .inputbar {

--- a/data/zathura.css_t
+++ b/data/zathura.css_t
@@ -1,13 +1,25 @@
 /* Index mode colors */
 
 #@session@ .indexmode {
+  background-color: @index-bg@;
+}
+
+#@session@ .indexmode row {
   color: @index-fg@;
   background-color: @index-bg@;
 }
 
-#@session@ .indexmode:selected {
+#@session@ .indexmode row:selected {
   color: @index-active-fg@;
   background-color: @index-active-bg@;
+}
+
+/* gtk4 draws a focus ring on the focused/selected row, like the inputbar entry */
+#@session@ .indexmode row:focus,
+#@session@ .indexmode row:focus-visible,
+#@session@ .indexmode row:selected {
+  outline: none;
+  box-shadow: none;
 }
 
 /* Scrollbar */

--- a/doc/man/zathura.1.rst
+++ b/doc/man/zathura.1.rst
@@ -4,7 +4,7 @@ Manpage
 Synopsis
 --------
 
-zathura [-e XID] [-c PATH] [-d PATH] [-p PATH] [-w PASSWORD] [-P NUMBER]
+zathura [-c PATH] [-d PATH] [-p PATH] [-w PASSWORD] [-P NUMBER]
 [--fork] [-l LEVEL] [-s] [-x CMD] [--synctex-forward INPUT] [--synctex-pid PID]
 [-find STRING]
 <files>
@@ -22,9 +22,6 @@ given, an empty **zathura** instance launches.
 
 Options
 -------
-
--e, --reparent=xid
-  Reparents to window specified by xid
 
 -c, --config-dir=path
   Path to the config directory

--- a/doc/man/zathurarc.5.rst
+++ b/doc/man/zathurarc.5.rst
@@ -1032,13 +1032,6 @@ The settings described here can be changed with ``set``.
   * Value type: Boolean
   * Default value: false
 
-*window-icon-document*
-  Defines whether the window document should be updated based on the first page of
-  a dcument.
-
-  * Value type: Boolean
-  * Default value: false
-
 *window-title-basename*
   Use basename of the file in the window title.
 

--- a/girara-gtk/callbacks.c
+++ b/girara-gtk/callbacks.c
@@ -14,18 +14,15 @@
 #include <glib/gi18n-lib.h>
 #include <string.h>
 
-static const guint ALL_ACCELS_MASK = GDK_CONTROL_MASK | GDK_SHIFT_MASK | GDK_MOD1_MASK;
-static const guint MOUSE_MASK      = GDK_CONTROL_MASK | GDK_SHIFT_MASK | GDK_MOD1_MASK | GDK_BUTTON1_MASK |
-                                GDK_BUTTON2_MASK | GDK_BUTTON3_MASK | GDK_BUTTON4_MASK | GDK_BUTTON5_MASK;
+static const guint ALL_ACCELS_MASK = GDK_CONTROL_MASK | GDK_SHIFT_MASK | GDK_ALT_MASK;
+static const guint MOUSE_MASK = GDK_CONTROL_MASK | GDK_SHIFT_MASK | GDK_ALT_MASK | GDK_BUTTON1_MASK | GDK_BUTTON2_MASK |
+                                GDK_BUTTON3_MASK | GDK_BUTTON4_MASK | GDK_BUTTON5_MASK;
 
-static bool clean_mask(GtkWidget* widget, guint hardware_keycode, GdkModifierType state, gint group, guint* clean,
-                       guint* keyval) {
-  GdkDisplay* display      = gtk_widget_get_display(widget);
+static bool clean_mask(GtkEventControllerKey* controller, GdkModifierType state, guint* clean, guint* keyval) {
   GdkModifierType consumed = 0;
-
-  if ((gdk_keymap_translate_keyboard_state(gdk_keymap_get_for_display(display), hardware_keycode, state, group, keyval,
-                                           NULL, NULL, &consumed)) == FALSE) {
-    return false;
+  GdkEvent* event          = gtk_event_controller_get_current_event(GTK_EVENT_CONTROLLER(controller));
+  if (event != NULL && gdk_event_get_event_type(event) == GDK_KEY_PRESS) {
+    consumed = gdk_key_event_get_consumed_modifiers(event);
   }
 
   if (clean != NULL) {
@@ -70,15 +67,22 @@ static bool clean_mask(GtkWidget* widget, guint hardware_keycode, GdkModifierTyp
 }
 
 /* callback implementation */
-gboolean girara_callback_view_key_press_event(GtkWidget* widget, GdkEventKey* event, girara_session_t* session) {
+gboolean girara_callback_view_key_press_event(GtkEventControllerKey* controller, guint keyval_in, guint UNUSED(keycode),
+                                              GdkModifierType state, girara_session_t* session) {
   g_return_val_if_fail(session != NULL, FALSE);
 
   guint clean  = 0;
-  guint keyval = 0;
+  guint keyval = keyval_in;
 
-  if (clean_mask(widget, event->hardware_keycode, event->state, event->group, &clean, &keyval) == false) {
+  if (clean_mask(controller, state, &clean, &keyval) == false) {
     return false;
   }
+
+  return girara_process_view_key(session, keyval, clean);
+}
+
+gboolean girara_process_view_key(girara_session_t* session, guint keyval, guint clean) {
+  g_return_val_if_fail(session != NULL, FALSE);
 
   girara_session_private_t* session_private = session->private_data;
 
@@ -210,36 +214,31 @@ gboolean girara_callback_view_key_press_event(GtkWidget* widget, GdkEventKey* ev
   return FALSE;
 }
 
-gboolean girara_callback_view_button_press_event(GtkWidget* UNUSED(widget), GdkEventButton* button,
+gboolean girara_callback_view_button_press_event(GtkGestureClick* gesture, gint n_press, gdouble x, gdouble y,
                                                  girara_session_t* session) {
   g_return_val_if_fail(session != NULL, false);
-  g_return_val_if_fail(button != NULL, false);
 
-  /* prepare girara event */
-  girara_event_t event = {.x = button->x, .y = button->y};
+  girara_event_t event = {.x = x, .y = y};
 
-  switch (button->type) {
-  case GDK_BUTTON_PRESS:
-    event.type = GIRARA_EVENT_BUTTON_PRESS;
-    break;
-  case GDK_2BUTTON_PRESS:
+  if (n_press == 2) {
     event.type = GIRARA_EVENT_2BUTTON_PRESS;
-    break;
-  case GDK_3BUTTON_PRESS:
+  } else if (n_press == 3) {
     event.type = GIRARA_EVENT_3BUTTON_PRESS;
-    break;
-  default: /* do not handle unknown events */
+  } else if (n_press == 1) {
+    event.type = GIRARA_EVENT_BUTTON_PRESS;
+  } else {
     event.type = GIRARA_EVENT_OTHER;
-    break;
   }
 
-  const guint state                         = button->state & MOUSE_MASK;
+  const guint gbutton  = gtk_gesture_single_get_current_button(GTK_GESTURE_SINGLE(gesture));
+  GdkModifierType mods = gtk_event_controller_get_current_event_state(GTK_EVENT_CONTROLLER(gesture));
+  const guint state    = mods & MOUSE_MASK;
   girara_session_private_t* session_private = session->private_data;
 
   /* search registered mouse events */
   for (size_t idx = 0; idx != girara_list_size(session->bindings.mouse_events); ++idx) {
     girara_mouse_event_t* mouse_event = girara_list_nth(session->bindings.mouse_events, idx);
-    if (mouse_event->function != NULL && button->button == mouse_event->button && state == mouse_event->mask &&
+    if (mouse_event->function != NULL && gbutton == mouse_event->button && state == mouse_event->mask &&
         mouse_event->event_type == event.type &&
         (session->modes.current_mode == mouse_event->mode || mouse_event->mode == 0)) {
       mouse_event->function(session, &mouse_event->argument, &event, session_private->buffer.n);
@@ -250,21 +249,21 @@ gboolean girara_callback_view_button_press_event(GtkWidget* UNUSED(widget), GdkE
   return false;
 }
 
-gboolean girara_callback_view_button_release_event(GtkWidget* UNUSED(widget), GdkEventButton* button,
+gboolean girara_callback_view_button_release_event(GtkGestureClick* gesture, gint UNUSED(n_press), gdouble x, gdouble y,
                                                    girara_session_t* session) {
   g_return_val_if_fail(session != NULL, false);
-  g_return_val_if_fail(button != NULL, false);
 
-  /* prepare girara event */
-  girara_event_t event = {.type = GIRARA_EVENT_BUTTON_RELEASE, .x = button->x, .y = button->y};
+  girara_event_t event = {.type = GIRARA_EVENT_BUTTON_RELEASE, .x = x, .y = y};
 
-  const guint state                         = button->state & MOUSE_MASK;
+  const guint gbutton  = gtk_gesture_single_get_current_button(GTK_GESTURE_SINGLE(gesture));
+  GdkModifierType mods = gtk_event_controller_get_current_event_state(GTK_EVENT_CONTROLLER(gesture));
+  const guint state    = mods & MOUSE_MASK;
   girara_session_private_t* session_private = session->private_data;
 
   /* search registered mouse events */
   for (size_t idx = 0; idx != girara_list_size(session->bindings.mouse_events); ++idx) {
     girara_mouse_event_t* mouse_event = girara_list_nth(session->bindings.mouse_events, idx);
-    if (mouse_event->function != NULL && button->button == mouse_event->button && state == mouse_event->mask &&
+    if (mouse_event->function != NULL && gbutton == mouse_event->button && state == mouse_event->mask &&
         mouse_event->event_type == GIRARA_EVENT_BUTTON_RELEASE &&
         (session->modes.current_mode == mouse_event->mode || mouse_event->mode == 0)) {
       mouse_event->function(session, &(mouse_event->argument), &event, session_private->buffer.n);
@@ -275,15 +274,12 @@ gboolean girara_callback_view_button_release_event(GtkWidget* UNUSED(widget), Gd
   return false;
 }
 
-gboolean girara_callback_view_button_motion_notify_event(GtkWidget* UNUSED(widget), GdkEventMotion* button,
-                                                         girara_session_t* session) {
+static gboolean dispatch_mouse_motion(girara_session_t* session, double x, double y, GdkModifierType mods) {
   g_return_val_if_fail(session != NULL, false);
-  g_return_val_if_fail(button != NULL, false);
 
-  /* prepare girara event */
-  girara_event_t event = {.type = GIRARA_EVENT_MOTION_NOTIFY, .x = button->x, .y = button->y};
+  girara_event_t event = {.type = GIRARA_EVENT_MOTION_NOTIFY, .x = x, .y = y};
 
-  const guint state                         = button->state & MOUSE_MASK;
+  const guint state                         = mods & MOUSE_MASK;
   girara_session_private_t* session_private = session->private_data;
 
   /* search registered mouse events */
@@ -299,42 +295,97 @@ gboolean girara_callback_view_button_motion_notify_event(GtkWidget* UNUSED(widge
   return false;
 }
 
-gboolean girara_callback_view_scroll_event(GtkWidget* UNUSED(widget), GdkEventScroll* scroll,
+gboolean girara_callback_view_button_motion_notify_event(GtkEventControllerMotion* controller, gdouble x, gdouble y,
+                                                         girara_session_t* session) {
+  GdkModifierType mods = gtk_event_controller_get_current_event_state(GTK_EVENT_CONTROLLER(controller));
+  return dispatch_mouse_motion(session, x, y, mods);
+}
+
+bool girara_has_mouse_event(girara_session_t* session, girara_event_type_t type, guint button, GdkModifierType state) {
+  g_return_val_if_fail(session != NULL, false);
+
+  const guint masked = state & MOUSE_MASK;
+  for (size_t idx = 0; idx != girara_list_size(session->bindings.mouse_events); ++idx) {
+    girara_mouse_event_t* mouse_event = girara_list_nth(session->bindings.mouse_events, idx);
+    if (mouse_event->function != NULL && mouse_event->button == button && masked == mouse_event->mask &&
+        mouse_event->event_type == type &&
+        (session->modes.current_mode == mouse_event->mode || mouse_event->mode == 0)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/* recover the pointer position of a scroll event in widget coordinates (gtk3 scroll->x/y parity) */
+static void scroll_event_position(GtkEventControllerScroll* controller, double* x, double* y) {
+  *x = 0.0;
+  *y = 0.0;
+
+  GtkWidget* widget = gtk_event_controller_get_widget(GTK_EVENT_CONTROLLER(controller));
+  GdkEvent* event   = gtk_event_controller_get_current_event(GTK_EVENT_CONTROLLER(controller));
+  if (widget == NULL || event == NULL) {
+    return;
+  }
+
+  double sx = 0.0, sy = 0.0;
+  if (gdk_event_get_position(event, &sx, &sy) == FALSE) {
+    return;
+  }
+
+  GtkNative* native = gtk_widget_get_native(widget);
+  if (native == NULL) {
+    return;
+  }
+
+  double nx = 0.0, ny = 0.0;
+  gtk_native_get_surface_transform(native, &nx, &ny);
+  const graphene_point_t point = GRAPHENE_POINT_INIT((float)(sx - nx), (float)(sy - ny));
+  graphene_point_t out         = {0};
+  if (gtk_widget_compute_point(GTK_WIDGET(native), widget, &point, &out) == TRUE) {
+    *x = out.x;
+    *y = out.y;
+  }
+}
+
+gboolean girara_callback_view_scroll_event(GtkEventControllerScroll* controller, gdouble dx, gdouble dy,
                                            girara_session_t* session) {
   g_return_val_if_fail(session != NULL, false);
-  g_return_val_if_fail(scroll != NULL, false);
 
-  /* prepare girara event */
-  girara_event_t event = {.x = scroll->x, .y = scroll->y};
+  girara_event_t event = {.x = 0, .y = 0};
+  scroll_event_position(controller, &event.x, &event.y);
 
-  switch (scroll->direction) {
-  case GDK_SCROLL_UP:
-    event.type = GIRARA_EVENT_SCROLL_UP;
-    break;
-  case GDK_SCROLL_DOWN:
-    event.type = GIRARA_EVENT_SCROLL_DOWN;
-    break;
-  case GDK_SCROLL_LEFT:
-    event.type = GIRARA_EVENT_SCROLL_LEFT;
-    break;
-  case GDK_SCROLL_RIGHT:
-    event.type = GIRARA_EVENT_SCROLL_RIGHT;
-    break;
-  case GDK_SCROLL_SMOOTH:
+  /* only wheel units are discrete steps so touchpad deltas stay smooth */
+  if (gtk_event_controller_scroll_get_unit(controller) != GDK_SCROLL_UNIT_WHEEL) {
     event.type = GIRARA_EVENT_SCROLL_BIDIRECTIONAL;
-    /* We abuse x and y here. We really need more fields in girara_event_t. */
-    gdk_event_get_scroll_deltas((GdkEvent*)scroll, &event.x, &event.y);
+    event.x    = dx;
+    event.y    = dy;
 #ifdef __APPLE__
     /* Apple has much higher deltas */
     event.x /= 50;
     event.y /= 50;
 #endif
-    break;
-  default:
-    return false;
+  } else if (dx == 0.0 && dy < 0.0) {
+    event.type = GIRARA_EVENT_SCROLL_UP;
+  } else if (dx == 0.0 && dy > 0.0) {
+    event.type = GIRARA_EVENT_SCROLL_DOWN;
+  } else if (dy == 0.0 && dx < 0.0) {
+    event.type = GIRARA_EVENT_SCROLL_LEFT;
+  } else if (dy == 0.0 && dx > 0.0) {
+    event.type = GIRARA_EVENT_SCROLL_RIGHT;
+  } else {
+    event.type = GIRARA_EVENT_SCROLL_BIDIRECTIONAL;
+    event.x    = dx;
+    event.y    = dy;
+#ifdef __APPLE__
+    /* Apple has much higher deltas */
+    event.x /= 50;
+    event.y /= 50;
+#endif
   }
 
-  const guint state                         = scroll->state & MOUSE_MASK;
+  GdkModifierType mods = gtk_event_controller_get_current_event_state(GTK_EVENT_CONTROLLER(controller));
+  const guint state    = mods & MOUSE_MASK;
   girara_session_private_t* session_private = session->private_data;
 
   /* search registered mouse events */
@@ -365,9 +416,9 @@ gboolean girara_callback_inputbar_activate(GtkEntry* entry, girara_session_t* se
 
     if (session->gtk.inputbar_dialog != NULL && session->gtk.inputbar_entry != NULL) {
       gtk_label_set_markup(session->gtk.inputbar_dialog, "");
-      gtk_widget_hide(GTK_WIDGET(session->gtk.inputbar_dialog));
+      gtk_widget_set_visible(GTK_WIDGET(session->gtk.inputbar_dialog), FALSE);
       if (session->global.autohide_inputbar == true) {
-        gtk_widget_hide(GTK_WIDGET(session->gtk.inputbar));
+        gtk_widget_set_visible(GTK_WIDGET(session->gtk.inputbar), FALSE);
       }
       gtk_entry_set_visibility(session->gtk.inputbar_entry, TRUE);
       girara_isc_abort(session, NULL, NULL, 0);
@@ -389,7 +440,7 @@ gboolean girara_callback_inputbar_activate(GtkEntry* entry, girara_session_t* se
   }
 
   /* append to command history */
-  const char* command = gtk_entry_get_text(entry);
+  const char* command = gtk_editable_get_text(GTK_EDITABLE(entry));
   girara_input_history_append(session->command_history, command);
 
   /* special commands */
@@ -416,27 +467,32 @@ gboolean girara_callback_inputbar_activate(GtkEntry* entry, girara_session_t* se
   return girara_command_run(session, input);
 }
 
-gboolean girara_callback_inputbar_key_press_event(GtkWidget* entry, GdkEventKey* event, girara_session_t* session) {
+gboolean girara_callback_inputbar_key_press_event(GtkEventControllerKey* controller, guint keyval_in,
+                                                  guint UNUSED(keycode), GdkModifierType state,
+                                                  girara_session_t* session) {
   g_return_val_if_fail(session != NULL, false);
+
+  GtkWidget* entry = gtk_event_controller_get_widget(GTK_EVENT_CONTROLLER(controller));
 
   /* a custom handler has been installed (e.g. by girara_dialog) */
   gboolean custom_ret = false;
   if (session->signals.inputbar_custom_key_press_event != NULL) {
     girara_debug("Running custom key press event handler.");
+    GdkEvent* event = gtk_event_controller_get_current_event(GTK_EVENT_CONTROLLER(controller));
     custom_ret = session->signals.inputbar_custom_key_press_event(entry, event, session->signals.inputbar_custom_data);
     if (custom_ret == true) {
       girara_isc_abort(session, NULL, NULL, 0);
 
       if (session->global.autohide_inputbar == true) {
-        gtk_widget_hide(GTK_WIDGET(session->gtk.inputbar));
+        gtk_widget_set_visible(GTK_WIDGET(session->gtk.inputbar), FALSE);
       }
-      gtk_widget_hide(GTK_WIDGET(session->gtk.inputbar_dialog));
+      gtk_widget_set_visible(GTK_WIDGET(session->gtk.inputbar_dialog), FALSE);
     }
   }
 
-  guint keyval = 0;
+  guint keyval = keyval_in;
   guint clean  = 0;
-  if (clean_mask(entry, event->hardware_keycode, event->state, event->group, &clean, &keyval) == false) {
+  if (clean_mask(controller, state, &clean, &keyval) == false) {
     girara_debug("clean_mask returned false.");
     return false;
   }
@@ -458,7 +514,7 @@ gboolean girara_callback_inputbar_key_press_event(GtkWidget* entry, GdkEventKey*
 
   if ((session->gtk.results != NULL) && (gtk_widget_get_visible(GTK_WIDGET(session->gtk.results)) == TRUE) &&
       (keyval == GDK_KEY_space)) {
-    gtk_widget_hide(GTK_WIDGET(session->gtk.results));
+    gtk_widget_set_visible(GTK_WIDGET(session->gtk.results), FALSE);
   }
 
   return custom_ret;

--- a/girara-gtk/callbacks.h
+++ b/girara-gtk/callbacks.h
@@ -14,7 +14,7 @@
  * @param data Custom data
  * @return true if no error occurred
  */
-typedef gboolean (*girara_callback_inputbar_key_press_event_t)(GtkWidget* widget, GdkEventKey* event, void* data);
+typedef gboolean (*girara_callback_inputbar_key_press_event_t)(GtkWidget* widget, GdkEvent* event, void* data);
 
 /**
  * Callback definition for an inputbar key press event handler
@@ -34,7 +34,8 @@ typedef gboolean (*girara_callback_inputbar_activate_t)(GtkEntry* entry, void* d
  * @return TRUE No error occurred
  * @return FALSE An error occurred
  */
-gboolean girara_callback_view_key_press_event(GtkWidget* widget, GdkEventKey* event, girara_session_t* session);
+gboolean girara_callback_view_key_press_event(GtkEventControllerKey* controller, guint keyval, guint keycode,
+                                              GdkModifierType state, girara_session_t* session);
 
 /**
  * Default callback when a button (typically a mouse button) has been pressed
@@ -45,7 +46,8 @@ gboolean girara_callback_view_key_press_event(GtkWidget* widget, GdkEventKey* ev
  * @return true to stop other handlers from being invoked for the event.
  * @return false to propagate the event further.
  */
-gboolean girara_callback_view_button_press_event(GtkWidget* widget, GdkEventButton* button, girara_session_t* session);
+gboolean girara_callback_view_button_press_event(GtkGestureClick* gesture, gint n_press, gdouble x, gdouble y,
+                                                 girara_session_t* session);
 
 /**
  * Default callback when a button (typically a mouse button) has been released
@@ -56,7 +58,7 @@ gboolean girara_callback_view_button_press_event(GtkWidget* widget, GdkEventButt
  * @return true to stop other handlers from being invoked for the event.
  * @return false to propagate the event further.
  */
-gboolean girara_callback_view_button_release_event(GtkWidget* widget, GdkEventButton* button,
+gboolean girara_callback_view_button_release_event(GtkGestureClick* gesture, gint n_press, gdouble x, gdouble y,
                                                    girara_session_t* session);
 
 /**
@@ -68,8 +70,13 @@ gboolean girara_callback_view_button_release_event(GtkWidget* widget, GdkEventBu
  * @return true to stop other handlers from being invoked for the event.
  * @return false to propagate the event further.
  */
-gboolean girara_callback_view_button_motion_notify_event(GtkWidget* widget, GdkEventMotion* button,
+gboolean girara_process_view_key(girara_session_t* session, guint keyval, guint clean);
+
+gboolean girara_callback_view_button_motion_notify_event(GtkEventControllerMotion* controller, gdouble x, gdouble y,
                                                          girara_session_t* session);
+
+/* return true if a mouse binding matches the given event in the current mode (state is masked internally) */
+bool girara_has_mouse_event(girara_session_t* session, girara_event_type_t type, guint button, GdkModifierType state);
 
 /**
  * Default callback then a scroll event is triggered by the view
@@ -80,7 +87,8 @@ gboolean girara_callback_view_button_motion_notify_event(GtkWidget* widget, GdkE
  * @return true to stop other handlers from being invoked for the event.
  * @return false to propagate the event further.
  */
-gboolean girara_callback_view_scroll_event(GtkWidget* widget, GdkEventScroll* event, girara_session_t* session);
+gboolean girara_callback_view_scroll_event(GtkEventControllerScroll* controller, gdouble dx, gdouble dy,
+                                           girara_session_t* session);
 
 /**
  * Default callback if the inputbar gets activated
@@ -101,7 +109,8 @@ gboolean girara_callback_inputbar_activate(GtkEntry* entry, girara_session_t* se
  * @return TRUE No error occurred
  * @return FALSE An error occurred
  */
-gboolean girara_callback_inputbar_key_press_event(GtkWidget* widget, GdkEventKey* event, girara_session_t* session);
+gboolean girara_callback_inputbar_key_press_event(GtkEventControllerKey* controller, guint keyval, guint keycode,
+                                                  GdkModifierType state, girara_session_t* session);
 
 /**
  * Default callback if the text of the input bar has changed

--- a/girara-gtk/commands.c
+++ b/girara-gtk/commands.c
@@ -325,7 +325,7 @@ static bool girara_cmd_map_unmap(girara_session_t* session, girara_list_t* argum
         break;
       case 'A':
       case 'M':
-        shortcut_mask = GDK_MOD1_MASK;
+        shortcut_mask = GDK_ALT_MASK;
         break;
       case 'C':
         shortcut_mask = GDK_CONTROL_MASK;
@@ -834,9 +834,9 @@ bool girara_command_run(girara_session_t* session, const char* input) {
       girara_isc_abort(session, NULL, NULL, 0);
 
       if (session->global.autohide_inputbar == true) {
-        gtk_widget_hide(GTK_WIDGET(session->gtk.inputbar));
+        gtk_widget_set_visible(GTK_WIDGET(session->gtk.inputbar), FALSE);
       }
-      gtk_widget_hide(GTK_WIDGET(session->gtk.inputbar_dialog));
+      gtk_widget_set_visible(GTK_WIDGET(session->gtk.inputbar_dialog), FALSE);
       return true;
     }
   }
@@ -848,9 +848,9 @@ bool girara_command_run(girara_session_t* session, const char* input) {
       girara_isc_abort(session, NULL, NULL, 0);
 
       if (session->global.autohide_inputbar == true) {
-        gtk_widget_hide(GTK_WIDGET(session->gtk.inputbar));
+        gtk_widget_set_visible(GTK_WIDGET(session->gtk.inputbar), FALSE);
       }
-      gtk_widget_hide(GTK_WIDGET(session->gtk.inputbar_dialog));
+      gtk_widget_set_visible(GTK_WIDGET(session->gtk.inputbar_dialog), FALSE);
 
       return true;
     }

--- a/girara-gtk/completion.c
+++ b/girara-gtk/completion.c
@@ -12,14 +12,14 @@
 #include "settings.h"
 #include "shortcuts.h"
 
-static GtkEventBox* girara_completion_row_create(const char*, const char*, bool);
-static void girara_completion_row_set_color(GtkEventBox*, int);
+static GtkWidget* girara_completion_row_create(const char*, const char*, bool);
+static void girara_completion_row_set_color(GtkWidget*, int);
 
 /* completion */
 struct girara_internal_completion_entry_s {
-  GtkEventBox* widget; /**< Eventbox widget */
-  char* value;         /**< Name of the entry */
-  bool group;          /**< The entry is a group */
+  GtkWidget* widget; /**< Row widget (GtkBox) */
+  char* value;       /**< Name of the entry */
+  bool group;        /**< The entry is a group */
 };
 
 /**
@@ -185,7 +185,10 @@ bool girara_isc_completion(girara_session_t* session, girara_argument_t* argumen
         girara_internal_completion_entry_t* entry = (girara_internal_completion_entry_t*)element->data;
 
         if (entry != NULL) {
-          gtk_widget_destroy(GTK_WIDGET(entry->widget));
+          if (entry->widget != NULL) {
+            gtk_box_remove(GTK_BOX(session->gtk.results), entry->widget);
+            entry->widget = NULL;
+          }
           g_free(entry->value);
           g_free(entry);
         }
@@ -195,8 +198,19 @@ bool girara_isc_completion(girara_session_t* session, girara_argument_t* argumen
       priv->completion.entries         = NULL;
       priv->completion.entries_current = NULL;
 
-      /* delete row box */
-      gtk_widget_destroy(GTK_WIDGET(session->gtk.results));
+      /* a scrolled window wraps plain children in a viewport */
+      GtkWidget* results = GTK_WIDGET(session->gtk.results);
+      GtkWidget* scroll  = gtk_widget_get_ancestor(results, GTK_TYPE_SCROLLED_WINDOW);
+      if (scroll != NULL) {
+        gtk_scrolled_window_set_child(GTK_SCROLLED_WINDOW(scroll), NULL);
+        gtk_box_remove(GTK_BOX(priv->gtk.bottom_box), scroll);
+      } else if (gtk_widget_get_parent(results) != NULL) {
+        gtk_widget_unparent(results);
+      } else {
+        /* sink and drop a results box that never got a parent */
+        g_object_ref_sink(results);
+        g_object_unref(results);
+      }
       session->gtk.results = NULL;
     }
 
@@ -252,7 +266,7 @@ bool girara_isc_completion(girara_session_t* session, girara_argument_t* argumen
           priv->completion.entries = g_list_append(priv->completion.entries, entry);
 
           /* show entry row */
-          gtk_box_pack_start(session->gtk.results, GTK_WIDGET(entry->widget), FALSE, FALSE, 0);
+          gtk_box_append(GTK_BOX(session->gtk.results), GTK_WIDGET(entry->widget));
         }
       }
     }
@@ -269,7 +283,10 @@ bool girara_isc_completion(girara_session_t* session, girara_argument_t* argumen
         current_command_length        = strlen(current_command);
 
         /* clear list */
-        gtk_widget_destroy(GTK_WIDGET(entry->widget));
+        if (entry->widget != NULL) {
+          gtk_box_remove(GTK_BOX(session->gtk.results), entry->widget);
+          entry->widget = NULL;
+        }
 
         priv->completion.entries =
             g_list_remove(priv->completion.entries, g_list_first(priv->completion.entries)->data);
@@ -307,7 +324,7 @@ bool girara_isc_completion(girara_session_t* session, girara_argument_t* argumen
 
         priv->completion.entries = g_list_append(priv->completion.entries, entry);
 
-        gtk_box_pack_start(session->gtk.results, GTK_WIDGET(entry->widget), FALSE, FALSE, 0);
+        gtk_box_append(GTK_BOX(session->gtk.results), GTK_WIDGET(entry->widget));
         priv->completion.command_mode = true;
       } else {
         /* generate completion result
@@ -339,7 +356,7 @@ bool girara_isc_completion(girara_session_t* session, girara_argument_t* argumen
 
             priv->completion.entries = g_list_append(priv->completion.entries, entry);
 
-            gtk_box_pack_start(session->gtk.results, GTK_WIDGET(entry->widget), FALSE, FALSE, 0);
+            gtk_box_append(GTK_BOX(session->gtk.results), GTK_WIDGET(entry->widget));
           }
 
           for (size_t inner_idx = 0; inner_idx != girara_list_size(group->elements); ++inner_idx) {
@@ -352,7 +369,7 @@ bool girara_isc_completion(girara_session_t* session, girara_argument_t* argumen
 
             priv->completion.entries = g_list_append(priv->completion.entries, entry);
 
-            gtk_box_pack_start(session->gtk.results, GTK_WIDGET(entry->widget), FALSE, FALSE, 0);
+            gtk_box_append(GTK_BOX(session->gtk.results), GTK_WIDGET(entry->widget));
           }
         }
         girara_completion_free(result);
@@ -364,8 +381,13 @@ bool girara_isc_completion(girara_session_t* session, girara_argument_t* argumen
     if (priv->completion.entries != NULL) {
       priv->completion.entries_current =
           (argument->n == GIRARA_NEXT) ? g_list_last(priv->completion.entries) : priv->completion.entries;
-      gtk_box_pack_start(priv->gtk.bottom_box, GTK_WIDGET(session->gtk.results), FALSE, FALSE, 0);
-      gtk_widget_show(GTK_WIDGET(session->gtk.results));
+      GtkWidget* scroll = gtk_scrolled_window_new();
+      gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scroll), GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
+      gtk_scrolled_window_set_propagate_natural_height(GTK_SCROLLED_WINDOW(scroll), TRUE);
+      gtk_scrolled_window_set_max_content_height(GTK_SCROLLED_WINDOW(scroll), 300);
+      gtk_scrolled_window_set_child(GTK_SCROLLED_WINDOW(scroll), GTK_WIDGET(session->gtk.results));
+      gtk_box_append(GTK_BOX(priv->gtk.bottom_box), scroll);
+      gtk_widget_set_visible(GTK_WIDGET(session->gtk.results), TRUE);
     }
   }
 
@@ -431,16 +453,17 @@ bool girara_isc_completion(girara_session_t* session, girara_argument_t* argumen
         if ((n_elements <= n_completion_items) || (i >= (current_item - lh) && (i <= current_item + uh)) ||
             (i < n_completion_items && current_item < lh) ||
             (i >= (n_elements - n_completion_items) && (current_item >= (n_elements - uh))) || (i == current_group)) {
-          gtk_widget_show(GTK_WIDGET(tmp->widget));
+          gtk_widget_set_visible(GTK_WIDGET(tmp->widget), TRUE);
         } else {
-          gtk_widget_hide(GTK_WIDGET(tmp->widget));
+          gtk_widget_set_visible(GTK_WIDGET(tmp->widget), FALSE);
         }
 
         tmpentry = g_list_next(tmpentry);
       }
     } else {
-      gtk_widget_hide(
-          GTK_WIDGET(((girara_internal_completion_entry_t*)(g_list_nth(priv->completion.entries, 0))->data)->widget));
+      gtk_widget_set_visible(
+          GTK_WIDGET(((girara_internal_completion_entry_t*)(g_list_nth(priv->completion.entries, 0))->data)->widget),
+          FALSE);
     }
 
     /* update text */
@@ -454,7 +477,7 @@ bool girara_isc_completion(girara_session_t* session, girara_argument_t* argumen
       temp = g_strconcat(":", priv->completion.previous_command, " ", escaped_value, NULL);
     }
 
-    gtk_entry_set_text(session->gtk.inputbar_entry, temp);
+    gtk_editable_set_text(GTK_EDITABLE(session->gtk.inputbar_entry), temp);
     gtk_editable_set_position(GTK_EDITABLE(session->gtk.inputbar_entry), -1);
     g_free(escaped_value);
 
@@ -482,10 +505,10 @@ bool girara_isc_completion(girara_session_t* session, girara_argument_t* argumen
   return false;
 }
 
-static GtkEventBox* girara_completion_row_create(const char* command, const char* description, bool group) {
+static GtkWidget* girara_completion_row_create(const char* command, const char* description, bool group) {
   GtkBox* col = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
 
-  GtkEventBox* row = GTK_EVENT_BOX(gtk_event_box_new());
+  GtkWidget* row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
   GtkLabel* show_command     = GTK_LABEL(gtk_label_new(NULL));
   GtkLabel* show_description = GTK_LABEL(gtk_label_new(NULL));
@@ -512,22 +535,25 @@ static GtkEventBox* girara_completion_row_create(const char* command, const char
   widget_add_class(GTK_WIDGET(row), class);
   widget_add_class(GTK_WIDGET(col), class);
 
-  gtk_box_pack_start(GTK_BOX(col), GTK_WIDGET(show_command), TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(col), GTK_WIDGET(show_description), TRUE, TRUE, 0);
+  gtk_widget_set_hexpand(GTK_WIDGET(show_command), TRUE);
+  gtk_widget_set_hexpand(GTK_WIDGET(show_description), TRUE);
+  gtk_box_append(GTK_BOX(col), GTK_WIDGET(show_command));
+  gtk_box_append(GTK_BOX(col), GTK_WIDGET(show_description));
 
-  gtk_container_add(GTK_CONTAINER(row), GTK_WIDGET(col));
-  gtk_widget_show_all(GTK_WIDGET(row));
+  gtk_box_append(GTK_BOX(row), GTK_WIDGET(col));
 
   return row;
 }
 
-static void girara_completion_row_set_color(GtkEventBox* row, int mode) {
+static void girara_completion_row_set_color(GtkWidget* row, int mode) {
   g_return_if_fail(row != NULL);
 
-  GtkBox* col            = GTK_BOX(gtk_bin_get_child(GTK_BIN(row)));
-  g_autoptr(GList) items = gtk_container_get_children(GTK_CONTAINER(col));
-  GtkWidget* cmd         = GTK_WIDGET(g_list_nth_data(items, 0));
-  GtkWidget* desc        = GTK_WIDGET(g_list_nth_data(items, 1));
+  GtkWidget* col  = gtk_widget_get_first_child(row);
+  GtkWidget* cmd  = col ? gtk_widget_get_first_child(col) : NULL;
+  GtkWidget* desc = cmd ? gtk_widget_get_next_sibling(cmd) : NULL;
+  if (cmd == NULL || desc == NULL) {
+    return;
+  }
 
   if (mode == GIRARA_HIGHLIGHT) {
     gtk_widget_set_state_flags(cmd, GTK_STATE_FLAG_SELECTED, false);

--- a/girara-gtk/session.c
+++ b/girara-gtk/session.c
@@ -174,6 +174,12 @@ static void fill_template_with_values(girara_session_t* session) {
   }
 }
 
+static void cb_css_parsing_error(GtkCssProvider* UNUSED(provider), GtkCssSection* section, const GError* error,
+                                 gpointer UNUSED(data)) {
+  g_autofree char* location = section != NULL ? gtk_css_section_to_string(section) : NULL;
+  girara_error("Unable to load CSS (%s): %s", location != NULL ? location : "unknown location", error->message);
+}
+
 static void css_template_changed(GiraraTemplate* csstemplate, girara_session_t* session) {
   GtkCssProvider* provider  = session->private_data->gtk.cssprovider;
   g_autofree char* css_data = girara_template_evaluate(csstemplate);
@@ -185,17 +191,16 @@ static void css_template_changed(GiraraTemplate* csstemplate, girara_session_t* 
   if (provider == NULL) {
     provider = session->private_data->gtk.cssprovider = gtk_css_provider_new();
 
+    /* the load call has no error return so errors arrive on this signal */
+    g_signal_connect(provider, "parsing-error", G_CALLBACK(cb_css_parsing_error), NULL);
+
     /* add CSS style provider */
     GdkDisplay* display = gdk_display_get_default();
-    GdkScreen* screen   = gdk_display_get_default_screen(display);
-    gtk_style_context_add_provider_for_screen(screen, GTK_STYLE_PROVIDER(provider),
-                                              GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+    gtk_style_context_add_provider_for_display(display, GTK_STYLE_PROVIDER(provider),
+                                               GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
   }
 
-  g_autoptr(GError) error = NULL;
-  if (gtk_css_provider_load_from_data(provider, css_data, -1, &error) == FALSE) {
-    girara_error("Unable to load CSS: %s", error->message);
-  }
+  gtk_css_provider_load_from_string(provider, css_data);
 }
 
 static void mode_string_free(void* data) {
@@ -275,14 +280,13 @@ girara_session_t* girara_session_create(void) {
   session->gtk.inputbar_box       = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
   gtk_box_set_homogeneous(session->gtk.inputbar_box, TRUE);
   session->gtk.view = gtk_stack_new();
-  gtk_widget_add_events(session->gtk.view, GDK_SCROLL_MASK);
   gtk_widget_set_can_focus(session->gtk.view, true);
-  session->gtk.statusbar         = gtk_event_box_new();
-  session->gtk.notification_area = gtk_event_box_new();
+  session->gtk.statusbar         = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+  session->gtk.notification_area = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   session->gtk.notification_text = gtk_label_new(NULL);
   session->gtk.inputbar_dialog   = GTK_LABEL(gtk_label_new(NULL));
   session->gtk.inputbar_entry    = GTK_ENTRY(gtk_entry_new());
-  session->gtk.inputbar          = gtk_event_box_new();
+  session->gtk.inputbar          = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
   /* make notification text selectable */
   gtk_label_set_selectable(GTK_LABEL(session->gtk.notification_text), TRUE);
@@ -290,15 +294,6 @@ girara_session_t* girara_session_create(void) {
   gtk_label_set_ellipsize(GTK_LABEL(session->gtk.notification_text), PANGO_ELLIPSIZE_END);
 
   return session;
-}
-
-static void screen_changed(GtkWidget* widget, GdkScreen* GIRARA_UNUSED(old_screen), gpointer GIRARA_UNUSED(userdata)) {
-  GdkScreen* screen = gtk_widget_get_screen(widget);
-  GdkVisual* visual = gdk_screen_get_rgba_visual(screen);
-  if (!visual) {
-    visual = gdk_screen_get_system_visual(screen);
-  }
-  gtk_widget_set_visual(widget, visual);
 }
 
 bool girara_session_init(girara_session_t* session, const char* sessionname) {
@@ -309,72 +304,44 @@ bool girara_session_init(girara_session_t* session, const char* sessionname) {
   /* set session name */
   session->private_data->session_name = g_strdup(sessionname);
 
-  /* enable smooth scroll events */
-  gtk_widget_add_events(session->gtk.view, GDK_SMOOTH_SCROLL_MASK);
-
   /* load CSS style */
   fill_template_with_values(session);
   g_signal_connect(G_OBJECT(session->private_data->csstemplate), "changed", G_CALLBACK(css_template_changed), session);
 
   /* window */
-#ifdef GDK_WINDOWING_X11
-  if (session->gtk.embed != 0) {
-    session->gtk.window = gtk_plug_new(session->gtk.embed);
-  } else {
-#endif
-    session->gtk.window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
-#ifdef GDK_WINDOWING_X11
-  }
-#endif
-
+  session->gtk.window = gtk_window_new();
   gtk_widget_set_name(session->gtk.window, session->private_data->session_name);
-
-  g_signal_connect(G_OBJECT(session->gtk.window), "screen-changed", G_CALLBACK(screen_changed), NULL);
-  screen_changed(GTK_WIDGET(session->gtk.window), NULL, NULL);
 
   /* apply CSS style */
   css_template_changed(session->private_data->csstemplate, session);
 
-  GdkGeometry hints = {
-      .base_height = 1,
-      .base_width  = 1,
-      .height_inc  = 0,
-      .max_aspect  = 0,
-      .max_height  = 0,
-      .max_width   = 0,
-      .min_aspect  = 0,
-      .min_height  = 0,
-      .min_width   = 0,
-      .width_inc   = 0,
-  };
-
-  gtk_window_set_geometry_hints(GTK_WINDOW(session->gtk.window), NULL, &hints, GDK_HINT_MIN_SIZE);
-
   /* view */
-  session->signals.view_key_pressed = g_signal_connect(G_OBJECT(session->gtk.view), "key-press-event",
-                                                       G_CALLBACK(girara_callback_view_key_press_event), session);
+  /* run in capture phase so the scrolled window does not eat navigation keys */
+  GtkEventController* key_ctrl = gtk_event_controller_key_new();
+  gtk_event_controller_set_propagation_phase(key_ctrl, GTK_PHASE_CAPTURE);
+  g_signal_connect(key_ctrl, "key-pressed", G_CALLBACK(girara_callback_view_key_press_event), session);
+  gtk_widget_add_controller(session->gtk.view, key_ctrl);
 
-  session->signals.view_button_press_event = g_signal_connect(
-      G_OBJECT(session->gtk.view), "button-press-event", G_CALLBACK(girara_callback_view_button_press_event), session);
+  GtkGesture* click = gtk_gesture_click_new();
+  gtk_gesture_single_set_button(GTK_GESTURE_SINGLE(click), 0);
+  g_signal_connect(click, "pressed", G_CALLBACK(girara_callback_view_button_press_event), session);
+  g_signal_connect(click, "released", G_CALLBACK(girara_callback_view_button_release_event), session);
+  gtk_widget_add_controller(session->gtk.view, GTK_EVENT_CONTROLLER(click));
 
-  session->signals.view_button_release_event =
-      g_signal_connect(G_OBJECT(session->gtk.view), "button-release-event",
-                       G_CALLBACK(girara_callback_view_button_release_event), session);
+  GtkEventController* motion = gtk_event_controller_motion_new();
+  g_signal_connect(motion, "motion", G_CALLBACK(girara_callback_view_button_motion_notify_event), session);
+  gtk_widget_add_controller(session->gtk.view, motion);
 
-  session->signals.view_motion_notify_event =
-      g_signal_connect(G_OBJECT(session->gtk.view), "motion-notify-event",
-                       G_CALLBACK(girara_callback_view_button_motion_notify_event), session);
-
-  session->signals.view_scroll_event = g_signal_connect(G_OBJECT(session->gtk.view), "scroll-event",
-                                                        G_CALLBACK(girara_callback_view_scroll_event), session);
+  GtkEventController* scroll = gtk_event_controller_scroll_new(GTK_EVENT_CONTROLLER_SCROLL_BOTH_AXES);
+  gtk_event_controller_set_propagation_phase(scroll, GTK_PHASE_CAPTURE);
+  g_signal_connect(scroll, "scroll", G_CALLBACK(girara_callback_view_scroll_event), session);
+  gtk_widget_add_controller(session->gtk.view, scroll);
 
   /* statusbar */
-  gtk_container_add(GTK_CONTAINER(session->gtk.statusbar), GTK_WIDGET(session->gtk.statusbar_entries));
+  gtk_box_append(GTK_BOX(session->gtk.statusbar), GTK_WIDGET(session->gtk.statusbar_entries));
 
   /* notification area */
-  g_signal_connect(G_OBJECT(session->gtk.notification_area), "key-press-event",
-                   G_CALLBACK(girara_callback_view_key_press_event), session);
-  gtk_container_add(GTK_CONTAINER(session->gtk.notification_area), session->gtk.notification_text);
+  gtk_box_append(GTK_BOX(session->gtk.notification_area), session->gtk.notification_text);
   gtk_widget_set_halign(session->gtk.notification_text, GTK_ALIGN_START);
   gtk_widget_set_valign(session->gtk.notification_text, GTK_ALIGN_CENTER);
   gtk_label_set_use_markup(GTK_LABEL(session->gtk.notification_text), TRUE);
@@ -387,9 +354,9 @@ bool girara_session_init(girara_session_t* session, const char* sessionname) {
   widget_add_class(session->gtk.notification_text, "bottom_box");
   widget_add_class(GTK_WIDGET(session->gtk.statusbar_entries), "bottom_box");
 
-  session->signals.inputbar_key_pressed =
-      g_signal_connect(G_OBJECT(session->gtk.inputbar_entry), "key-press-event",
-                       G_CALLBACK(girara_callback_inputbar_key_press_event), session);
+  GtkEventController* ib_key = gtk_event_controller_key_new();
+  g_signal_connect(ib_key, "key-pressed", G_CALLBACK(girara_callback_inputbar_key_press_event), session);
+  gtk_widget_add_controller(GTK_WIDGET(session->gtk.inputbar_entry), ib_key);
 
   session->signals.inputbar_changed = g_signal_connect(G_OBJECT(session->gtk.inputbar_entry), "changed",
                                                        G_CALLBACK(girara_callback_inputbar_changed_event), session);
@@ -401,31 +368,32 @@ bool girara_session_init(girara_session_t* session, const char* sessionname) {
   gtk_box_set_spacing(session->gtk.inputbar_box, 5);
 
   /* inputbar box */
-  gtk_box_pack_start(GTK_BOX(session->gtk.inputbar_box), GTK_WIDGET(session->gtk.inputbar_dialog), FALSE, FALSE, 0);
-  gtk_box_pack_start(GTK_BOX(session->gtk.inputbar_box), GTK_WIDGET(session->gtk.inputbar_entry), TRUE, TRUE, 0);
-  gtk_container_add(GTK_CONTAINER(session->gtk.inputbar), GTK_WIDGET(session->gtk.inputbar_box));
+  gtk_box_append(GTK_BOX(session->gtk.inputbar_box), GTK_WIDGET(session->gtk.inputbar_dialog));
+  gtk_box_append(GTK_BOX(session->gtk.inputbar_box), GTK_WIDGET(session->gtk.inputbar_entry));
+  gtk_widget_set_hexpand(GTK_WIDGET(session->gtk.inputbar_entry), true);
+  gtk_box_append(GTK_BOX(session->gtk.inputbar), GTK_WIDGET(session->gtk.inputbar_box));
 
   /* bottom box */
   gtk_box_set_spacing(session->private_data->gtk.bottom_box, 0);
 
-  gtk_box_pack_end(GTK_BOX(session->private_data->gtk.bottom_box), GTK_WIDGET(session->gtk.inputbar), TRUE, TRUE, 0);
-  gtk_box_pack_end(GTK_BOX(session->private_data->gtk.bottom_box), GTK_WIDGET(session->gtk.notification_area), TRUE,
-                   TRUE, 0);
-  gtk_box_pack_end(GTK_BOX(session->private_data->gtk.bottom_box), GTK_WIDGET(session->gtk.statusbar), TRUE, TRUE, 0);
+  gtk_box_prepend(GTK_BOX(session->private_data->gtk.bottom_box), GTK_WIDGET(session->gtk.inputbar));
+  gtk_box_prepend(GTK_BOX(session->private_data->gtk.bottom_box), GTK_WIDGET(session->gtk.notification_area));
+  gtk_box_prepend(GTK_BOX(session->private_data->gtk.bottom_box), GTK_WIDGET(session->gtk.statusbar));
 
   /* packing */
   gtk_box_set_spacing(session->gtk.box, 0);
-  gtk_box_pack_start(session->gtk.box, GTK_WIDGET(session->gtk.view), TRUE, TRUE, 0);
+  gtk_widget_set_vexpand(GTK_WIDGET(session->gtk.view), TRUE);
+  gtk_box_append(session->gtk.box, GTK_WIDGET(session->gtk.view));
 
   /* box */
-  gtk_container_add(GTK_CONTAINER(session->private_data->gtk.overlay), GTK_WIDGET(session->gtk.box));
+  gtk_overlay_set_child(GTK_OVERLAY(session->private_data->gtk.overlay), GTK_WIDGET(session->gtk.box));
   /* bottom_box */
   g_object_set(session->private_data->gtk.bottom_box, "halign", GTK_ALIGN_FILL, NULL);
   g_object_set(session->private_data->gtk.bottom_box, "valign", GTK_ALIGN_END, NULL);
 
-  gtk_container_add(GTK_CONTAINER(session->gtk.box), GTK_WIDGET(session->private_data->gtk.bottom_box));
+  gtk_box_append(session->gtk.box, GTK_WIDGET(session->private_data->gtk.bottom_box));
 
-  gtk_container_add(GTK_CONTAINER(session->gtk.window), GTK_WIDGET(session->private_data->gtk.overlay));
+  gtk_window_set_child(GTK_WINDOW(session->gtk.window), GTK_WIDGET(session->private_data->gtk.overlay));
 
   /* statusbar */
   widget_add_class(GTK_WIDGET(session->gtk.statusbar), "statusbar");
@@ -450,16 +418,16 @@ bool girara_session_init(girara_session_t* session, const char* sessionname) {
     gtk_window_set_default_size(GTK_WINDOW(session->gtk.window), window_width, window_height);
   }
 
-  gtk_widget_show_all(GTK_WIDGET(session->gtk.window));
-  gtk_widget_hide(GTK_WIDGET(session->gtk.notification_area));
-  gtk_widget_hide(GTK_WIDGET(session->gtk.inputbar_dialog));
+  gtk_widget_set_visible(GTK_WIDGET(session->gtk.window), TRUE);
+  gtk_widget_set_visible(GTK_WIDGET(session->gtk.notification_area), FALSE);
+  gtk_widget_set_visible(GTK_WIDGET(session->gtk.inputbar_dialog), FALSE);
 
   if (session->global.autohide_inputbar == true) {
-    gtk_widget_hide(GTK_WIDGET(session->gtk.inputbar));
+    gtk_widget_set_visible(GTK_WIDGET(session->gtk.inputbar), FALSE);
   }
 
   if (session->global.hide_statusbar == true) {
-    gtk_widget_hide(GTK_WIDGET(session->gtk.statusbar));
+    gtk_widget_set_visible(GTK_WIDGET(session->gtk.statusbar), FALSE);
   }
 
   gtk_widget_grab_focus(GTK_WIDGET(session->gtk.view));
@@ -602,8 +570,8 @@ void girara_notify(girara_session_t* session, int level, const char* format, ...
   gtk_label_set_markup(GTK_LABEL(session->gtk.notification_text), message);
 
   /* update visibility */
-  gtk_widget_show(GTK_WIDGET(session->gtk.notification_area));
-  gtk_widget_hide(GTK_WIDGET(session->gtk.inputbar));
+  gtk_widget_set_visible(GTK_WIDGET(session->gtk.notification_area), TRUE);
+  gtk_widget_set_visible(GTK_WIDGET(session->gtk.inputbar), FALSE);
 
   gtk_widget_grab_focus(GTK_WIDGET(session->gtk.view));
 }
@@ -616,7 +584,7 @@ void girara_dialog(girara_session_t* session, const char* dialog, bool invisible
     return;
   }
 
-  gtk_widget_show(GTK_WIDGET(session->gtk.inputbar_dialog));
+  gtk_widget_set_visible(GTK_WIDGET(session->gtk.inputbar_dialog), TRUE);
 
   /* set dialog message */
   if (dialog != NULL) {
@@ -644,7 +612,7 @@ bool girara_set_view(girara_session_t* session, GtkWidget* widget) {
 
   GtkWidget* parent = gtk_widget_get_parent(widget);
   if (parent != session->gtk.view) {
-    gtk_container_add(GTK_CONTAINER(session->gtk.view), widget);
+    gtk_stack_add_child(GTK_STACK(session->gtk.view), widget);
   }
 
   gtk_widget_set_visible(widget, true);
@@ -707,25 +675,9 @@ bool girara_set_window_icon(girara_session_t* session, const char* name) {
     return false;
   }
 
-  GtkWindow* window     = GTK_WINDOW(session->gtk.window);
-  g_autofree char* path = girara_fix_path(name);
-  bool success          = true;
-
-  if (g_file_test(path, G_FILE_TEST_EXISTS) == TRUE) {
-    girara_debug("Loading window icon from file: %s", path);
-
-    g_autoptr(GError) error = NULL;
-    success                 = gtk_window_set_icon_from_file(window, path, &error);
-
-    if (success == false) {
-      girara_debug("Failed to load window icon (file): %s", error->message);
-    }
-  } else {
-    girara_debug("Loading window icon with name: %s", name);
-    gtk_window_set_icon_name(window, name);
-  }
-
-  return success;
+  girara_debug("Loading window icon with name: %s", name);
+  gtk_window_set_icon_name(GTK_WINDOW(session->gtk.window), name);
+  return true;
 }
 
 girara_list_t* girara_get_command_history(girara_session_t* session) {

--- a/girara-gtk/session.h
+++ b/girara-gtk/session.h
@@ -9,12 +9,6 @@
 #include <girara/log.h>
 #include <gtk/gtk.h>
 
-#ifdef GDK_WINDOWING_X11
-#include <gtk/gtkx.h>
-#else
-typedef int Window;
-#endif
-
 struct girara_session_s {
   girara_session_private_t* private_data; /**< Private data of a girara session */
   GiraraInputHistory* command_history;    /**< Command history */
@@ -32,7 +26,6 @@ struct girara_session_s {
     GtkLabel* inputbar_dialog;    /**< Inputbar dialog */
     GtkEntry* inputbar_entry;     /**< Inputbar entry */
     GtkBox* results;              /**< Completion results */
-    Window embed;                 /**< Embedded window */
   } gtk;
 
   struct {
@@ -60,13 +53,7 @@ struct girara_session_s {
     girara_callback_inputbar_key_press_event_t inputbar_custom_key_press_event; /**< Custom handler */
     void* inputbar_custom_data;                                                 /**< Data for custom handler */
     int inputbar_activate;                                                      /**< Inputbar activation */
-    int inputbar_key_pressed;                                                   /**< Pressed key in inputbar */
     int inputbar_changed;                                                       /**< Inputbar text changed */
-    int view_key_pressed;                                                       /**< Pressed key in view */
-    int view_button_press_event;                                                /**< Pressed button */
-    int view_button_release_event;                                              /**< Released button */
-    int view_motion_notify_event;                                               /**< Cursor movement event */
-    int view_scroll_event;                                                      /**< Scroll event */
   } signals;
 
   struct {

--- a/girara-gtk/shortcuts.c
+++ b/girara-gtk/shortcuts.c
@@ -2,6 +2,7 @@
 
 #include "shortcuts.h"
 
+#include "callbacks.h"
 #include "internal.h"
 #include "session.h"
 #include "settings.h"
@@ -144,9 +145,9 @@ bool girara_isc_abort(girara_session_t* session, girara_argument_t* UNUSED(argum
   gtk_widget_grab_focus(GTK_WIDGET(session->gtk.view));
 
   /* hide inputbar */
-  gtk_widget_hide(GTK_WIDGET(session->gtk.inputbar_dialog));
+  gtk_widget_set_visible(GTK_WIDGET(session->gtk.inputbar_dialog), FALSE);
   if (session->global.autohide_inputbar == true) {
-    gtk_widget_hide(GTK_WIDGET(session->gtk.inputbar));
+    gtk_widget_set_visible(GTK_WIDGET(session->gtk.inputbar), FALSE);
   }
 
   /* Begin from the last command when navigating through history */
@@ -244,7 +245,7 @@ bool girara_isc_command_history(girara_session_t* session, girara_argument_t* ar
                                                      : girara_input_history_previous(session->command_history, temp);
 
   if (command != NULL) {
-    gtk_entry_set_text(session->gtk.inputbar_entry, command);
+    gtk_editable_set_text(GTK_EDITABLE(session->gtk.inputbar_entry), command);
     gtk_widget_grab_focus(GTK_WIDGET(session->gtk.inputbar_entry));
     gtk_editable_set_position(GTK_EDITABLE(session->gtk.inputbar_entry), -1);
   }
@@ -259,27 +260,18 @@ bool girara_sc_focus_inputbar(girara_session_t* session, girara_argument_t* argu
   g_return_val_if_fail(session->gtk.inputbar_entry != NULL, false);
 
   if (gtk_widget_get_visible(GTK_WIDGET(session->gtk.inputbar)) == false) {
-    gtk_widget_show(GTK_WIDGET(session->gtk.inputbar));
+    gtk_widget_set_visible(GTK_WIDGET(session->gtk.inputbar), TRUE);
   }
 
   if (gtk_widget_get_visible(GTK_WIDGET(session->gtk.notification_area)) == true) {
-    gtk_widget_hide(GTK_WIDGET(session->gtk.notification_area));
+    gtk_widget_set_visible(GTK_WIDGET(session->gtk.notification_area), FALSE);
   }
 
   gtk_widget_grab_focus(GTK_WIDGET(session->gtk.inputbar_entry));
 
   if (argument != NULL && argument->data != NULL) {
-    gtk_entry_set_text(session->gtk.inputbar_entry, (char*)argument->data);
-
-    /* we save the X clipboard that will be clear by "grab_focus" */
-    g_autofree gchar* x_clipboard_text = gtk_clipboard_wait_for_text(gtk_clipboard_get(GDK_SELECTION_PRIMARY));
-
+    gtk_editable_set_text(GTK_EDITABLE(session->gtk.inputbar_entry), (char*)argument->data);
     gtk_editable_set_position(GTK_EDITABLE(session->gtk.inputbar_entry), -1);
-
-    if (x_clipboard_text != NULL) {
-      /* we reset the X clipboard with saved text */
-      gtk_clipboard_set_text(gtk_clipboard_get(GDK_SELECTION_PRIMARY), x_clipboard_text, -1);
-    }
   }
 
   return true;
@@ -291,10 +283,10 @@ bool girara_sc_abort(girara_session_t* session, girara_argument_t* UNUSED(argume
 
   girara_isc_abort(session, NULL, NULL, 0);
 
-  gtk_widget_hide(GTK_WIDGET(session->gtk.notification_area));
+  gtk_widget_set_visible(GTK_WIDGET(session->gtk.notification_area), FALSE);
 
   if (session->global.autohide_inputbar == false) {
-    gtk_widget_show(GTK_WIDGET(session->gtk.inputbar));
+    gtk_widget_set_visible(GTK_WIDGET(session->gtk.inputbar), TRUE);
   }
 
   return false;
@@ -306,9 +298,9 @@ static void girara_toggle_widget_visibility(GtkWidget* widget) {
   }
 
   if (gtk_widget_get_visible(widget) == TRUE) {
-    gtk_widget_hide(widget);
+    gtk_widget_set_visible(widget, FALSE);
   } else {
-    gtk_widget_show(widget);
+    gtk_widget_set_visible(widget, TRUE);
   }
 }
 
@@ -373,46 +365,6 @@ bool girara_sc_set(girara_session_t* session, girara_argument_t* argument, girar
   return false;
 }
 
-static bool simulate_key_press(girara_session_t* session, int state, int key) {
-  if (session == NULL || session->gtk.box == NULL) {
-    return false;
-  }
-
-  g_autoptr(GdkEvent) event = gdk_event_new(GDK_KEY_PRESS);
-
-  event->any.type       = GDK_KEY_PRESS;
-  event->key.window     = g_object_ref(gtk_widget_get_parent_window(GTK_WIDGET(session->gtk.box)));
-  event->key.send_event = false;
-  event->key.time       = GDK_CURRENT_TIME;
-  event->key.state      = state;
-  event->key.keyval     = key;
-
-  GdkDisplay* display           = gtk_widget_get_display(GTK_WIDGET(session->gtk.box));
-  g_autofree GdkKeymapKey* keys = NULL;
-  gint number_of_keys           = 0;
-
-  if (gdk_keymap_get_entries_for_keyval(gdk_keymap_get_for_display(display), event->key.keyval, &keys,
-                                        &number_of_keys) == FALSE) {
-    return false;
-  }
-
-  event->key.hardware_keycode = keys[0].keycode;
-  event->key.group            = keys[0].group;
-
-  GdkSeat* seat       = gdk_display_get_default_seat(display);
-  GdkDevice* keyboard = gdk_seat_get_keyboard(seat);
-  gdk_event_set_device(event, keyboard);
-
-  gdk_event_put(event);
-
-  // process events until there are no pending events left
-  do {
-    g_main_context_iteration(NULL, FALSE);
-  } while (g_main_context_pending(NULL));
-
-  return true;
-}
-
 static int update_state_by_keyval(int state, int keyval) {
   /* The following is probably not true for some keyboard layouts. */
   if ((keyval >= '!' && keyval <= '/') || (keyval >= ':' && keyval <= '@') || (keyval >= '[' && keyval <= '`') ||
@@ -461,7 +413,7 @@ bool girara_sc_feedkeys(girara_session_t* session, girara_argument_t* argument, 
             state = GDK_SHIFT_MASK;
             break;
           case 'A':
-            state = GDK_MOD1_MASK;
+            state = GDK_ALT_MASK;
             break;
           case 'C':
             state = GDK_CONTROL_MASK;
@@ -501,7 +453,7 @@ bool girara_sc_feedkeys(girara_session_t* session, girara_argument_t* argument, 
 
     single_key:
       state = update_state_by_keyval(state, keyval);
-      simulate_key_press(session, state, keyval);
+      girara_process_view_key(session, keyval, state);
     }
   }
 

--- a/girara-gtk/statusbar.c
+++ b/girara-gtk/statusbar.c
@@ -8,7 +8,8 @@
 #include "internal.h"
 #include "settings.h"
 
-girara_statusbar_item_t* girara_statusbar_item_add(girara_session_t* session, bool expand, bool fill, bool left) {
+girara_statusbar_item_t* girara_statusbar_item_add(girara_session_t* session, bool expand, bool UNUSED(fill),
+                                                   bool left) {
   g_return_val_if_fail(session != NULL, NULL);
 
   girara_session_private_t* session_private = session->private_data;
@@ -33,8 +34,9 @@ girara_statusbar_item_t* girara_statusbar_item_add(girara_session_t* session, bo
   }
 
   /* add it to the list */
-  gtk_box_pack_start(session->gtk.statusbar_entries, GTK_WIDGET(item->text), expand, fill, 0);
-  gtk_widget_show_all(GTK_WIDGET(item->text));
+  gtk_widget_set_hexpand(GTK_WIDGET(item->text), expand);
+  gtk_box_append(session->gtk.statusbar_entries, GTK_WIDGET(item->text));
+  gtk_widget_set_visible(GTK_WIDGET(item->text), TRUE);
 
   girara_list_append(session_private->elements.statusbar_items, item);
   return item;

--- a/girara-gtk/utils.c
+++ b/girara-gtk/utils.c
@@ -13,9 +13,8 @@ void widget_add_class(GtkWidget* widget, const char* styleclass) {
     return;
   }
 
-  GtkStyleContext* context = gtk_widget_get_style_context(widget);
-  if (gtk_style_context_has_class(context, styleclass) == FALSE) {
-    gtk_style_context_add_class(context, styleclass);
+  if (gtk_widget_has_css_class(widget, styleclass) == FALSE) {
+    gtk_widget_add_css_class(widget, styleclass);
   }
 }
 
@@ -24,8 +23,7 @@ void widget_remove_class(GtkWidget* widget, const char* styleclass) {
     return;
   }
 
-  GtkStyleContext* context = gtk_widget_get_style_context(widget);
-  if (gtk_style_context_has_class(context, styleclass) == TRUE) {
-    gtk_style_context_remove_class(context, styleclass);
+  if (gtk_widget_has_css_class(widget, styleclass) == TRUE) {
+    gtk_widget_remove_css_class(widget, styleclass);
   }
 }

--- a/meson.build
+++ b/meson.build
@@ -48,18 +48,13 @@ glib = dependency('glib-2.0', version: '>=2.76')
 gio = dependency('gio-unix-2.0', required: host_machine.system() != 'windows')
 gthread = dependency('gthread-2.0', version: '>=2.72')
 gmodule = dependency('gmodule-no-export-2.0', version: '>=2.72')
-gtk3 = dependency('gtk+-3.0', version: '>=3.24')
+gtk4 = dependency('gtk4', version: '>=4.12', include_type: 'system')
 json_glib = dependency('json-glib-1.0')
 cairo = dependency('cairo')
 magic = dependency('libmagic')
 sqlite = dependency('sqlite3', version: '>=3.6.23')
 
-build_dependencies = [libm, girara, glib, gio, gthread, gmodule, gtk3, cairo, magic, json_glib]
-
-if host_machine.system() == 'darwin'
-  gtk_mac_integration = dependency('gtk-mac-integration-gtk3')
-  build_dependencies += gtk_mac_integration
-endif
+build_dependencies = [libm, girara, glib, gio, gthread, gmodule, gtk4, cairo, magic, json_glib]
 
 # defines
 defines = [
@@ -229,7 +224,7 @@ pkg.generate(
   description: 'document viewer - plugin API',
   url: 'https://pwmt.org/projects/zathura',
   version: version,
-  requires: ['girara', 'gtk+-3.0', 'cairo'],
+  requires: ['girara', 'gtk4', 'cairo'],
   variables: [
     'apiversion=@0@'.format(plugin_api_version),
     'abiversion=@0@'.format(plugin_abi_version),

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -81,8 +81,10 @@ if xvfb.found()
     protocol: 'tap',
     env: env + [
       'NO_AT_BRIDGE=1',
+      'GTK_A11Y=none',
       'MESA_LOG=null',
-      'LIBGL_DEBUG=quiet'
+      'LIBGL_DEBUG=quiet',
+      'EGL_LOG_LEVEL=fatal'
     ]
   )
   test('xvfb_config', xvfb,
@@ -92,8 +94,10 @@ if xvfb.found()
     protocol: 'tap',
     env: [
       'NO_AT_BRIDGE=1',
+      'GTK_A11Y=none',
       'MESA_LOG=null',
-      'LIBGL_DEBUG=quiet'
+      'LIBGL_DEBUG=quiet',
+      'EGL_LOG_LEVEL=fatal'
     ]
   )
   test('xvfb_setting', xvfb,
@@ -103,8 +107,10 @@ if xvfb.found()
     protocol: 'tap',
     env: [
       'NO_AT_BRIDGE=1',
+      'GTK_A11Y=none',
       'MESA_LOG=null',
-      'LIBGL_DEBUG=quiet'
+      'LIBGL_DEBUG=quiet',
+      'EGL_LOG_LEVEL=fatal'
     ]
   )
 endif
@@ -119,6 +125,7 @@ if weston.found()
     protocol: 'tap',
     env: env + [
       'NO_AT_BRIDGE=1',
+      'GTK_A11Y=none',
       'WAYLAND_DISPLAY=zathura-test-weston'
     ]
   )
@@ -128,6 +135,7 @@ if weston.found()
     protocol: 'tap',
     env: env + [
       'NO_AT_BRIDGE=1',
+      'GTK_A11Y=none',
       'WAYLAND_DISPLAY=zathura-test-weston'
     ]
   )
@@ -137,6 +145,7 @@ if weston.found()
     protocol: 'tap',
     env: env + [
       'NO_AT_BRIDGE=1',
+      'GTK_A11Y=none',
       'WAYLAND_DISPLAY=zathura-test-weston'
     ]
   )
@@ -156,6 +165,7 @@ if weston.found()
         'G_TEST_SRCDIR=@0@'.format(meson.current_source_dir()),
         'G_TEST_BUILDDIR=@0@'.format(meson.current_build_dir()),
         'NO_AT_BRIDGE=1',
+      'GTK_A11Y=none',
         'WAYLAND_DISPLAY=zathura-test-weston'
       ]
     )

--- a/tests/test_config.c
+++ b/tests/test_config.c
@@ -88,7 +88,7 @@ static void test_config_parse(void) {
 int main(int argc, char* argv[]) {
   setup_logger();
 
-  gtk_init(NULL, NULL);
+  gtk_init();
   g_test_init(&argc, &argv, NULL);
   g_test_add_func("/config/parse", test_config_parse);
   g_test_add_func("/config/parse_modifier_keys", test_config_parse_modifier_keys);

--- a/tests/test_sandbox.c
+++ b/tests/test_sandbox.c
@@ -11,6 +11,11 @@
 
 #include "tests.h"
 
+#include <gtk/gtk.h>
+#ifdef GDK_WINDOWING_X11
+#include <gdk/x11/gdkx.h>
+#endif
+
 static void test_create(void) {
   setup_logger();
 
@@ -47,7 +52,7 @@ static void test_create(void) {
 int main(int argc, char* argv[]) {
   setup_logger();
 
-  gtk_init(NULL, NULL);
+  gtk_init();
   g_test_init(&argc, &argv, NULL);
   g_test_add_func("/sandbox/session_create", test_create);
   return g_test_run();

--- a/tests/test_session.c
+++ b/tests/test_session.c
@@ -39,7 +39,7 @@ static void test_create(void) {
 int main(int argc, char* argv[]) {
   setup_logger();
 
-  gtk_init(NULL, NULL);
+  gtk_init();
   g_test_init(&argc, &argv, NULL);
   g_test_add_func("/girara/session/create", test_girara_create);
   g_test_add_func("/girara/session/init", test_girara_init);

--- a/tests/test_setting.c
+++ b/tests/test_setting.c
@@ -72,7 +72,7 @@ static void test_settings_callback(void) {
 int main(int argc, char* argv[]) {
   setup_logger();
 
-  gtk_init(NULL, NULL);
+  gtk_init();
   g_test_init(&argc, &argv, NULL);
   g_test_add_func("/settings/basic", test_settings_basic);
   g_test_add_func("/settings/callback", test_settings_callback);

--- a/tests/weston_session.sh
+++ b/tests/weston_session.sh
@@ -3,6 +3,9 @@
 export XDG_RUNTIME_DIR=$(mktemp -d)
 mkdir -p "$XDG_RUNTIME_DIR"
 
+# headless GPU drivers can lose the Vulkan surface and abort, so render in software
+export GSK_RENDERER=cairo
+
 weston --backend=headless-backend.so --socket=zathura-test-weston --idle-time=0 &
 WESTON_PID=$!
 

--- a/zathura/adjustment.c
+++ b/zathura/adjustment.c
@@ -181,10 +181,6 @@ void zathura_adjustment_set_value(GtkAdjustment* adjustment, gdouble value) {
 }
 
 void zathura_adjustment_set_value_from_ratio(GtkAdjustment* adjustment, gdouble ratio) {
-  if (ratio == 0.0) {
-    return;
-  }
-
   gdouble lower     = gtk_adjustment_get_lower(adjustment);
   gdouble upper     = gtk_adjustment_get_upper(adjustment);
   gdouble page_size = gtk_adjustment_get_page_size(adjustment);

--- a/zathura/callbacks.c
+++ b/zathura/callbacks.c
@@ -26,12 +26,22 @@
 #include "synctex.h"
 #include "dbus-interface.h"
 
-gboolean cb_destroy(GtkWidget* UNUSED(widget), zathura_t* zathura) {
+gboolean cb_destroy(GtkWidget* widget, zathura_t* zathura) {
+  /* genuine "destroy": the window and its child widgets are being finalized, so drop the borrowed pointers first */
+  if (widget != NULL && zathura != NULL && zathura->ui.session != NULL) {
+    zathura->ui.document_widget     = NULL;
+    zathura->ui.session->gtk.window = NULL;
+  }
+
   if (zathura_has_document(zathura) == true) {
     document_close(zathura, false);
   }
 
-  gtk_main_quit();
+  GApplication* app = g_application_get_default();
+  if (app != NULL) {
+    g_application_quit(app);
+  }
+
   return TRUE;
 }
 
@@ -99,6 +109,12 @@ void update_visible_pages(zathura_t* zathura) {
   }
 }
 
+static bool in_single_page_mode(zathura_t* zathura) {
+  int layout_mode = DOCUMENT_WIDGET_GRID;
+  g_object_get(zathura->ui.document_widget, "layout-mode", &layout_mode, NULL);
+  return layout_mode == DOCUMENT_WIDGET_SINGLE;
+}
+
 void cb_view_hadjustment_value_changed(GtkAdjustment* adjustment, gpointer data) {
   zathura_t* zathura = data;
   if (zathura_has_document(zathura) == false) {
@@ -119,7 +135,10 @@ void cb_view_hadjustment_value_changed(GtkAdjustment* adjustment, gpointer data)
 
   zathura_document_set_position_x(document, position_x);
   zathura_document_set_position_y(document, position_y);
-  zathura_document_set_current_page_number(document, page_id);
+  /* In single-page mode the page is selected explicitly so scrolling must not change it */
+  if (in_single_page_mode(zathura) == false) {
+    zathura_document_set_current_page_number(document, page_id);
+  }
 
   statusbar_page_number_update(zathura);
 }
@@ -144,7 +163,10 @@ void cb_view_vadjustment_value_changed(GtkAdjustment* adjustment, gpointer data)
 
   zathura_document_set_position_x(document, position_x);
   zathura_document_set_position_y(document, position_y);
-  zathura_document_set_current_page_number(document, page_id);
+  /* In single-page mode the page is selected explicitly so scrolling must not change it */
+  if (in_single_page_mode(zathura) == false) {
+    zathura_document_set_current_page_number(document, page_id);
+  }
 
   statusbar_page_number_update(zathura);
 }
@@ -176,6 +198,17 @@ static void cb_view_adjustment_changed(GtkAdjustment* adjustment, zathura_t* zat
       width == true ? zathura_document_get_position_x(document) : zathura_document_get_position_y(document);
 
   zathura_adjustment_set_value_from_ratio(adjustment, ratio);
+
+  /* store the position that was actually applied so it stays valid after the view is sized */
+  const double extent = gtk_adjustment_get_upper(adjustment) - gtk_adjustment_get_lower(adjustment);
+  if (extent > size) {
+    const double applied = zathura_adjustment_get_ratio(adjustment);
+    if (width == true) {
+      zathura_document_set_position_x(document, applied);
+    } else {
+      zathura_document_set_position_y(document, applied);
+    }
+  }
 }
 
 void cb_view_hadjustment_changed(GtkAdjustment* adjustment, gpointer data) {
@@ -225,51 +258,14 @@ void cb_refresh_view(GtkWidget* GIRARA_UNUSED(view), gpointer data) {
   statusbar_page_number_update(zathura);
 }
 
-void cb_monitors_changed(GdkScreen* screen, gpointer data) {
-  girara_debug("signal received");
-
-  zathura_t* zathura = data;
-  if (screen == NULL || zathura == NULL) {
-    return;
-  }
-
-  zathura_update_view_ppi(zathura);
-}
-
-void cb_widget_screen_changed(GtkWidget* widget, GdkScreen* previous_screen, gpointer data) {
-  girara_debug("called");
-
-  zathura_t* zathura = data;
-  if (widget == NULL || zathura == NULL) {
-    return;
-  }
-
-  /* disconnect previous screen handler if present */
-  if (previous_screen != NULL && zathura->signals.monitors_changed_handler > 0) {
-    g_signal_handler_disconnect(previous_screen, zathura->signals.monitors_changed_handler);
-    zathura->signals.monitors_changed_handler = 0;
-  }
-
-  if (gtk_widget_has_screen(widget)) {
-    GdkScreen* screen = gtk_widget_get_screen(widget);
-
-    /* connect to new screen */
-    zathura->signals.monitors_changed_handler =
-        g_signal_connect(G_OBJECT(screen), "monitors-changed", G_CALLBACK(cb_monitors_changed), zathura);
-  }
-
-  zathura_update_view_ppi(zathura);
-}
-
-gboolean cb_widget_configured(GtkWidget* UNUSED(widget), GdkEvent* UNUSED(event), gpointer data) {
+void cb_monitors_changed(GListModel* UNUSED(model), guint UNUSED(position), guint UNUSED(removed), guint UNUSED(added),
+                         gpointer data) {
   zathura_t* zathura = data;
   if (zathura == NULL) {
-    return false;
+    return;
   }
 
   zathura_update_view_ppi(zathura);
-
-  return false;
 }
 
 void cb_scale_factor(GObject* object, GParamSpec* UNUSED(pspec), gpointer data) {
@@ -346,32 +342,36 @@ void cb_page_layout_value_changed(girara_session_t* session, const char* name, g
   g_object_set_property(G_OBJECT(zathura->ui.document_widget), "pages-right-to-left", &page_right_to_left_value);
 
   zathura_document_widget_refresh_layout(document_widget);
+
+  /* padding/column changes shift each page's relative position, so re-anchor on the current page;
+     otherwise its stale ratio leaves it off-screen and unrendered until the next manual scroll */
+  zathura_document_t* document    = zathura_get_document(zathura);
+  const unsigned int current_page = zathura_document_get_current_page_number(document);
+  double anchor_x = 0.0, anchor_y = 0.0;
+  page_number_to_position(zathura, current_page, 0.5, 0.5, &anchor_x, &anchor_y);
+  zathura_document_set_position_x(document, anchor_x);
+  zathura_document_set_position_y(document, anchor_y);
+  refresh_view(zathura);
 }
 
-void cb_index_row_activated(GtkTreeView* tree_view, GtkTreePath* path, GtkTreeViewColumn* UNUSED(column), void* data) {
+void cb_index_row_activated(GtkListView* view, guint position, void* data) {
   zathura_t* zathura = data;
-  if (tree_view == NULL || zathura == NULL || zathura->ui.session == NULL) {
+  if (view == NULL || zathura == NULL || zathura->ui.session == NULL) {
     return;
   }
 
-  GtkTreeModel* model;
-  GtkTreeIter iter;
-
-  g_object_get(G_OBJECT(tree_view), "model", &model, NULL);
-
-  if (gtk_tree_model_get_iter(model, &iter, path)) {
-    zathura_index_element_t* index_element;
-    gtk_tree_model_get(model, &iter, 3, &index_element, -1);
-
-    if (index_element == NULL) {
-      return;
-    }
-
-    sc_toggle_index(zathura->ui.session, NULL, NULL, 0);
-    zathura_link_evaluate(zathura, index_element->link);
+  GListModel* model             = G_LIST_MODEL(gtk_list_view_get_model(view));
+  g_autoptr(GtkTreeListRow) row = g_list_model_get_item(model, position);
+  if (row == NULL) {
+    return;
+  }
+  g_autoptr(ZathuraIndexElementObject) item = gtk_tree_list_row_get_item(row);
+  if (item == NULL || item->element == NULL) {
+    return;
   }
 
-  g_object_unref(model);
+  sc_toggle_index(zathura->ui.session, NULL, NULL, 0);
+  zathura_link_evaluate(zathura, item->element->link);
 }
 
 typedef enum zathura_link_action_e {
@@ -424,7 +424,7 @@ static gboolean handle_link(GtkEntry* entry, girara_session_t* session, zathura_
       zathura_link_display(zathura, link);
       break;
     case ZATHURA_LINK_ACTION_COPY: {
-      g_autofree GdkAtom* selection = get_selection(zathura);
+      GdkClipboard* selection = get_selection(zathura);
       if (selection == NULL) {
         break;
       }
@@ -527,14 +527,14 @@ gboolean cb_password_dialog(GtkEntry* entry, void* data) {
 
   /* no or empty password: ask again */
   if (input == NULL || strlen(input) == 0) {
-    gdk_threads_add_idle(password_dialog, dialog);
+    g_idle_add(password_dialog, dialog);
     return false;
   }
 
   /* try to open document again */
   if (document_open(dialog->zathura, dialog->path, dialog->uri, input, ZATHURA_PAGE_NUMBER_UNSPECIFIED, NULL) ==
       false) {
-    gdk_threads_add_idle(password_dialog, dialog);
+    g_idle_add(password_dialog, dialog);
   } else {
     password_dialog_info_free(dialog);
   }
@@ -636,13 +636,13 @@ void cb_page_widget_text_selected(ZathuraPageWidget* page, const char* text, voi
     return;
   }
 
-  g_autofree GdkAtom* selection = get_selection(zathura);
+  GdkClipboard* selection = get_selection(zathura);
   if (selection == NULL) {
     return;
   }
 
   /* copy to clipboard */
-  gtk_clipboard_set_text(gtk_clipboard_get(*selection), text, -1);
+  gdk_clipboard_set_text(selection, text);
 
   bool notification = true;
   girara_setting_get(zathura->ui.session, "selection-notification", &notification);
@@ -659,18 +659,18 @@ void cb_page_widget_text_selected(ZathuraPageWidget* page, const char* text, voi
   }
 }
 
-void cb_page_widget_image_selected(ZathuraPageWidget* page, GdkPixbuf* pixbuf, void* data) {
+void cb_page_widget_image_selected(ZathuraPageWidget* page, GdkTexture* texture, void* data) {
   g_return_if_fail(page != NULL);
-  g_return_if_fail(pixbuf != NULL);
+  g_return_if_fail(texture != NULL);
   g_return_if_fail(data != NULL);
 
-  zathura_t* zathura            = data;
-  g_autofree GdkAtom* selection = get_selection(zathura);
+  zathura_t* zathura      = data;
+  GdkClipboard* selection = get_selection(zathura);
   if (selection == NULL) {
     return;
   }
 
-  gtk_clipboard_set_image(gtk_clipboard_get(*selection), pixbuf);
+  gdk_clipboard_set(selection, GDK_TYPE_TEXTURE, texture);
 
   bool notification = true;
   girara_setting_get(zathura->ui.session, "selection-notification", &notification);
@@ -690,14 +690,15 @@ void cb_page_widget_link(ZathuraPageWidget* page, void* data) {
 
   bool enter = (bool)data;
 
-  GdkWindow* window   = gtk_widget_get_parent_window(GTK_WIDGET(page));
-  GdkDisplay* display = gtk_widget_get_display(GTK_WIDGET(page));
-  GdkCursor* cursor   = gdk_cursor_new_for_display(display, enter == true ? GDK_HAND1 : GDK_LEFT_PTR);
-  gdk_window_set_cursor(window, cursor);
-  g_object_unref(cursor);
+  GdkCursor* cursor = gdk_cursor_new_from_name(enter == true ? "pointer" : "default", NULL);
+  gtk_widget_set_cursor(GTK_WIDGET(page), cursor);
+  if (cursor != NULL) {
+    g_object_unref(cursor);
+  }
 }
 
-void cb_page_widget_scaled_button_release(ZathuraPageWidget* page_widget, GdkEventButton* event, void* data) {
+void cb_page_widget_scaled_button_release(ZathuraPageWidget* page_widget, scaled_button_release_event_t* event,
+                                          void* data) {
   zathura_t* zathura   = data;
   zathura_page_t* page = zathura_page_widget_get_page(page_widget);
 
@@ -729,21 +730,6 @@ void cb_page_widget_scaled_button_release(ZathuraPageWidget* page_widget, GdkEve
 
     synctex_edit(zathura, editor, page, event->x, event->y);
   }
-}
-
-void cb_window_update_icon(ZathuraRenderRequest* GIRARA_UNUSED(request), cairo_surface_t* surface, void* data) {
-  zathura_t* zathura = data;
-
-  girara_debug("updating window icon");
-  GdkPixbuf* pixbuf = gdk_pixbuf_get_from_surface(surface, 0, 0, cairo_image_surface_get_width(surface),
-                                                  cairo_image_surface_get_height(surface));
-  if (pixbuf == NULL) {
-    girara_error("Unable to convert cairo surface to Gdk Pixbuf.");
-    return;
-  }
-
-  gtk_window_set_icon(GTK_WINDOW(zathura->ui.session->gtk.window), pixbuf);
-  g_object_unref(pixbuf);
 }
 
 void cb_gesture_zoom_begin(GtkGesture* UNUSED(self), GdkEventSequence* UNUSED(sequence), void* data) {

--- a/zathura/callbacks.h
+++ b/zathura/callbacks.h
@@ -10,6 +10,7 @@
 #include "internal.h"
 #include "document.h"
 #include "zathura.h"
+#include "page-widget.h"
 
 /**
  * Quits the current zathura session
@@ -80,47 +81,6 @@ void cb_view_vadjustment_changed(GtkAdjustment* adjustment, gpointer data);
 void cb_refresh_view(GtkWidget* view, gpointer data);
 
 /**
- * This function gets called when the monitors associated with the GdkScreen
- * change.
- *
- * It checks for a change of monitor PPI, storing the new value and triggering
- * a refresh if appropriate.
- *
- * @param screen The GDK screen
- * @param gpointer The zathura instance
- */
-void cb_monitors_changed(GdkScreen* screen, gpointer data);
-
-/**
- * This function gets called when the screen associated with the view widget
- * changes.
- *
- * It updates the connection on the monitors-changed signal and checks for a
- * change of monitor PPI, storing the new value and triggering a refresh if
- * appropriate.
- *
- * @param widget The view widget
- * @param previous_screen The widget's previous screen
- * @param gpointer The zathura instance
- */
-void cb_widget_screen_changed(GtkWidget* widget, GdkScreen* previous_screen, gpointer data);
-
-/**
- * This function gets called when the main window's size, position or stacking
- * changes.
- *
- * It checks for a change of monitor PPI (due to the window moving between
- * different monitors), storing the new value and triggering a refresh if
- * appropriate.
- *
- * @param widget The main window widget
- * @param event The configure event
- * @param gpointer The zathura instance
- * @return true if no error occurred and the event has been handled
- */
-gboolean cb_widget_configured(GtkWidget* widget, GdkEvent* event, gpointer data);
-
-/**
  * This function gets called when the view widget scale factor changes (e.g.
  * when moving from a regular to a HiDPI screen).
  *
@@ -131,6 +91,20 @@ gboolean cb_widget_configured(GtkWidget* widget, GdkEvent* event, gpointer data)
  * @param gpointer The zathura instance
  */
 void cb_scale_factor(GObject* object, GParamSpec* pspec, gpointer data);
+
+/**
+ * This function gets called when the monitor configuration changes (e.g.
+ * a monitor is plugged in or unplugged).
+ *
+ * It re-evaluates the view PPI to keep rendering accurate.
+ *
+ * @param model The GListModel of monitors
+ * @param position The position of the first changed monitor
+ * @param removed The number of removed monitors
+ * @param added The number of added monitors
+ * @param data The zathura instance
+ */
+void cb_monitors_changed(GListModel* model, guint position, guint removed, guint added, gpointer data);
 
 /**
  * This function gets called when the value of the "pages-per-row"
@@ -148,12 +122,11 @@ void cb_page_layout_value_changed(girara_session_t* session, const char* name, g
 /**
  * Called when an index element is activated (e.g.: double click)
  *
- * @param tree_view Tree view
- * @param path Path
- * @param column Column
- * @param zathura Zathura session
+ * @param view The index list view
+ * @param position Row position within the selection model
+ * @param data Zathura session
  */
-void cb_index_row_activated(GtkTreeView* tree_view, GtkTreePath* path, GtkTreeViewColumn* column, void* zathura);
+void cb_index_row_activated(GtkListView* view, guint position, void* data);
 
 /**
  * Called when input has been passed to the sc_follow dialog
@@ -256,18 +229,13 @@ bool cb_unknown_command(girara_session_t* session, const char* input);
  */
 void cb_page_widget_text_selected(ZathuraPageWidget* page, const char* text, void* data);
 
-void cb_page_widget_image_selected(ZathuraPageWidget* page, GdkPixbuf* pixbuf, void* data);
+void cb_page_widget_image_selected(ZathuraPageWidget* page, GdkTexture* texture, void* data);
 
-void cb_page_widget_scaled_button_release(ZathuraPageWidget* page, GdkEventButton* event, void* data);
+void cb_page_widget_scaled_button_release(ZathuraPageWidget* page, scaled_button_release_event_t* event, void* data);
 
 void cb_page_widget_link(ZathuraPageWidget* page, void* data);
 
 void update_visible_pages(zathura_t* zathura);
-
-/**
- * Update window icon from cairo surface.
- */
-void cb_window_update_icon(ZathuraRenderRequest* request, cairo_surface_t* surface, void* data);
 
 void cb_gesture_zoom_begin(GtkGesture* self, GdkEventSequence* sequence, void* data);
 

--- a/zathura/config.c
+++ b/zathura/config.c
@@ -139,7 +139,7 @@ static void cb_global_modifiers_changed(girara_session_t* session, const char* n
   } else if (g_strcmp0(modifier, "ctrl") == 0) {
     *p = GDK_CONTROL_MASK;
   } else if (g_strcmp0(modifier, "alt") == 0) {
-    *p = GDK_MOD1_MASK;
+    *p = GDK_ALT_MASK;
   } else {
     girara_error("Invalid %s option: '%s'", name, modifier);
   }
@@ -257,18 +257,18 @@ static void cb_guioptions(girara_session_t* session, const char* UNUSED(name), g
   /* apply settings */
   if (show_commandline == true) {
     session->global.autohide_inputbar = false;
-    gtk_widget_show(session->gtk.inputbar);
+    gtk_widget_set_visible(session->gtk.inputbar, TRUE);
   } else {
     session->global.autohide_inputbar = true;
-    gtk_widget_hide(session->gtk.inputbar);
+    gtk_widget_set_visible(session->gtk.inputbar, FALSE);
   }
 
   if (show_statusbar == true) {
     session->global.hide_statusbar = false;
-    gtk_widget_show(session->gtk.statusbar);
+    gtk_widget_set_visible(session->gtk.statusbar, TRUE);
   } else {
     session->global.hide_statusbar = true;
-    gtk_widget_hide(session->gtk.statusbar);
+    gtk_widget_set_visible(session->gtk.statusbar, FALSE);
   }
 }
 
@@ -314,10 +314,10 @@ static void add_default_shortcuts(girara_session_t* gsession, girara_mode_t mode
 
   girara_shortcut_add(gsession, 0, GDK_KEY_J, NULL, sc_navigate, mode, NEXT, NULL);
   girara_shortcut_add(gsession, 0, GDK_KEY_K, NULL, sc_navigate, mode, PREVIOUS, NULL);
-  girara_shortcut_add(gsession, GDK_MOD1_MASK, GDK_KEY_Right, NULL, sc_navigate, mode, NEXT, NULL);
-  girara_shortcut_add(gsession, GDK_MOD1_MASK, GDK_KEY_KP_Right, NULL, sc_navigate, mode, NEXT, NULL);
-  girara_shortcut_add(gsession, GDK_MOD1_MASK, GDK_KEY_Left, NULL, sc_navigate, mode, PREVIOUS, NULL);
-  girara_shortcut_add(gsession, GDK_MOD1_MASK, GDK_KEY_KP_Left, NULL, sc_navigate, mode, PREVIOUS, NULL);
+  girara_shortcut_add(gsession, GDK_ALT_MASK, GDK_KEY_Right, NULL, sc_navigate, mode, NEXT, NULL);
+  girara_shortcut_add(gsession, GDK_ALT_MASK, GDK_KEY_KP_Right, NULL, sc_navigate, mode, NEXT, NULL);
+  girara_shortcut_add(gsession, GDK_ALT_MASK, GDK_KEY_Left, NULL, sc_navigate, mode, PREVIOUS, NULL);
+  girara_shortcut_add(gsession, GDK_ALT_MASK, GDK_KEY_KP_Left, NULL, sc_navigate, mode, PREVIOUS, NULL);
   girara_shortcut_add(gsession, 0, GDK_KEY_Page_Down, NULL, sc_navigate, mode, NEXT, NULL);
   girara_shortcut_add(gsession, 0, GDK_KEY_KP_Page_Down, NULL, sc_navigate, mode, NEXT, NULL);
   girara_shortcut_add(gsession, 0, GDK_KEY_Page_Up, NULL, sc_navigate, mode, PREVIOUS, NULL);
@@ -349,12 +349,12 @@ static void add_default_shortcuts(girara_session_t* gsession, girara_mode_t mode
   girara_shortcut_add(gsession, 0, GDK_KEY_KP_Right, NULL, sc_scroll, mode, RIGHT, NULL);
   girara_shortcut_add(gsession, GDK_CONTROL_MASK, GDK_KEY_t, NULL, sc_scroll, mode, HALF_LEFT, NULL);
 
-  girara_shortcut_add(gsession, GDK_MOD1_MASK, GDK_KEY_k, NULL, sc_scroll, mode, PARTIAL_UP, NULL);
-  girara_shortcut_add(gsession, GDK_MOD1_MASK, GDK_KEY_j, NULL, sc_scroll, mode, PARTIAL_DOWN, NULL);
-  girara_shortcut_add(gsession, GDK_MOD1_MASK, GDK_KEY_Up, NULL, sc_scroll, mode, PARTIAL_UP, NULL);
-  girara_shortcut_add(gsession, GDK_MOD1_MASK, GDK_KEY_KP_Up, NULL, sc_scroll, mode, PARTIAL_UP, NULL);
-  girara_shortcut_add(gsession, GDK_MOD1_MASK, GDK_KEY_Down, NULL, sc_scroll, mode, PARTIAL_DOWN, NULL);
-  girara_shortcut_add(gsession, GDK_MOD1_MASK, GDK_KEY_KP_Down, NULL, sc_scroll, mode, PARTIAL_DOWN, NULL);
+  girara_shortcut_add(gsession, GDK_ALT_MASK, GDK_KEY_k, NULL, sc_scroll, mode, PARTIAL_UP, NULL);
+  girara_shortcut_add(gsession, GDK_ALT_MASK, GDK_KEY_j, NULL, sc_scroll, mode, PARTIAL_DOWN, NULL);
+  girara_shortcut_add(gsession, GDK_ALT_MASK, GDK_KEY_Up, NULL, sc_scroll, mode, PARTIAL_UP, NULL);
+  girara_shortcut_add(gsession, GDK_ALT_MASK, GDK_KEY_KP_Up, NULL, sc_scroll, mode, PARTIAL_UP, NULL);
+  girara_shortcut_add(gsession, GDK_ALT_MASK, GDK_KEY_Down, NULL, sc_scroll, mode, PARTIAL_DOWN, NULL);
+  girara_shortcut_add(gsession, GDK_ALT_MASK, GDK_KEY_KP_Down, NULL, sc_scroll, mode, PARTIAL_DOWN, NULL);
 
   girara_shortcut_add(gsession, GDK_CONTROL_MASK, GDK_KEY_d, NULL, sc_scroll, mode, HALF_DOWN, NULL);
   girara_shortcut_add(gsession, GDK_CONTROL_MASK, GDK_KEY_u, NULL, sc_scroll, mode, HALF_UP, NULL);
@@ -397,7 +397,7 @@ static void add_default_shortcuts(girara_session_t* gsession, girara_mode_t mode
   girara_shortcut_add(gsession, 0, 0, "zz", sc_zoom, mode, ZOOM_SPECIFIC, NULL);
   girara_shortcut_add(gsession, 0, 0, "zZ", sc_zoom, mode, ZOOM_SPECIFIC, NULL);
 
-  girara_shortcut_add(gsession, GDK_MOD1_MASK, GDK_KEY_o, NULL, sc_file_chooser, mode, 0, NULL);
+  girara_shortcut_add(gsession, GDK_ALT_MASK, GDK_KEY_o, NULL, sc_file_chooser, mode, 0, NULL);
 }
 
 static void add_default_mouse_events(girara_session_t* gsession, girara_mode_t mode) {
@@ -584,8 +584,6 @@ void config_load_default(zathura_t* zathura) {
   girara_setting_add(gsession, "window-title-home-tilde",    &bool_value,  BOOLEAN, false, _("Use ~ instead of $HOME in the filename in the window title"), cb_window_statbusbar_changed, NULL);
   bool_value = false;
   girara_setting_add(gsession, "window-title-page",          &bool_value,  BOOLEAN, false, _("Display the page number in the window title"), cb_window_statbusbar_changed, NULL);
-  bool_value = false;
-  girara_setting_add(gsession, "window-icon-document",       &bool_value,  BOOLEAN, false, _("Use first page of a document as window icon"), NULL, NULL);
   bool_value = false;
   girara_setting_add(gsession, "statusbar-basename",         &bool_value,  BOOLEAN, false, _("Use basename of the file in the statusbar"), cb_window_statbusbar_changed, NULL);
   bool_value = false;

--- a/zathura/dbus-interface.c
+++ b/zathura/dbus-interface.c
@@ -262,7 +262,7 @@ static void synctex_highlight_rects_idle(zathura_t* zathura, girara_list_t** rec
   data->page            = page;
   data->number_of_pages = number_of_pages;
 
-  gdk_threads_add_idle(synctex_highlight_rects_impl, data);
+  g_idle_add(synctex_highlight_rects_impl, data);
 }
 
 static void handle_highlight_rects(zathura_t* zathura, GVariant* parameters, GDBusMethodInvocation* invocation) {
@@ -376,7 +376,7 @@ static void synctex_view_idle(zathura_t* zathura, gchar* input_file, unsigned in
   data->line       = line;
   data->column     = column;
 
-  gdk_threads_add_idle(synctex_view_impl, data);
+  g_idle_add(synctex_view_impl, data);
 }
 
 static void handle_synctex_view(zathura_t* zathura, GVariant* parameters, GDBusMethodInvocation* invocation) {
@@ -456,7 +456,7 @@ static void handle_method_call(GDBusConnection* UNUSED(connection), const gchar*
 
     (*handlers[idx].handler)(priv->zathura, parameters, invocation);
 
-    if (handlers[idx].present_window == true && priv->zathura->ui.session->gtk.embed == 0) {
+    if (handlers[idx].present_window == true) {
       bool present_window = true;
       girara_setting_get(priv->zathura->ui.session, "dbus-raise-window", &present_window);
       if (present_window == true) {

--- a/zathura/document-widget.c
+++ b/zathura/document-widget.c
@@ -6,6 +6,7 @@
 #include <girara/log.h>
 
 #include "adjustment.h"
+#include "callbacks.h"
 #include "page-widget.h"
 #include "page.h"
 #include "utils.h"
@@ -30,6 +31,10 @@ typedef struct zathura_document_widget_private_s {
   unsigned int first_page_column; /**< column of the first page */
   unsigned int page_v_padding;    /**< padding between pages */
   unsigned int page_h_padding;    /**< padding between pages */
+  int alloc_width;
+  int alloc_height;
+
+  GtkWidget* grid;
 
   /* Scrolling */
   GtkAdjustment* hadjustment;
@@ -38,17 +43,15 @@ typedef struct zathura_document_widget_private_s {
   GtkScrollablePolicy vscroll_policy;
 } ZathuraDocumentWidgetPrivate;
 
-G_DEFINE_TYPE_WITH_CODE(ZathuraDocumentWidget, zathura_document_widget, GTK_TYPE_CONTAINER,
+G_DEFINE_TYPE_WITH_CODE(ZathuraDocumentWidget, zathura_document_widget, GTK_TYPE_WIDGET,
                         G_ADD_PRIVATE(ZathuraDocumentWidget) G_IMPLEMENT_INTERFACE(GTK_TYPE_SCROLLABLE, NULL))
 
 static void zathura_document_widget_set_property(GObject* object, guint prop_id, const GValue* value,
                                                  GParamSpec* pspec);
 static void zathura_document_widget_get_property(GObject* object, guint prop_id, GValue* value, GParamSpec* pspec);
-static void zathura_document_widget_size_allocate(GtkWidget* widget, GtkAllocation* allocation);
-static void zathura_document_widget_container_add(GtkContainer* container, GtkWidget* widget);
-static void zathura_document_widget_container_remove(GtkContainer* container, GtkWidget* widget);
-static void zathura_document_widget_container_forall(GtkContainer* container, gboolean include_internals,
-                                                     GtkCallback callback, gpointer user_data);
+static void zathura_document_widget_size_allocate(GtkWidget* widget, int width, int height, int baseline);
+static void zathura_document_widget_measure(GtkWidget* widget, GtkOrientation orientation, int for_size, int* minimum,
+                                            int* natural, int* minimum_baseline, int* natural_baseline);
 static void zathura_document_widget_dispose(GObject* object);
 static void zathura_document_widget_finalize(GObject* object);
 
@@ -66,17 +69,13 @@ enum properties_e {
 static void zathura_document_widget_class_init(ZathuraDocumentWidgetClass* class) {
   GtkWidgetClass* widget_class = GTK_WIDGET_CLASS(class);
   widget_class->size_allocate  = zathura_document_widget_size_allocate;
+  widget_class->measure        = zathura_document_widget_measure;
 
   GObjectClass* object_class = G_OBJECT_CLASS(class);
   object_class->set_property = zathura_document_widget_set_property;
   object_class->get_property = zathura_document_widget_get_property;
   object_class->dispose      = zathura_document_widget_dispose;
   object_class->finalize     = zathura_document_widget_finalize;
-
-  GtkContainerClass* container_class = GTK_CONTAINER_CLASS(class);
-  container_class->add               = zathura_document_widget_container_add;
-  container_class->remove            = zathura_document_widget_container_remove;
-  container_class->forall            = zathura_document_widget_container_forall;
 
   g_object_class_install_property(
       object_class, PROP_ZATHURA,
@@ -100,8 +99,6 @@ static void zathura_document_widget_class_init(ZathuraDocumentWidgetClass* class
 }
 
 static void zathura_document_widget_init(ZathuraDocumentWidget* widget) {
-  gtk_widget_set_has_window(GTK_WIDGET(widget), false);
-
   ZathuraDocumentWidgetPrivate* priv = zathura_document_widget_get_instance_private(widget);
 
   priv->zathura     = NULL;
@@ -110,6 +107,16 @@ static void zathura_document_widget_init(ZathuraDocumentWidget* widget) {
   priv->ncol        = 0;
   priv->row_heights = NULL;
   priv->col_widths  = NULL;
+
+  /* clip the offset grid like GtkViewport does; gtk4 widgets do not clip children by default */
+  gtk_widget_set_overflow(GTK_WIDGET(widget), GTK_OVERFLOW_HIDDEN);
+
+  priv->grid = gtk_grid_new();
+  gtk_grid_set_row_homogeneous(GTK_GRID(priv->grid), FALSE);
+  gtk_grid_set_column_homogeneous(GTK_GRID(priv->grid), FALSE);
+  gtk_widget_set_halign(priv->grid, GTK_ALIGN_CENTER);
+  gtk_widget_set_valign(priv->grid, GTK_ALIGN_CENTER);
+  gtk_widget_set_parent(priv->grid, GTK_WIDGET(widget));
 }
 
 GtkWidget* zathura_document_widget_new(zathura_t* zathura) {
@@ -169,6 +176,7 @@ static void zathura_document_widget_set_property(GObject* object, guint prop_id,
     break;
   case PROP_LAYOUT_MODE:
     priv->layout_mode = g_value_get_int(value);
+    zathura_document_widget_update_mode(document);
     gtk_widget_queue_allocate(GTK_WIDGET(document));
     break;
   case PROP_PAGES_RIGHT_TO_LEFT:
@@ -278,188 +286,145 @@ static void zathura_document_widget_arrange_grid(ZathuraDocumentWidget* widget) 
   zathura_document_widget_line_prefix_sum(priv->row_heights, nrow, page_v_padding);
 }
 
-static void document_adjustment(ZathuraDocumentWidget* document, int height, int width, int* adj_v, int* adj_h) {
+void zathura_document_widget_update_mode(ZathuraDocumentWidget* document) {
+  g_return_if_fail(document != NULL);
+
   ZathuraDocumentWidgetPrivate* priv = zathura_document_widget_get_instance_private(document);
-
-  const unsigned int value_v = gtk_adjustment_get_value(priv->vadjustment);
-  const unsigned int value_h = gtk_adjustment_get_value(priv->hadjustment);
-
-  unsigned int doc_height = 0, doc_width = 0;
-  zathura_document_widget_get_document_size(document, &doc_height, &doc_width);
-
-  const int center_v = (height - doc_height) / 2;
-  const int center_h = (width - doc_width) / 2;
-
-  // if document is smaller than allocation, center the document
-  *adj_v = ((int)doc_height < height) ? -center_v : (int)value_v;
-  *adj_h = ((int)doc_width < width) ? -center_h : (int)value_h;
-}
-
-/*
- * Calculate allocation for a single page
- *
- * If height or width is smaller than the allocation,
- * set the position to 0 and height/width to allocation
- * so the page centers that dimension. Otherwise,
- * use the document position, clamped to the page edges,
- * to offset the page position.
- *
- * @param document ZathuraDocumentWidget
- * @param page_id  index of the page in the document
- * @param height   allocation height
- * @param width    allocation width
- * @return page_alloc the final allocation
- */
-static void page_allocation(ZathuraDocumentWidget* document, int page_id, int height, int width,
-                            GtkAllocation* page_alloc) {
-  ZathuraDocumentWidgetPrivate* priv = zathura_document_widget_get_instance_private(document);
-
-  unsigned int row = 0, col = 0;
-  zathura_document_widget_get_page_position(document, page_id, &row, &col);
-
-  const unsigned int x = priv->pages_right_to_left ? priv->ncol - 1 - col : col;
-  const unsigned int y = row;
-
-  const int page_width  = priv->col_widths[x].size;
-  const int page_height = priv->row_heights[y].size;
-  const int value_h     = gtk_adjustment_get_value(priv->hadjustment) - priv->col_widths[x].pos;
-  const int value_v     = gtk_adjustment_get_value(priv->vadjustment) - priv->row_heights[y].pos;
-
-  /* clamp x and y offsets so we don't leave the page */
-  const int clamp_h = MAX(MIN(-value_h, 0), -(page_width - width));
-  const int clamp_v = MAX(MIN(-value_v, 0), -(page_height - height));
-
-  page_alloc->x      = ((int)page_width < width) ? 0 : clamp_h;
-  page_alloc->y      = ((int)page_height < height) ? 0 : clamp_v;
-  page_alloc->width  = MAX(page_width, width);
-  page_alloc->height = MAX(page_height, height);
-}
-
-static void size_allocate_grid(ZathuraDocumentWidget* document, GtkAllocation* allocation) {
-  ZathuraDocumentWidgetPrivate* priv = zathura_document_widget_get_instance_private(document);
-  zathura_document_t* z_document     = zathura_get_document(priv->zathura);
-
-  const unsigned int npag = zathura_document_get_number_of_pages(z_document);
-
-  gtk_widget_show_all(GTK_WIDGET(document));
-
-  int adj_v, adj_h;
-  document_adjustment(document, allocation->height, allocation->width, &adj_v, &adj_h);
-
-  for (unsigned int i = 0; i < npag; i++) {
-    zathura_page_t* page   = zathura_document_get_page(z_document, i);
-    GtkWidget* page_widget = zathura_page_get_widget(priv->zathura, page);
-
-    unsigned int row;
-    unsigned int col;
-    zathura_document_widget_get_page_position(document, i, &row, &col);
-
-    unsigned int x = priv->pages_right_to_left ? priv->ncol - 1 - col : col;
-    unsigned int y = row;
-
-    document_widget_line_s col_line = priv->col_widths[x];
-    document_widget_line_s row_line = priv->row_heights[y];
-
-    GtkAllocation page_alloc = {
-        .x      = col_line.pos - adj_h,
-        .y      = row_line.pos - adj_v,
-        .width  = col_line.size,
-        .height = row_line.size,
-    };
-
-    gtk_widget_size_allocate(page_widget, &page_alloc);
+  zathura_document_t* z_document     = priv->zathura != NULL ? zathura_get_document(priv->zathura) : NULL;
+  if (z_document == NULL || priv->grid == NULL) {
+    return;
   }
-}
 
-static void size_allocate_single_page(ZathuraDocumentWidget* document, GtkAllocation* allocation) {
-  ZathuraDocumentWidgetPrivate* priv = zathura_document_widget_get_instance_private(document);
-  zathura_document_t* z_document     = zathura_get_document(priv->zathura);
-
+  const bool single          = priv->layout_mode == DOCUMENT_WIDGET_SINGLE;
   const unsigned int npag    = zathura_document_get_number_of_pages(z_document);
   const unsigned int page_id = zathura_document_get_current_page_number(z_document);
 
-  GtkAllocation page_alloc;
-  page_allocation(document, page_id, allocation->height, allocation->width, &page_alloc);
-
   for (unsigned int i = 0; i < npag; i++) {
     zathura_page_t* page   = zathura_document_get_page(z_document, i);
     GtkWidget* page_widget = zathura_page_get_widget(priv->zathura, page);
-
-    gtk_widget_set_visible(page_widget, page_id == i);
-
-    if (i == page_id) {
-      gtk_widget_size_allocate(page_widget, &page_alloc);
+    if (page_widget != NULL) {
+      gtk_widget_set_visible(page_widget, single == false || i == page_id);
     }
   }
+
+  if (single == true) {
+    gtk_adjustment_set_value(priv->hadjustment, 0);
+    gtk_adjustment_set_value(priv->vadjustment, 0);
+  } else {
+    zathura_document_widget_compute_layout(document);
+  }
+
+  gtk_widget_queue_resize(GTK_WIDGET(document));
 }
 
-static void zathura_document_widget_size_allocate(GtkWidget* widget, GtkAllocation* allocation) {
-  ZathuraDocumentWidget* document    = ZATHURA_DOCUMENT_WIDGET(widget);
+static void size_allocate_single(ZathuraDocumentWidget* document, int width, int height, int baseline) {
   ZathuraDocumentWidgetPrivate* priv = zathura_document_widget_get_instance_private(document);
   zathura_document_t* z_document     = zathura_get_document(priv->zathura);
 
-  if (z_document == NULL || priv->zathura == NULL) {
+  zathura_page_t* page = zathura_document_get_page(z_document, zathura_document_get_current_page_number(z_document));
+  if (page == NULL) {
     return;
   }
 
-  gtk_adjustment_set_page_size(priv->hadjustment, allocation->width);
-  gtk_adjustment_set_page_size(priv->vadjustment, allocation->height);
+  unsigned int page_width = 0, page_height = 0;
+  page_calc_height_width(z_document, page, &page_height, &page_width, true);
 
-  zathura_document_set_viewport_height(z_document, allocation->height);
-  zathura_document_set_viewport_width(z_document, allocation->width);
-
-  adjust_view(priv->zathura);
-
-  /* allocate pages */
-  switch (priv->layout_mode) {
-  case DOCUMENT_WIDGET_GRID:
-    size_allocate_grid(document, allocation);
-    break;
-  case DOCUMENT_WIDGET_SINGLE:
-    size_allocate_single_page(document, allocation);
-    break;
-  default:
-    girara_error("unknown layout mode");
+  if ((int)gtk_adjustment_get_upper(priv->hadjustment) != (int)page_width) {
+    gtk_adjustment_set_upper(priv->hadjustment, page_width);
+  }
+  if ((int)gtk_adjustment_get_upper(priv->vadjustment) != (int)page_height) {
+    gtk_adjustment_set_upper(priv->vadjustment, page_height);
   }
 
-  GTK_WIDGET_CLASS(zathura_document_widget_parent_class)->size_allocate(widget, allocation);
+  const int value_h = gtk_adjustment_get_value(priv->hadjustment);
+  const int value_v = gtk_adjustment_get_value(priv->vadjustment);
+  const int clamp_h = MAX(MIN(-value_h, 0), -((int)page_width - width));
+  const int clamp_v = MAX(MIN(-value_v, 0), -((int)page_height - height));
+
+  const int x = ((int)page_width < width) ? (width - (int)page_width) / 2 : clamp_h;
+  const int y = ((int)page_height < height) ? (height - (int)page_height) / 2 : clamp_v;
+
+  gtk_widget_size_allocate(
+      priv->grid, &(GtkAllocation){.x = x, .y = y, .width = (int)page_width, .height = (int)page_height}, baseline);
 }
 
-/* container class funcs */
+static void zathura_document_widget_size_allocate(GtkWidget* widget, int width, int height, int baseline) {
+  ZathuraDocumentWidget* document    = ZATHURA_DOCUMENT_WIDGET(widget);
+  ZathuraDocumentWidgetPrivate* priv = zathura_document_widget_get_instance_private(document);
+  zathura_document_t* z_document     = priv->zathura ? zathura_get_document(priv->zathura) : NULL;
 
-static void zathura_document_widget_container_add(GtkContainer* container, GtkWidget* widget) {
-  GtkWidget* parent = gtk_widget_get_parent(widget);
-  if (parent != NULL) {
-    girara_warning("page widget is already added to a document widget");
-    return;
+  bool size_changed = false;
+
+  if (z_document != NULL) {
+    size_changed       = width != priv->alloc_width || height != priv->alloc_height;
+    priv->alloc_width  = width;
+    priv->alloc_height = height;
   }
 
-  gtk_widget_set_parent(widget, GTK_WIDGET(container));
+  if (z_document != NULL) {
+    if (size_changed == true) {
+      zathura_document_set_viewport_height(z_document, height);
+      zathura_document_set_viewport_width(z_document, width);
+      adjust_view(priv->zathura);
+    }
+    update_visible_pages(priv->zathura);
+  }
+
+  /* set the page size after adjust_view so the changed handler stores the position against the
+   * final document height and the view stays at the top on first open */
+  if (priv->grid != NULL && size_changed == true) {
+    gtk_adjustment_set_page_size(priv->hadjustment, width);
+    gtk_adjustment_set_page_size(priv->vadjustment, height);
+    gtk_adjustment_set_page_increment(priv->hadjustment, width * 0.9);
+    gtk_adjustment_set_page_increment(priv->vadjustment, height * 0.9);
+  }
+
+  if (priv->grid != NULL) {
+    /* position the grid by the adjustment values so navigation moves the view */
+    /* read natural size from arrange_grid totals to avoid measuring during size_allocate */
+    unsigned int doc_w = 0, doc_h = 0;
+    if (priv->col_widths != NULL && priv->row_heights != NULL && priv->nrow > 0 && priv->ncol > 0) {
+      zathura_document_widget_get_document_size(document, &doc_h, &doc_w);
+    }
+
+    const int alloc_w = MAX(width, (int)doc_w);
+    const int alloc_h = MAX(height, (int)doc_h);
+
+    if (priv->layout_mode == DOCUMENT_WIDGET_SINGLE && z_document != NULL) {
+      size_allocate_single(document, width, height, baseline);
+      return;
+    }
+
+    const int x = -(int)gtk_adjustment_get_value(priv->hadjustment);
+    const int y = -(int)gtk_adjustment_get_value(priv->vadjustment);
+    gtk_widget_size_allocate(priv->grid, &(GtkAllocation){.x = x, .y = y, .width = alloc_w, .height = alloc_h},
+                             baseline);
+  }
 }
 
-static void zathura_document_widget_container_remove(GtkContainer* UNUSED(container), GtkWidget* widget) {
-  gtk_widget_unparent(widget);
-}
-
-static void zathura_document_widget_container_forall(GtkContainer* container, gboolean UNUSED(include_internals),
-                                                     GtkCallback callback, gpointer user_data) {
-  ZathuraDocumentWidget* document    = ZATHURA_DOCUMENT_WIDGET(container);
+static void zathura_document_widget_measure(GtkWidget* widget, GtkOrientation orientation, int for_size, int* minimum,
+                                            int* natural, int* minimum_baseline, int* natural_baseline) {
+  ZathuraDocumentWidget* document    = ZATHURA_DOCUMENT_WIDGET(widget);
   ZathuraDocumentWidgetPrivate* priv = zathura_document_widget_get_instance_private(document);
 
-  zathura_document_t* z_document = zathura_get_document(priv->zathura);
-  unsigned int npag              = zathura_document_get_number_of_pages(z_document);
-
-  for (unsigned int i = 0; i < npag; i++) {
-    zathura_page_t* page   = zathura_document_get_page(z_document, i);
-    GtkWidget* page_widget = zathura_page_get_widget(priv->zathura, page);
-
-    callback(page_widget, user_data);
+  if (priv->grid != NULL) {
+    gtk_widget_measure(priv->grid, orientation, for_size, minimum, natural, minimum_baseline, natural_baseline);
+    return;
+  }
+  *minimum = *natural = 0;
+  if (minimum_baseline != NULL) {
+    *minimum_baseline = -1;
+  }
+  if (natural_baseline != NULL) {
+    *natural_baseline = -1;
   }
 }
 
 static void zathura_document_widget_dispose(GObject* object) {
   ZathuraDocumentWidget* document    = ZATHURA_DOCUMENT_WIDGET(object);
   ZathuraDocumentWidgetPrivate* priv = zathura_document_widget_get_instance_private(document);
+
+  g_clear_pointer(&priv->grid, gtk_widget_unparent);
 
   g_clear_object(&priv->hadjustment);
   g_clear_object(&priv->vadjustment);
@@ -484,6 +449,8 @@ void zathura_document_widget_refresh_layout(ZathuraDocumentWidget* document) {
   g_return_if_fail(document != NULL);
 
   ZathuraDocumentWidgetPrivate* priv = zathura_document_widget_get_instance_private(document);
+  priv->alloc_width                  = -1;
+  priv->alloc_height                 = -1;
   zathura_document_t* z_document     = zathura_get_document(priv->zathura);
 
   const unsigned int c0   = priv->first_page_column;
@@ -507,19 +474,37 @@ void zathura_document_widget_refresh_layout(ZathuraDocumentWidget* document) {
   priv->ncol = ncol;
   priv->nrow = nrow;
 
-  // parent all page widgets to the document widget
   for (unsigned int i = 0; i < npag; i++) {
     zathura_page_t* page   = zathura_document_get_page(z_document, i);
     GtkWidget* page_widget = zathura_page_get_widget(priv->zathura, page);
+    if (page_widget == NULL) {
+      continue;
+    }
 
-    gtk_widget_unparent(page_widget);
-    gtk_container_add(GTK_CONTAINER(document), page_widget);
+    GtkWidget* parent = gtk_widget_get_parent(page_widget);
+    if (parent == priv->grid) {
+      gtk_grid_remove(GTK_GRID(priv->grid), page_widget);
+    } else if (parent != NULL) {
+      gtk_widget_unparent(page_widget);
+    }
+
+    unsigned int row = 0;
+    unsigned int col = 0;
+    zathura_document_widget_get_page_position(document, i, &row, &col);
+    unsigned int x  = priv->pages_right_to_left ? priv->ncol - 1 - col : col;
+    GtkAlign halign = priv->ncol == 1 ? GTK_ALIGN_CENTER : (x == 0 ? GTK_ALIGN_END : GTK_ALIGN_START);
+    gtk_widget_set_halign(page_widget, halign);
+    gtk_grid_attach(GTK_GRID(priv->grid), page_widget, (int)x, (int)row, 1, 1);
   }
 
   zathura_document_widget_compute_layout(document);
 
   gtk_widget_set_visible(GTK_WIDGET(document), true);
+  zathura_document_widget_update_mode(document);
   gtk_widget_queue_resize(GTK_WIDGET(document));
+
+  /* the cached visibility flags are stale after pages move */
+  update_visible_pages(priv->zathura);
 }
 
 void zathura_document_widget_compute_layout(ZathuraDocumentWidget* document) {
@@ -680,6 +665,9 @@ void zathura_document_widget_render_all(ZathuraDocumentWidget* document) {
     return;
   }
 
+  priv->alloc_width  = -1;
+  priv->alloc_height = -1;
+
   zathura_document_widget_compute_layout(document);
 
   /* unmark all pages */
@@ -709,6 +697,13 @@ void zathura_document_widget_set_page_layout(ZathuraDocumentWidget* document, un
   priv->page_v_padding = page_v_padding;
   priv->page_h_padding = page_h_padding;
   priv->pages_per_row  = pages_per_row;
+
+  /* keep grid spacing in sync with the padding arrange_grid uses */
+  /* otherwise position_to_page_number reads stale positions and navigation jumps */
+  if (priv->grid != NULL) {
+    gtk_grid_set_row_spacing(GTK_GRID(priv->grid), page_v_padding);
+    gtk_grid_set_column_spacing(GTK_GRID(priv->grid), page_h_padding);
+  }
 
   if (first_page_column < 1) {
     first_page_column = 1;

--- a/zathura/document-widget.h
+++ b/zathura/document-widget.h
@@ -10,11 +10,11 @@
  * The document view widget.
  */
 struct zathura_document_widget_s {
-  GtkContainer parent;
+  GtkWidget parent;
 };
 
 struct zathura_document_widget_class_s {
-  GtkContainerClass parent_class;
+  GtkWidgetClass parent_class;
 };
 
 #define ZATHURA_TYPE_DOCUMENT_WIDGET (zathura_document_widget_get_type())
@@ -49,6 +49,8 @@ GtkWidget* zathura_document_widget_new(zathura_t* zathura);
  * @param document ZathuraDocumentWidget
  */
 void zathura_document_widget_refresh_layout(ZathuraDocumentWidget* document);
+
+void zathura_document_widget_update_mode(ZathuraDocumentWidget* document);
 
 /**
  * Calculate the position of each grid cell.

--- a/zathura/links.c
+++ b/zathura/links.c
@@ -303,7 +303,7 @@ static void link_confirm(zathura_t* zathura, zathura_link_type_t type, const cha
   ctx->type    = type;
   ctx->value   = g_strdup(value);
 
-  gdk_threads_add_idle(link_confirm_spawn, ctx);
+  g_idle_add(link_confirm_spawn, ctx);
 }
 #endif
 
@@ -365,13 +365,13 @@ void zathura_link_display(zathura_t* zathura, zathura_link_t* link) {
   }
 }
 
-void zathura_link_copy(zathura_t* zathura, zathura_link_t* link, GdkAtom* selection) {
+void zathura_link_copy(zathura_t* zathura, zathura_link_t* link, GdkClipboard* selection) {
   zathura_link_type_t type     = zathura_link_get_type(link);
   zathura_link_target_t target = zathura_link_get_target(link);
   switch (type) {
   case ZATHURA_LINK_GOTO_DEST: {
     g_autofree gchar* tmp = g_strdup_printf("%d", target.page_number);
-    gtk_clipboard_set_text(gtk_clipboard_get(*selection), tmp, -1);
+    gdk_clipboard_set_text(selection, tmp);
     girara_notify(zathura->ui.session, GIRARA_INFO, _("Copied page number: %d"), target.page_number);
     break;
   }
@@ -379,7 +379,7 @@ void zathura_link_copy(zathura_t* zathura, zathura_link_t* link, GdkAtom* select
   case ZATHURA_LINK_URI:
   case ZATHURA_LINK_LAUNCH:
   case ZATHURA_LINK_NAMED: {
-    gtk_clipboard_set_text(gtk_clipboard_get(*selection), target.value, -1);
+    gdk_clipboard_set_text(selection, target.value);
     g_autofree gchar* escaped_value = g_markup_escape_text(target.value, -1);
     girara_notify(zathura->ui.session, GIRARA_INFO, _("Copied link: %s"), escaped_value);
     break;

--- a/zathura/links.h
+++ b/zathura/links.h
@@ -72,6 +72,6 @@ void zathura_link_display(zathura_t* zathura, zathura_link_t* link);
  * @param link The link
  * @param selection target clipboard
  */
-void zathura_link_copy(zathura_t* zathura, zathura_link_t* link, GdkAtom* selection);
+void zathura_link_copy(zathura_t* zathura, zathura_link_t* link, GdkClipboard* selection);
 
 #endif // LINK_H

--- a/zathura/main-sandbox.c
+++ b/zathura/main-sandbox.c
@@ -23,14 +23,13 @@
 #endif
 
 static zathura_t* init_zathura(const char* config_dir, const char* data_dir, const char* cache_dir,
-                               const char* plugin_path, char** argv, Window embed) {
+                               const char* plugin_path, char** argv) {
   /* create zathura session */
   zathura_t* zathura = zathura_create();
   if (zathura == NULL) {
     return NULL;
   }
 
-  zathura_set_xid(zathura, embed);
   zathura_set_config_dir(zathura, config_dir);
   zathura_set_data_dir(zathura, data_dir);
   zathura_set_cache_dir(zathura, cache_dir);
@@ -65,10 +64,84 @@ static zathura_t* init_zathura(const char* config_dir, const char* data_dir, con
     return NULL;
   }
 #endif
-  /* unset the input method to avoid communication with external services */
-  unsetenv("GTK_IM_MODULE");
 
   return zathura;
+}
+
+/* state shared between the application lifecycle callbacks */
+typedef struct {
+  const char* config_dir;
+  const char* data_dir;
+  const char* cache_dir;
+  const char* plugin_path;
+  const char* password;
+  const char* mode;
+  const char* bookmark_name;
+  const char* search_string;
+  /* file argument exactly as given on the command line */
+  const char* raw_file;
+  int page_number;
+  char** argv;
+  zathura_t* zathura;
+} zathura_app_ctx_t;
+
+static void cb_app_startup(GApplication* app, gpointer data) {
+  zathura_app_ctx_t* ctx = data;
+
+  ctx->zathura = init_zathura(ctx->config_dir, ctx->data_dir, ctx->cache_dir, ctx->plugin_path, ctx->argv);
+  if (ctx->zathura == NULL) {
+    girara_error("Could not initialize zathura.");
+    g_application_quit(app);
+    return;
+  }
+
+  gtk_application_add_window(GTK_APPLICATION(app), GTK_WINDOW(ctx->zathura->ui.session->gtk.window));
+}
+
+static void cb_app_activate(GApplication* UNUSED(app), gpointer data) {
+  /* present the window when the app starts without a file */
+  zathura_app_ctx_t* ctx = data;
+  if (ctx->zathura != NULL && ctx->zathura->ui.session != NULL && ctx->zathura->ui.session->gtk.window != NULL) {
+    gtk_window_present(GTK_WINDOW(ctx->zathura->ui.session->gtk.window));
+  }
+}
+
+static void cb_app_open(GApplication* UNUSED(app), GFile** files, gint n_files, const gchar* UNUSED(hint),
+                        gpointer data) {
+  zathura_app_ctx_t* ctx = data;
+  if (ctx->zathura == NULL || n_files < 1) {
+    return;
+  }
+
+  /* gfile turns a plain dash into an absolute path which breaks stdin so keep the raw argument */
+  g_autofree char* gfile_path = NULL;
+  const char* path            = NULL;
+  if (g_strcmp0(ctx->raw_file, "-") == 0) {
+    path = "-";
+  } else {
+    gfile_path = g_file_get_path(files[0]);
+    /* g_file_get_path returns NULL for non-local URIs; fall back to the raw argument */
+    path = gfile_path != NULL ? gfile_path : ctx->raw_file;
+  }
+  if (path == NULL) {
+    girara_error("Failed to determine path for the given file.");
+    return;
+  }
+
+  int page_number = ctx->page_number;
+  if (page_number > 0) {
+    --page_number;
+  }
+  document_open_idle(ctx->zathura, path, ctx->password, page_number, ctx->mode, NULL, ctx->bookmark_name,
+                     ctx->search_string);
+}
+
+static void cb_app_shutdown(GApplication* UNUSED(app), gpointer data) {
+  zathura_app_ctx_t* ctx = data;
+  if (ctx->zathura != NULL) {
+    zathura_free(ctx->zathura);
+    ctx->zathura = NULL;
+  }
 }
 
 /* main function */
@@ -88,10 +161,8 @@ GIRARA_VISIBLE int main(int argc, char* argv[]) {
   bool forkback                   = false;
   bool print_version              = false;
   int page_number                 = ZATHURA_PAGE_NUMBER_UNSPECIFIED;
-  Window embed                    = 0;
 
-  const GOptionEntry entries[] = {
-      {"reparent", 'e', 0, G_OPTION_ARG_INT, &embed, _("Reparents to window specified by xid (X11)"), "xid"},
+  GOptionEntry entries[] = {
       {"config-dir", 'c', 0, G_OPTION_ARG_FILENAME, &config_dir, _("Path to the config directory"), "path"},
       {"data-dir", 'd', 0, G_OPTION_ARG_FILENAME, &data_dir, _("Path to the data directory"), "path"},
       {"cache-dir", '\0', 0, G_OPTION_ARG_FILENAME, &cache_dir, _("Path to the cache directory"), "path"},
@@ -199,9 +270,10 @@ GIRARA_VISIBLE int main(int argc, char* argv[]) {
     zathura_plugin_manager_set_dir(plugin_manager, plugin_path);
     zathura_plugin_manager_load(plugin_manager);
 
-    g_autofree char* string = zathura_get_version_string(plugin_manager, false);
+    char* string = zathura_get_version_string(plugin_manager, false);
     if (string != NULL) {
       fprintf(stdout, "%s\n", string);
+      g_free(string);
     }
     zathura_plugin_manager_free(plugin_manager);
 
@@ -215,31 +287,55 @@ GIRARA_VISIBLE int main(int argc, char* argv[]) {
   /* disable dconf writing - uses /var/empty as alternative to /dev/null to avoid ioctl call */
   g_setenv("DCONF_PROFILE", "/var/empty", TRUE);
 
-  /* Initialize GTK+ */
-  gtk_init(&argc, &argv);
+  /* use the software renderer to avoid the gpu stack attack surface (and high risk syscalls) */
+  g_setenv("GSK_RENDERER", "cairo", TRUE);
 
-  /* Create zathura session */
-  g_autoptr(zathura_t) zathura = init_zathura(config_dir, data_dir, cache_dir, plugin_path, argv, embed);
-  if (zathura == NULL) {
-    girara_error("Could not initialize zathura.");
-    return -1;
-  }
+  /* unset the input method to avoid communication with external services */
+  unsetenv("GTK_IM_MODULE");
 
-  /* open document if passed */
-  if (file_idx != 0) {
-    if (page_number > 0) {
-      --page_number;
+  /* fail early so these errors still exit with an error status */
+  if (file_idx == 0) {
+    if (bookmark_name != NULL) {
+      girara_error("Can not use bookmark argument when no file is given");
+      return -1;
     }
-    document_open_idle(zathura, argv[file_idx], password, page_number, mode, NULL, bookmark_name, search_string);
-  } else if (bookmark_name != NULL) {
-    girara_error("Can not use bookmark argument when no file is given");
-    return -1;
-  } else if (search_string != NULL) {
-    girara_error("Can not use find argument when no file is given");
-    return -1;
+    if (search_string != NULL) {
+      girara_error("Can not use find argument when no file is given");
+      return -1;
+    }
   }
 
-  /* run zathura */
-  gtk_main();
-  return 0;
+  /* run zathura as a GtkApplication */
+  zathura_app_ctx_t ctx = {
+      .config_dir    = config_dir,
+      .data_dir      = data_dir,
+      .cache_dir     = cache_dir,
+      .plugin_path   = plugin_path,
+      .password      = password,
+      .mode          = mode,
+      .bookmark_name = bookmark_name,
+      .search_string = search_string,
+      .raw_file      = NULL,
+      .page_number   = page_number,
+      .argv          = argv,
+      .zathura       = NULL,
+  };
+
+  /* a NULL application id keeps the process non-unique and skips D-Bus registration */
+  g_autoptr(GtkApplication) app = gtk_application_new(NULL, G_APPLICATION_NON_UNIQUE | G_APPLICATION_HANDLES_OPEN);
+  g_signal_connect(app, "startup", G_CALLBACK(cb_app_startup), &ctx);
+  g_signal_connect(app, "activate", G_CALLBACK(cb_app_activate), &ctx);
+  g_signal_connect(app, "open", G_CALLBACK(cb_app_open), &ctx);
+  g_signal_connect(app, "shutdown", G_CALLBACK(cb_app_shutdown), &ctx);
+
+  /* feed g_application_run a minimal argv so it routes via open or activate */
+  char* run_argv[3] = {argv[0], NULL, NULL};
+  int run_argc      = 1;
+  if (file_idx != 0) {
+    ctx.raw_file = argv[file_idx];
+    run_argv[1]  = argv[file_idx];
+    run_argc     = 2;
+  }
+
+  return g_application_run(G_APPLICATION(app), run_argc, run_argv);
 }

--- a/zathura/main.c
+++ b/zathura/main.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: Zlib */
 
-#ifdef __APPLE__
-#include <gtkosxapplication.h>
-#endif
-
 #include <girara-gtk/settings.h>
 #include <girara/log.h>
 
@@ -58,14 +54,13 @@ static int run_synctex_forward(const char* synctex_fwd, const char* filename, in
 #endif
 
 static zathura_t* init_zathura(const char* config_dir, const char* data_dir, const char* cache_dir,
-                               const char* plugin_path, char** argv, const char* synctex_editor, Window embed) {
+                               const char* plugin_path, char** argv, const char* synctex_editor) {
   /* create zathura session */
   zathura_t* zathura = zathura_create();
   if (zathura == NULL) {
     return NULL;
   }
 
-  zathura_set_xid(zathura, embed);
   zathura_set_config_dir(zathura, config_dir);
   zathura_set_data_dir(zathura, data_dir);
   zathura_set_cache_dir(zathura, cache_dir);
@@ -83,6 +78,85 @@ static zathura_t* init_zathura(const char* config_dir, const char* data_dir, con
   }
 
   return zathura;
+}
+
+/* state shared between the application lifecycle callbacks */
+typedef struct {
+  const char* config_dir;
+  const char* data_dir;
+  const char* cache_dir;
+  const char* plugin_path;
+  const char* synctex_editor;
+  const char* password;
+  const char* synctex_fwd;
+  const char* mode;
+  const char* bookmark_name;
+  const char* search_string;
+  /* file argument exactly as given on the command line */
+  const char* raw_file;
+  int page_number;
+  char** argv;
+  zathura_t* zathura;
+} zathura_app_ctx_t;
+
+static void cb_app_startup(GApplication* app, gpointer data) {
+  zathura_app_ctx_t* ctx = data;
+
+  ctx->zathura =
+      init_zathura(ctx->config_dir, ctx->data_dir, ctx->cache_dir, ctx->plugin_path, ctx->argv, ctx->synctex_editor);
+  if (ctx->zathura == NULL) {
+    girara_error("Could not initialize zathura.");
+    g_application_quit(app);
+    return;
+  }
+
+  gtk_application_add_window(GTK_APPLICATION(app), GTK_WINDOW(ctx->zathura->ui.session->gtk.window));
+}
+
+static void cb_app_activate(GApplication* UNUSED(app), gpointer data) {
+  /* present the window when the app starts without a file */
+  zathura_app_ctx_t* ctx = data;
+  if (ctx->zathura != NULL && ctx->zathura->ui.session != NULL && ctx->zathura->ui.session->gtk.window != NULL) {
+    gtk_window_present(GTK_WINDOW(ctx->zathura->ui.session->gtk.window));
+  }
+}
+
+static void cb_app_open(GApplication* UNUSED(app), GFile** files, gint n_files, const gchar* UNUSED(hint),
+                        gpointer data) {
+  zathura_app_ctx_t* ctx = data;
+  if (ctx->zathura == NULL || n_files < 1) {
+    return;
+  }
+
+  /* gfile turns a plain dash into an absolute path which breaks stdin so keep the raw argument */
+  g_autofree char* gfile_path = NULL;
+  const char* path            = NULL;
+  if (g_strcmp0(ctx->raw_file, "-") == 0) {
+    path = "-";
+  } else {
+    gfile_path = g_file_get_path(files[0]);
+    /* g_file_get_path returns NULL for non-local URIs; fall back to the raw argument */
+    path = gfile_path != NULL ? gfile_path : ctx->raw_file;
+  }
+  if (path == NULL) {
+    girara_error("Failed to determine path for the given file.");
+    return;
+  }
+
+  int page_number = ctx->page_number;
+  if (page_number > 0) {
+    --page_number;
+  }
+  document_open_idle(ctx->zathura, path, ctx->password, page_number, ctx->mode, ctx->synctex_fwd, ctx->bookmark_name,
+                     ctx->search_string);
+}
+
+static void cb_app_shutdown(GApplication* UNUSED(app), gpointer data) {
+  zathura_app_ctx_t* ctx = data;
+  if (ctx->zathura != NULL) {
+    zathura_free(ctx->zathura);
+    ctx->zathura = NULL;
+  }
 }
 
 static GStrv build_argv_for_child(int idx, char** argv, int argc, char** orig_argv, int orig_argc, int file_idx_base) {
@@ -136,10 +210,8 @@ GIRARA_VISIBLE int main(int argc, char* argv[]) {
   gboolean print_version           = false;
   gint page_number                 = ZATHURA_PAGE_NUMBER_UNSPECIFIED;
   gint synctex_pid                 = -1;
-  Window embed                     = 0;
 
-  const GOptionEntry entries[] = {
-      {"reparent", 'e', 0, G_OPTION_ARG_INT, &embed, _("Reparents to window specified by xid (X11)"), "xid"},
+  GOptionEntry entries[] = {
       {"config-dir", 'c', 0, G_OPTION_ARG_FILENAME, &config_dir, _("Path to the config directory"), "path"},
       {"data-dir", 'd', 0, G_OPTION_ARG_FILENAME, &data_dir, _("Path to the data directory"), "path"},
       {"cache-dir", '\0', 0, G_OPTION_ARG_FILENAME, &cache_dir, _("Path to the cache directory"), "path"},
@@ -270,44 +342,51 @@ GIRARA_VISIBLE int main(int argc, char* argv[]) {
     return 0;
   }
 
-  /* Initialize GTK+ */
-  gtk_init(&argc, &argv);
-
-  /* Create zathura session */
-  g_autoptr(zathura_t) zathura =
-      init_zathura(config_dir, data_dir, cache_dir, plugin_path, argv, synctex_editor, embed);
-  if (zathura == NULL) {
-    girara_error("Could not initialize zathura.");
-    return -1;
+  /* fail early so these errors still exit with an error status */
+  if (file_idx == 0) {
+    if (bookmark_name != NULL) {
+      girara_error("Can not use bookmark argument when no file is given");
+      return -1;
+    }
+    if (search_string != NULL) {
+      girara_error("Can not use find argument when no file is given");
+      return -1;
+    }
   }
 
-  /* open document if passed */
+  /* run zathura as a GtkApplication */
+  zathura_app_ctx_t ctx = {
+      .config_dir     = config_dir,
+      .data_dir       = data_dir,
+      .cache_dir      = cache_dir,
+      .plugin_path    = plugin_path,
+      .synctex_editor = synctex_editor,
+      .password       = password,
+      .synctex_fwd    = synctex_fwd,
+      .mode           = mode,
+      .bookmark_name  = bookmark_name,
+      .search_string  = search_string,
+      .raw_file       = NULL,
+      .page_number    = page_number,
+      .argv           = argv,
+      .zathura        = NULL,
+  };
+
+  /* a NULL application id keeps the process non-unique and skips D-Bus registration */
+  g_autoptr(GtkApplication) app = gtk_application_new(NULL, G_APPLICATION_NON_UNIQUE | G_APPLICATION_HANDLES_OPEN);
+  g_signal_connect(app, "startup", G_CALLBACK(cb_app_startup), &ctx);
+  g_signal_connect(app, "activate", G_CALLBACK(cb_app_activate), &ctx);
+  g_signal_connect(app, "open", G_CALLBACK(cb_app_open), &ctx);
+  g_signal_connect(app, "shutdown", G_CALLBACK(cb_app_shutdown), &ctx);
+
+  /* feed g_application_run a minimal argv so it routes via open or activate */
+  char* run_argv[3] = {argv[0], NULL, NULL};
+  int run_argc      = 1;
   if (file_idx != 0) {
-    if (page_number > 0) {
-      --page_number;
-    }
-    document_open_idle(zathura, argv[file_idx], password, page_number, mode, synctex_fwd, bookmark_name, search_string);
-  } else if (bookmark_name != NULL) {
-    girara_error("Can not use bookmark argument when no file is given");
-    return -1;
-  } else if (search_string != NULL) {
-    girara_error("Can not use find argument when no file is given");
-    return -1;
+    ctx.raw_file = argv[file_idx];
+    run_argv[1]  = argv[file_idx];
+    run_argc     = 2;
   }
 
-#ifdef __APPLE__
-  GtkosxApplication* zathuraApp = g_object_new(GTKOSX_TYPE_APPLICATION, NULL);
-  gtkosx_application_set_use_quartz_accelerators(zathuraApp, FALSE);
-  gtkosx_application_ready(zathuraApp);
-  {
-    const gchar* id = gtkosx_application_get_bundle_id();
-    if (id != NULL) {
-      girara_warning("TestIntegration Error! Bundle has ID %s", id);
-    }
-  }
-#endif
-
-  /* run zathura */
-  gtk_main();
-  return 0;
+  return g_application_run(G_APPLICATION(app), run_argc, run_argv);
 }

--- a/zathura/marks.c
+++ b/zathura/marks.c
@@ -18,51 +18,39 @@
 static void mark_add(zathura_t* zathura, int key);
 static void mark_evaluate(zathura_t* zathura, int key);
 
-static gboolean cb_marks_view_key_press_event_add(GtkWidget* UNUSED(widget), GdkEventKey* event, gpointer user_data) {
-  g_return_val_if_fail(user_data != NULL, FALSE);
+static gboolean cb_marks_one_shot(GtkEventControllerKey* controller, guint keyval, guint UNUSED(keycode),
+                                  GdkModifierType UNUSED(state), gpointer user_data) {
   girara_session_t* session = user_data;
-  g_return_val_if_fail(session->gtk.view != NULL, FALSE);
-  g_return_val_if_fail(session->global.data != NULL, FALSE);
+  g_return_val_if_fail(session != NULL && session->global.data != NULL, FALSE);
   zathura_t* zathura = session->global.data;
 
-  /* reset signal handler */
-  g_signal_handler_disconnect(G_OBJECT(session->gtk.view), session->signals.view_key_pressed);
-  session->signals.view_key_pressed = g_signal_connect(G_OBJECT(session->gtk.view), "key-press-event",
-                                                       G_CALLBACK(girara_callback_view_key_press_event), session);
+  GtkEventController* ctrl = GTK_EVENT_CONTROLLER(controller);
+  gboolean evaluate        = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(ctrl), "evaluate"));
+  GtkWidget* win           = gtk_event_controller_get_widget(ctrl);
 
-  /* evaluate key */
-  if (((event->keyval >= '0' && event->keyval <= '9') || (event->keyval >= 'a' && event->keyval <= 'z') ||
-       (event->keyval >= 'A' && event->keyval <= 'Z')) == false) {
-    return FALSE;
-  }
+  /* remove the controller from its own callback so it only fires once */
+  gtk_widget_remove_controller(win, ctrl);
 
-  mark_add(zathura, event->keyval);
-
-  return TRUE;
-}
-
-static gboolean cb_marks_view_key_press_event_evaluate(GtkWidget* UNUSED(widget), GdkEventKey* event,
-                                                       gpointer user_data) {
-  g_return_val_if_fail(user_data != NULL, FALSE);
-  girara_session_t* session = user_data;
-  g_return_val_if_fail(session->gtk.view != NULL, FALSE);
-  g_return_val_if_fail(session->global.data != NULL, FALSE);
-  zathura_t* zathura = session->global.data;
-
-  /* reset signal handler */
-  g_signal_handler_disconnect(G_OBJECT(session->gtk.view), session->signals.view_key_pressed);
-  session->signals.view_key_pressed = g_signal_connect(G_OBJECT(session->gtk.view), "key-press-event",
-                                                       G_CALLBACK(girara_callback_view_key_press_event), session);
-
-  /* evaluate key */
-  if (((event->keyval >= '0' && event->keyval <= '9') || (event->keyval >= 'a' && event->keyval <= 'z') ||
-       (event->keyval >= 'A' && event->keyval <= 'Z')) == false) {
+  if (((keyval >= '0' && keyval <= '9') || (keyval >= 'a' && keyval <= 'z') || (keyval >= 'A' && keyval <= 'Z')) ==
+      false) {
     return TRUE;
   }
 
-  mark_evaluate(zathura, event->keyval);
-
+  if (evaluate) {
+    mark_evaluate(zathura, keyval);
+  } else {
+    mark_add(zathura, keyval);
+  }
   return TRUE;
+}
+
+/* set up a one-shot controller, evaluate selects between add and evaluate */
+static void marks_install_one_shot(girara_session_t* session, gboolean evaluate) {
+  GtkEventController* ctrl = gtk_event_controller_key_new();
+  gtk_event_controller_set_propagation_phase(ctrl, GTK_PHASE_CAPTURE);
+  g_object_set_data(G_OBJECT(ctrl), "evaluate", GINT_TO_POINTER(evaluate));
+  g_signal_connect(ctrl, "key-pressed", G_CALLBACK(cb_marks_one_shot), session);
+  gtk_widget_add_controller(session->gtk.window, ctrl);
 }
 
 bool sc_mark_add(girara_session_t* session, girara_argument_t* UNUSED(argument), girara_event_t* UNUSED(event),
@@ -70,11 +58,7 @@ bool sc_mark_add(girara_session_t* session, girara_argument_t* UNUSED(argument),
   g_return_val_if_fail(session != NULL, false);
   g_return_val_if_fail(session->gtk.view != NULL, false);
 
-  /* redirect signal handler */
-  g_signal_handler_disconnect(G_OBJECT(session->gtk.view), session->signals.view_key_pressed);
-  session->signals.view_key_pressed = g_signal_connect(G_OBJECT(session->gtk.view), "key-press-event",
-                                                       G_CALLBACK(cb_marks_view_key_press_event_add), session);
-
+  marks_install_one_shot(session, FALSE);
   return true;
 }
 
@@ -83,11 +67,7 @@ bool sc_mark_evaluate(girara_session_t* session, girara_argument_t* UNUSED(argum
   g_return_val_if_fail(session != NULL, false);
   g_return_val_if_fail(session->gtk.view != NULL, false);
 
-  /* redirect signal handler */
-  g_signal_handler_disconnect(G_OBJECT(session->gtk.view), session->signals.view_key_pressed);
-  session->signals.view_key_pressed = g_signal_connect(G_OBJECT(session->gtk.view), "key-press-event",
-                                                       G_CALLBACK(cb_marks_view_key_press_event_evaluate), session);
-
+  marks_install_one_shot(session, TRUE);
   return true;
 }
 

--- a/zathura/page-widget.c
+++ b/zathura/page-widget.c
@@ -3,6 +3,7 @@
 #include "page-widget.h"
 
 #include <girara/utils.h>
+#include <girara-gtk/callbacks.h>
 #include <girara-gtk/settings.h>
 #include <girara/datastructures.h>
 #include <girara-gtk/session.h>
@@ -66,26 +67,30 @@ typedef struct zathura_page_widget_private_s {
     gboolean retrieved;  /**< True if we already tried to retrieve the list of signatures */
     gboolean draw;       /**< True if links should be drawn */
   } signatures;
+
+  GtkWidget* drawing_area;           /**< child layer that draws the page */
+  GtkWidget* image_popover;          /**< lazily created image context menu */
+  GSimpleActionGroup* image_actions; /**< action group for the image popup */
 } ZathuraPageWidgetPrivate;
 
-G_DEFINE_TYPE_WITH_CODE(ZathuraPageWidget, zathura_page_widget, GTK_TYPE_DRAWING_AREA, G_ADD_PRIVATE(ZathuraPageWidget))
+G_DEFINE_TYPE_WITH_CODE(ZathuraPageWidget, zathura_page_widget, GTK_TYPE_WIDGET, G_ADD_PRIVATE(ZathuraPageWidget))
 
-static gboolean zathura_page_widget_draw(GtkWidget* widget, cairo_t* cairo);
+static void cb_page_draw(GtkDrawingArea* area, cairo_t* cairo, int width, int height, gpointer data);
 static void zathura_page_widget_finalize(GObject* object);
 static void zathura_page_widget_dispose(GObject* object);
 static void zathura_page_widget_set_property(GObject* object, guint prop_id, const GValue* value, GParamSpec* pspec);
 static void zathura_page_widget_get_property(GObject* object, guint prop_id, GValue* value, GParamSpec* pspec);
-static void redraw_rect(ZathuraPageWidget* widget, zathura_rectangle_t* rectangle);
-static void redraw_all_rects(ZathuraPageWidget* widget, girara_list_t* rectangles);
 static void evaluate_link_at_mouse_position(ZathuraPageWidget* widget, int oldx, int oldy);
-static void zathura_page_widget_popup_menu(GtkWidget* widget, GdkEventButton* event);
-static gboolean cb_zathura_page_widget_button_press_event(GtkWidget* widget, GdkEventButton* button);
-static gboolean cb_zathura_page_widget_button_release_event(GtkWidget* widget, GdkEventButton* button);
-static gboolean cb_zathura_page_widget_motion_notify(GtkWidget* widget, GdkEventMotion* event);
-static gboolean cb_zathura_page_widget_leave_notify(GtkWidget* widget, GdkEventCrossing* event);
-static gboolean cb_zathura_page_widget_popup_menu(GtkWidget* widget);
-static void cb_menu_image_copy(GtkMenuItem* item, ZathuraPageWidget* page);
-static void cb_menu_image_save(GtkMenuItem* item, ZathuraPageWidget* page);
+static void zathura_page_widget_popup_menu(GtkWidget* widget, double x, double y);
+static void cb_menu_image_copy(GSimpleAction* action, GVariant* parameter, gpointer data);
+static void cb_menu_image_save(GSimpleAction* action, GVariant* parameter, gpointer data);
+static void cb_zathura_page_widget_button_press_event(GtkGestureClick* gesture, gint n_press, gdouble x, gdouble y,
+                                                      gpointer data);
+static void cb_zathura_page_widget_button_release_event(GtkGestureClick* gesture, gint n_press, gdouble x, gdouble y,
+                                                        gpointer data);
+static void cb_zathura_page_widget_motion_notify(GtkEventControllerMotion* controller, gdouble x, gdouble y,
+                                                 gpointer data);
+static void cb_zathura_page_widget_leave_notify(GtkEventControllerMotion* controller, gpointer data);
 static void cb_update_surface(ZathuraRenderRequest* request, cairo_surface_t* surface, void* data);
 static void cb_cache_added(ZathuraRenderRequest* request, void* data);
 static void cb_cache_invalidated(ZathuraRenderRequest* request, void* data);
@@ -120,13 +125,8 @@ static guint signals[LAST_SIGNAL] = {0};
 
 static void zathura_page_widget_class_init(ZathuraPageWidgetClass* class) {
   /* overwrite methods */
-  GtkWidgetClass* widget_class       = GTK_WIDGET_CLASS(class);
-  widget_class->draw                 = zathura_page_widget_draw;
-  widget_class->button_press_event   = cb_zathura_page_widget_button_press_event;
-  widget_class->button_release_event = cb_zathura_page_widget_button_release_event;
-  widget_class->motion_notify_event  = cb_zathura_page_widget_motion_notify;
-  widget_class->leave_notify_event   = cb_zathura_page_widget_leave_notify;
-  widget_class->popup_menu           = cb_zathura_page_widget_popup_menu;
+  GtkWidgetClass* widget_class = GTK_WIDGET_CLASS(class);
+  gtk_widget_class_set_layout_manager_type(widget_class, GTK_TYPE_BIN_LAYOUT);
 
   GObjectClass* object_class = G_OBJECT_CLASS(class);
   object_class->dispose      = zathura_page_widget_dispose;
@@ -232,9 +232,31 @@ static void zathura_page_widget_init(ZathuraPageWidget* widget) {
   priv->signatures.retrieved = false;
   priv->signatures.draw      = false;
 
-  const unsigned int event_mask =
-      GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_POINTER_MOTION_MASK | GDK_LEAVE_NOTIFY_MASK;
-  gtk_widget_add_events(GTK_WIDGET(widget), event_mask);
+  /* page is drawn into a child drawing area */
+  priv->drawing_area = gtk_drawing_area_new();
+  gtk_drawing_area_set_draw_func(GTK_DRAWING_AREA(priv->drawing_area), cb_page_draw, widget, NULL);
+  gtk_widget_set_parent(priv->drawing_area, GTK_WIDGET(widget));
+
+  GtkGesture* click = gtk_gesture_click_new();
+  gtk_gesture_single_set_button(GTK_GESTURE_SINGLE(click), 0);
+  g_signal_connect(click, "pressed", G_CALLBACK(cb_zathura_page_widget_button_press_event), widget);
+  g_signal_connect(click, "released", G_CALLBACK(cb_zathura_page_widget_button_release_event), widget);
+  gtk_widget_add_controller(GTK_WIDGET(widget), GTK_EVENT_CONTROLLER(click));
+
+  GtkEventController* motion = gtk_event_controller_motion_new();
+  g_signal_connect(motion, "motion", G_CALLBACK(cb_zathura_page_widget_motion_notify), widget);
+  g_signal_connect(motion, "leave", G_CALLBACK(cb_zathura_page_widget_leave_notify), widget);
+  gtk_widget_add_controller(GTK_WIDGET(widget), motion);
+
+  /* image popup actions are looked up by the popover via the image prefix */
+  static const GActionEntry image_action_entries[] = {
+      {"copy", cb_menu_image_copy, NULL, NULL, NULL, {0, 0, 0}},
+      {"save", cb_menu_image_save, NULL, NULL, NULL, {0, 0, 0}},
+  };
+  priv->image_actions = g_simple_action_group_new();
+  g_action_map_add_action_entries(G_ACTION_MAP(priv->image_actions), image_action_entries,
+                                  G_N_ELEMENTS(image_action_entries), widget);
+  gtk_widget_insert_action_group(GTK_WIDGET(widget), "image", G_ACTION_GROUP(priv->image_actions));
 }
 
 GtkWidget* zathura_page_widget_new(zathura_t* zathura, zathura_page_t* page) {
@@ -260,6 +282,9 @@ static void zathura_page_widget_dispose(GObject* object) {
   ZathuraPageWidgetPrivate* priv = zathura_page_widget_get_instance_private(widget);
 
   g_clear_object(&priv->render_request);
+  g_clear_pointer(&priv->image_popover, gtk_widget_unparent);
+  g_clear_object(&priv->image_actions);
+  g_clear_pointer(&priv->drawing_area, gtk_widget_unparent);
 
   G_OBJECT_CLASS(zathura_page_widget_parent_class)->dispose(object);
 }
@@ -301,11 +326,13 @@ static void set_font_from_property(cairo_t* cairo, zathura_t* zathura, cairo_fon
 
   /* convert point size to device units */
   if (!pango_font_description_get_size_is_absolute(descr)) {
+    /* gtk-xft-dpi units are 1024ths of a point */
     double font_dpi = 96.0;
     if (zathura->ui.session != NULL) {
-      if (gtk_widget_has_screen(zathura->ui.session->gtk.view)) {
-        GdkScreen* screen = gtk_widget_get_screen(zathura->ui.session->gtk.view);
-        font_dpi          = gdk_screen_get_resolution(screen);
+      int xft_dpi = -1;
+      g_object_get(gtk_widget_get_settings(zathura->ui.session->gtk.view), "gtk-xft-dpi", &xft_dpi, NULL);
+      if (xft_dpi > 0) {
+        font_dpi = xft_dpi / 1024.0;
       }
     }
     size = size * font_dpi / 72;
@@ -315,40 +342,6 @@ static void set_font_from_property(cairo_t* cairo, zathura_t* zathura, cairo_fon
   cairo_set_font_size(cairo, size);
 
   pango_font_description_free(descr);
-}
-
-static cairo_text_extents_t get_text_extents(const char* string, zathura_t* zathura, cairo_font_weight_t weight) {
-  cairo_text_extents_t text = {
-      0,
-  };
-
-  if (zathura == NULL) {
-    return text;
-  }
-
-  /* make dummy surface to satisfy API requirements */
-  cairo_surface_t* surface = cairo_image_surface_create(CAIRO_FORMAT_RGB24, 0, 0);
-  if (cairo_surface_status(surface) != CAIRO_STATUS_SUCCESS) {
-    return text;
-  }
-
-  cairo_t* cairo = cairo_create(surface);
-  if (cairo_status(cairo) != CAIRO_STATUS_SUCCESS) {
-    cairo_surface_destroy(surface);
-    return text;
-  }
-
-  set_font_from_property(cairo, zathura, weight);
-  cairo_text_extents(cairo, string, &text);
-
-  /* add some margin (for some reason the reported extents can be a bit short) */
-  text.width += 6;
-  text.height += 2;
-
-  cairo_destroy(cairo);
-  cairo_surface_destroy(surface);
-
-  return text;
 }
 
 static void zathura_page_widget_set_property(GObject* object, guint prop_id, const GValue* value, GParamSpec* pspec) {
@@ -372,21 +365,8 @@ static void zathura_page_widget_set_property(GObject* object, guint prop_id, con
     }
 
     if (priv->links.retrieved == TRUE && priv->links.list != NULL) {
-      /* get size of text that should be large enough for every link hint */
-      const cairo_text_extents_t text = get_text_extents("888", priv->zathura, CAIRO_FONT_WEIGHT_BOLD);
-
-      for (size_t idx = 0; idx != girara_list_size(priv->links.list); ++idx) {
-        zathura_link_t* link = girara_list_nth(priv->links.list, idx);
-        if (link != NULL) {
-          /* redraw link area */
-          zathura_rectangle_t rectangle = recalc_rectangle(priv->page, zathura_link_get_position(link));
-          redraw_rect(pageview, &rectangle);
-
-          /* also redraw area for link hint */
-          rectangle.x2 = rectangle.x1 + text.width;
-          rectangle.y1 = rectangle.y2 - text.height;
-          redraw_rect(pageview, &rectangle);
-        }
+      if (priv->drawing_area != NULL) {
+        gtk_widget_queue_draw(priv->drawing_area);
       }
     }
     break;
@@ -395,22 +375,26 @@ static void zathura_page_widget_set_property(GObject* object, guint prop_id, con
     break;
   case PROP_SEARCH_RESULTS:
     if (priv->search.list != NULL && priv->search.draw) {
-      redraw_all_rects(pageview, priv->search.list);
+      if (priv->drawing_area != NULL) {
+        gtk_widget_queue_draw(priv->drawing_area);
+      }
     }
     girara_list_free(priv->search.list);
     priv->search.list = g_value_get_pointer(value);
     if (priv->search.list != NULL && priv->search.draw) {
       priv->links.draw = FALSE;
-      redraw_all_rects(pageview, priv->search.list);
+      if (priv->drawing_area != NULL) {
+        gtk_widget_queue_draw(priv->drawing_area);
+      }
     }
     priv->search.current = -1;
     break;
   case PROP_SEARCH_RESULTS_CURRENT: {
     g_return_if_fail(priv->search.list != NULL);
     if (priv->search.current >= 0 && priv->search.current < (signed)girara_list_size(priv->search.list)) {
-      zathura_rectangle_t* rect     = girara_list_nth(priv->search.list, priv->search.current);
-      zathura_rectangle_t rectangle = recalc_rectangle(priv->page, *rect);
-      redraw_rect(pageview, &rectangle);
+      if (priv->drawing_area != NULL) {
+        gtk_widget_queue_draw(priv->drawing_area);
+      }
     }
     int val = g_value_get_int(value);
     if (val < 0) {
@@ -418,9 +402,9 @@ static void zathura_page_widget_set_property(GObject* object, guint prop_id, con
     } else {
       priv->search.current = val;
       if (priv->search.draw == TRUE && val >= 0 && val < (signed)girara_list_size(priv->search.list)) {
-        zathura_rectangle_t* rect     = girara_list_nth(priv->search.list, priv->search.current);
-        zathura_rectangle_t rectangle = recalc_rectangle(priv->page, *rect);
-        redraw_rect(pageview, &rectangle);
+        if (priv->drawing_area != NULL) {
+          gtk_widget_queue_draw(priv->drawing_area);
+        }
       }
     }
     break;
@@ -436,7 +420,9 @@ static void zathura_page_widget_set_property(GObject* object, guint prop_id, con
      */
 
     if (priv->search.list != NULL && zathura_page_get_visibility(priv->page)) {
-      gtk_widget_queue_draw(GTK_WIDGET(object));
+      if (priv->drawing_area != NULL) {
+        gtk_widget_queue_draw(priv->drawing_area);
+      }
     }
     break;
   case PROP_DRAW_SIGNATURES:
@@ -448,14 +434,8 @@ static void zathura_page_widget_set_property(GObject* object, guint prop_id, con
     }
 
     if (priv->signatures.retrieved == TRUE && priv->signatures.list != NULL) {
-      for (size_t idx = 0; idx != girara_list_size(priv->signatures.list); ++idx) {
-        zathura_signature_info_t* signature = girara_list_nth(priv->signatures.list, idx);
-        if (signature == NULL) {
-          continue;
-        }
-        /* redraw signature area */
-        zathura_rectangle_t rectangle = recalc_rectangle(priv->page, signature->position);
-        redraw_rect(pageview, &rectangle);
+      if (priv->drawing_area != NULL) {
+        gtk_widget_queue_draw(priv->drawing_area);
       }
     }
     break;
@@ -489,6 +469,23 @@ static void zathura_page_widget_get_property(GObject* object, guint prop_id, GVa
   }
 }
 
+/* test against current geometry because the cached visibility flag can lag behind layout */
+static bool page_widget_on_screen(GtkWidget* widget) {
+  GtkWidget* document_widget = gtk_widget_get_ancestor(widget, ZATHURA_TYPE_DOCUMENT_WIDGET);
+  if (document_widget == NULL) {
+    return gtk_widget_get_mapped(widget);
+  }
+
+  graphene_rect_t bounds = {0};
+  if (gtk_widget_compute_bounds(widget, document_widget, &bounds) == false) {
+    return false;
+  }
+
+  const graphene_rect_t view =
+      GRAPHENE_RECT_INIT(0, 0, gtk_widget_get_width(document_widget), gtk_widget_get_height(document_widget));
+  return graphene_rect_intersection(&view, &bounds, NULL);
+}
+
 static zathura_device_factors_t get_safe_device_factors(cairo_surface_t* surface) {
   zathura_device_factors_t factors;
   cairo_surface_get_device_scale(surface, &factors.x, &factors.y);
@@ -503,14 +500,15 @@ static zathura_device_factors_t get_safe_device_factors(cairo_surface_t* surface
   return factors;
 }
 
-static gboolean zathura_page_widget_draw(GtkWidget* widget, cairo_t* cairo) {
+static void cb_page_draw(GtkDrawingArea* GIRARA_UNUSED(area), cairo_t* cairo, int width, int height, gpointer data) {
+  GtkWidget* widget              = GTK_WIDGET(data);
   ZathuraPageWidget* page        = ZATHURA_PAGE_WIDGET(widget);
   ZathuraPageWidgetPrivate* priv = zathura_page_widget_get_instance_private(page);
   zathura_t* zathura             = priv->zathura;
 
   zathura_document_t* document   = zathura_page_get_document(priv->page);
-  const unsigned int page_height = gtk_widget_get_allocated_height(widget);
-  const unsigned int page_width  = gtk_widget_get_allocated_width(widget);
+  const unsigned int page_height = (unsigned int)height;
+  const unsigned int page_width  = (unsigned int)width;
 
   bool surface_exists = priv->surface != NULL || priv->thumbnail != NULL;
 
@@ -519,7 +517,9 @@ static gboolean zathura_page_widget_draw(GtkWidget* widget, cairo_t* cairo) {
 
     if (page_index < zathura_document_get_number_of_pages(priv->zathura->predecessor_document)) {
       /* render real page */
-      zathura_render_request(priv->render_request, g_get_real_time());
+      if (page_widget_on_screen(widget) == true) {
+        zathura_render_request(priv->render_request, g_get_real_time());
+      }
 
       girara_debug("using predecessor page for idx %d", page_index);
       document = priv->zathura->predecessor_document;
@@ -579,8 +579,10 @@ static gboolean zathura_page_widget_draw(GtkWidget* widget, cairo_t* cairo) {
       /* All but the last jobs requested here are aborted during zooming.
        * Processing and aborting smaller jobs first improves responsiveness. */
       const gint64 penalty = (gint64)pwidth * (gint64)pheight;
-      zathura_render_request(priv->render_request, g_get_real_time() + penalty);
-      return FALSE;
+      if (page_widget_on_screen(widget) == true) {
+        zathura_render_request(priv->render_request, g_get_real_time() + penalty);
+      }
+      return;
     }
 
     /* draw links */
@@ -712,6 +714,19 @@ static gboolean zathura_page_widget_draw(GtkWidget* widget, cairo_t* cairo) {
       cairo_fill(cairo);
     }
   } else {
+    /* No cached surface yet, render the on-screen page synchronously. All other rendering is asynchronous
+     * This makes the rendering of the first page much faster and avoids the "Loading..." message as well */
+    if (page_widget_on_screen(widget) == true) {
+      cairo_surface_t* rendered = zathura_renderer_render_page(zathura->sync.render_thread, priv->page);
+      if (rendered != NULL) {
+        zathura_page_widget_update_surface(page, rendered, false);
+        cairo_set_source_surface(cairo, rendered, 0, 0);
+        cairo_paint(cairo);
+        cairo_surface_destroy(rendered);
+        return;
+      }
+    }
+
     girara_debug("rendering loading screen, flicker might be happening");
 
     GdkRGBA color_fg = priv->zathura->ui.colors.render_loading_fg;
@@ -743,15 +758,18 @@ static gboolean zathura_page_widget_draw(GtkWidget* widget, cairo_t* cairo) {
       cairo_show_text(cairo, text);
     }
 
-    /* render real page */
-    zathura_render_request(priv->render_request, g_get_real_time());
+    /* request a render for every page that intersects the view */
+    if (page_widget_on_screen(widget) == true) {
+      zathura_render_request(priv->render_request, g_get_real_time());
+    }
   }
-  return FALSE;
 }
 
 static void zathura_page_widget_redraw_canvas(ZathuraPageWidget* pageview) {
-  GtkWidget* widget = GTK_WIDGET(pageview);
-  gtk_widget_queue_draw(widget);
+  ZathuraPageWidgetPrivate* priv = zathura_page_widget_get_instance_private(pageview);
+  if (priv->drawing_area != NULL) {
+    gtk_widget_queue_draw(priv->drawing_area);
+  }
 }
 
 /* smaller than max to be replaced by actual renders */
@@ -883,23 +901,6 @@ static void cb_cache_invalidated(ZathuraRenderRequest* UNUSED(request), void* da
   priv->cached = false;
 }
 
-static void redraw_rect(ZathuraPageWidget* widget, zathura_rectangle_t* rectangle) {
-  /* cause the rect to be drawn */
-  const int width  = (rectangle->x2 + 1) - rectangle->x1;
-  const int height = (rectangle->y2 + 1) - rectangle->y1;
-  gtk_widget_queue_draw_area(GTK_WIDGET(widget), rectangle->x1, rectangle->y1, width, height);
-}
-
-static void redraw_all_rects(ZathuraPageWidget* widget, girara_list_t* rectangles) {
-  ZathuraPageWidgetPrivate* priv = zathura_page_widget_get_instance_private(widget);
-
-  for (size_t idx = 0; idx != girara_list_size(rectangles); ++idx) {
-    zathura_rectangle_t* rect     = girara_list_nth(rectangles, idx);
-    zathura_rectangle_t rectangle = recalc_rectangle(priv->page, *rect);
-    redraw_rect(widget, &rectangle);
-  }
-}
-
 static void evaluate_link_at_mouse_position(ZathuraPageWidget* page, int oldx, int oldy) {
   ZathuraPageWidgetPrivate* priv = zathura_page_widget_get_instance_private(page);
   /* simple single click */
@@ -976,19 +977,31 @@ void zathura_page_widget_clear_selection(ZathuraPageWidget* widget) {
   zathura_page_widget_redraw_canvas(widget);
 }
 
-static gboolean cb_zathura_page_widget_button_press_event(GtkWidget* widget, GdkEventButton* button) {
-  g_return_val_if_fail(widget != NULL, false);
-  g_return_val_if_fail(button != NULL, false);
-
+static void cb_zathura_page_widget_button_press_event(GtkGestureClick* gesture, gint n_press, gdouble bx, gdouble by,
+                                                      gpointer data) {
+  GtkWidget* widget              = GTK_WIDGET(data);
   ZathuraPageWidget* page        = ZATHURA_PAGE_WIDGET(widget);
   ZathuraPageWidgetPrivate* priv = zathura_page_widget_get_instance_private(page);
 
-  if (girara_callback_view_button_press_event(widget, button, priv->zathura->ui.session) == true) {
-    return true;
+  const guint gbutton   = gtk_gesture_single_get_current_button(GTK_GESTURE_SINGLE(gesture));
+  GdkModifierType state = gtk_event_controller_get_current_event_state(GTK_EVENT_CONTROLLER(gesture));
+
+  /* yield to configured mouse bindings (dispatched by the view gestures) instead of starting a selection */
+  girara_event_type_t etype = GIRARA_EVENT_BUTTON_PRESS;
+  if (n_press == 2) {
+    etype = GIRARA_EVENT_2BUTTON_PRESS;
+  } else if (n_press == 3) {
+    etype = GIRARA_EVENT_3BUTTON_PRESS;
+  }
+  if (priv->zathura != NULL && priv->zathura->ui.session != NULL &&
+      girara_has_mouse_event(priv->zathura->ui.session, etype, gbutton, state) == true) {
+    return;
   }
 
-  if (button->button == GDK_BUTTON_PRIMARY) { /* left click */
-    if (button->type == GDK_BUTTON_PRESS) {
+  if (gbutton == GDK_BUTTON_PRIMARY) {
+    zathura_page_widget_clear_selection(page);
+
+    if (n_press == 1) {
       /* clear pages with a selection already */
       if (priv->zathura != NULL && priv->zathura->pages != NULL) {
         zathura_document_t* document = zathura_page_get_document(priv->page);
@@ -1007,58 +1020,43 @@ static gboolean cb_zathura_page_widget_button_press_event(GtkWidget* widget, Gdk
 
       /* start the selection */
       double x, y;
-      rotate_point(priv->zathura, zathura_page_get_index(priv->page), button->x, button->y, &x, &y);
-
+      rotate_point(priv->zathura, zathura_page_get_index(priv->page), bx, by, &x, &y);
       priv->mouse.selection.x1 = x;
       priv->mouse.selection.y1 = y;
       priv->mouse.selection.x2 = x;
       priv->mouse.selection.y2 = y;
-
-    } else if (button->type == GDK_2BUTTON_PRESS || button->type == GDK_3BUTTON_PRESS) {
+    } else if (n_press == 2 || n_press == 3) {
       /* abort the selection */
       priv->mouse.selection.x1 = -1;
       priv->mouse.selection.y1 = -1;
       priv->mouse.selection.x2 = -1;
       priv->mouse.selection.y2 = -1;
     }
-
-    return true;
-  } else if (gdk_event_triggers_context_menu((GdkEvent*)button) == TRUE &&
-             button->type == GDK_BUTTON_PRESS) { /* right click */
-    zathura_page_widget_popup_menu(widget, button);
-    return true;
+  } else if (gbutton == GDK_BUTTON_SECONDARY && n_press == 1) {
+    zathura_page_widget_popup_menu(widget, bx, by);
   }
-
-  return false;
 }
 
-static gboolean cb_zathura_page_widget_button_release_event(GtkWidget* widget, GdkEventButton* button) {
-  g_return_val_if_fail(widget != NULL, false);
-  g_return_val_if_fail(button != NULL, false);
-
-  if (button->type != GDK_BUTTON_RELEASE) {
-    return false;
-  }
-
+static void cb_zathura_page_widget_button_release_event(GtkGestureClick* gesture, gint UNUSED(n_press), gdouble bx,
+                                                        gdouble by, gpointer data) {
+  GtkWidget* widget              = GTK_WIDGET(data);
   ZathuraPageWidget* page        = ZATHURA_PAGE_WIDGET(widget);
   ZathuraPageWidgetPrivate* priv = zathura_page_widget_get_instance_private(page);
 
   zathura_document_t* document = zathura_page_get_document(priv->page);
   const double scale           = zathura_document_get_scale(document);
 
-  const int oldx = button->x;
-  const int oldy = button->y;
+  const int oldx        = bx;
+  const int oldy        = by;
+  const guint gbutton   = gtk_gesture_single_get_current_button(GTK_GESTURE_SINGLE(gesture));
+  GdkModifierType state = gtk_event_controller_get_current_event_state(GTK_EVENT_CONTROLLER(gesture));
 
-  button->x /= scale;
-  button->y /= scale;
+  /* signal payload, gtk4 events cannot be constructed by hand */
+  scaled_button_release_event_t srelease = {.x = bx / scale, .y = by / scale, .button = gbutton, .state = state};
+  g_signal_emit(page, signals[BUTTON_RELEASE], 0, &srelease);
 
-  g_signal_emit(page, signals[BUTTON_RELEASE], 0, button);
-
-  button->x = oldx;
-  button->y = oldy;
-
-  if (button->button != GDK_BUTTON_PRIMARY) {
-    return false;
+  if (gbutton != GDK_BUTTON_PRIMARY) {
+    return;
   }
 
   if (priv->mouse.selection.x2 == -1 && priv->mouse.selection.y2 == -1) {
@@ -1088,8 +1086,6 @@ static gboolean cb_zathura_page_widget_button_release_event(GtkWidget* widget, G
   priv->mouse.selection.y1 = -1;
   priv->mouse.selection.x2 = -1;
   priv->mouse.selection.y2 = -1;
-
-  return false;
 }
 
 static zathura_rectangle_t next_selection_rectangle(double basepoint_x, double basepoint_y, double next_x,
@@ -1115,21 +1111,21 @@ static zathura_rectangle_t next_selection_rectangle(double basepoint_x, double b
   return rect;
 }
 
-static gboolean cb_zathura_page_widget_motion_notify(GtkWidget* widget, GdkEventMotion* event) {
-  g_return_val_if_fail(widget != NULL, false);
-  g_return_val_if_fail(event != NULL, false);
-
+static void cb_zathura_page_widget_motion_notify(GtkEventControllerMotion* controller, gdouble ex, gdouble ey,
+                                                 gpointer data) {
+  GtkWidget* widget              = GTK_WIDGET(data);
   ZathuraPageWidget* page        = ZATHURA_PAGE_WIDGET(widget);
   ZathuraPageWidgetPrivate* priv = zathura_page_widget_get_instance_private(page);
 
   zathura_document_t* document = zathura_page_get_document(priv->page);
   const double scale           = zathura_document_get_scale(document);
+  GdkModifierType evstate      = gtk_event_controller_get_current_event_state(GTK_EVENT_CONTROLLER(controller));
 
-  if (event->state & GDK_BUTTON1_MASK) { /* holding left mouse button */
+  if (evstate & GDK_BUTTON1_MASK) { /* holding left mouse button */
     zathura_page_widget_clear_selection(page);
-    if (event->state & priv->zathura->global.highlighter_modmask) {
+    if (evstate & priv->zathura->global.highlighter_modmask) {
       double x, y;
-      rotate_point(priv->zathura, zathura_page_get_index(priv->page), event->x, event->y, &x, &y);
+      rotate_point(priv->zathura, zathura_page_get_index(priv->page), ex, ey, &x, &y);
       priv->highlighter.bounds = next_selection_rectangle(priv->mouse.selection.x1, priv->mouse.selection.y1, x, y);
       priv->highlighter.bounds.x1 /= scale;
       priv->highlighter.bounds.y1 /= scale;
@@ -1140,7 +1136,7 @@ static gboolean cb_zathura_page_widget_motion_notify(GtkWidget* widget, GdkEvent
       zathura_page_widget_redraw_canvas(page);
     } else {
       /* calculate next selection */
-      rotate_point(priv->zathura, zathura_page_get_index(priv->page), event->x, event->y, &priv->mouse.selection.x2,
+      rotate_point(priv->zathura, zathura_page_get_index(priv->page), ex, ey, &priv->mouse.selection.x2,
                    &priv->mouse.selection.y2);
 
       zathura_rectangle_t selection = priv->mouse.selection;
@@ -1167,7 +1163,7 @@ static gboolean cb_zathura_page_widget_motion_notify(GtkWidget* widget, GdkEvent
       for (size_t idx = 0; idx != girara_list_size(priv->links.list); ++idx) {
         zathura_link_t* link     = girara_list_nth(priv->links.list, idx);
         zathura_rectangle_t rect = recalc_rectangle(priv->page, zathura_link_get_position(link));
-        if (rect.x1 <= event->x && rect.x2 >= event->x && rect.y1 <= event->y && rect.y2 >= event->y) {
+        if (rect.x1 <= ex && rect.x2 >= ex && rect.y1 <= ey && rect.y2 >= ey) {
           over_link = true;
           break;
         }
@@ -1183,14 +1179,10 @@ static gboolean cb_zathura_page_widget_motion_notify(GtkWidget* widget, GdkEvent
       }
     }
   }
-
-  return false;
 }
 
-static gboolean cb_zathura_page_widget_leave_notify(GtkWidget* widget, GdkEventCrossing* UNUSED(event)) {
-  g_return_val_if_fail(widget != NULL, false);
-
-  ZathuraPageWidget* page        = ZATHURA_PAGE_WIDGET(widget);
+static void cb_zathura_page_widget_leave_notify(GtkEventControllerMotion* UNUSED(controller), gpointer data) {
+  ZathuraPageWidget* page        = ZATHURA_PAGE_WIDGET(data);
   ZathuraPageWidgetPrivate* priv = zathura_page_widget_get_instance_private(page);
 
   bool keep_selection = false;
@@ -1204,15 +1196,11 @@ static gboolean cb_zathura_page_widget_leave_notify(GtkWidget* widget, GdkEventC
     g_signal_emit(page, signals[LEAVE_LINK], 0);
     priv->mouse.over_link = false;
   }
-  return false;
 }
 
-static void zathura_page_widget_popup_menu(GtkWidget* widget, GdkEventButton* event) {
+/* show context menu for the image under the click position */
+static void zathura_page_widget_popup_menu(GtkWidget* widget, double x, double y) {
   g_return_if_fail(widget != NULL);
-  if (event == NULL) {
-    /* do something here in the future in case we have general popups */
-    return;
-  }
 
   ZathuraPageWidget* page        = ZATHURA_PAGE_WIDGET(widget);
   ZathuraPageWidgetPrivate* priv = zathura_page_widget_get_instance_private(page);
@@ -1226,12 +1214,12 @@ static void zathura_page_widget_popup_menu(GtkWidget* widget, GdkEventButton* ev
     return;
   }
 
-  /* search for underlaying image */
+  /* find the image under the click position */
   zathura_image_t* image = NULL;
   for (size_t idx = 0; idx != girara_list_size(priv->images.list); ++idx) {
     zathura_image_t* image_it = girara_list_nth(priv->images.list, idx);
     zathura_rectangle_t rect  = recalc_rectangle(priv->page, image_it->position);
-    if (rect.x1 <= event->x && rect.x2 >= event->x && rect.y1 <= event->y && rect.y2 >= event->y) {
+    if (rect.x1 <= x && rect.x2 >= x && rect.y1 <= y && rect.y2 >= y) {
       image = image_it;
     }
   }
@@ -1242,73 +1230,94 @@ static void zathura_page_widget_popup_menu(GtkWidget* widget, GdkEventButton* ev
 
   priv->images.current = image;
 
-  /* setup menu */
-  GtkWidget* menu = gtk_menu_new();
+  /* lazily create the popover so unused page widgets do not pay for it */
+  /* keeping it alive across right clicks avoids the action lookup failure */
+  /* when unparenting during the closed signal */
+  if (priv->image_popover == NULL) {
+    GMenu* model = g_menu_new();
+    g_menu_append(model, _("Copy image"), "image.copy");
+    g_menu_append(model, _("Save image as"), "image.save");
 
-  typedef struct menu_item_s {
-    char* text;
-    void (*callback)(GtkMenuItem*, ZathuraPageWidget*);
-  } menu_item_t;
+    priv->image_popover = gtk_popover_menu_new_from_model(G_MENU_MODEL(model));
+    g_object_unref(model);
 
-  const menu_item_t menu_items[] = {
-      {_("Copy image"), cb_menu_image_copy},
-      {_("Save image as"), cb_menu_image_save},
-  };
-
-  for (unsigned int i = 0; i < LENGTH(menu_items); i++) {
-    GtkWidget* item = gtk_menu_item_new_with_label(menu_items[i].text);
-    gtk_menu_shell_append(GTK_MENU_SHELL(menu), item);
-    gtk_widget_show(item);
-    g_signal_connect(G_OBJECT(item), "activate", G_CALLBACK(menu_items[i].callback), page);
+    gtk_widget_set_parent(priv->image_popover, widget);
+    gtk_popover_set_has_arrow(GTK_POPOVER(priv->image_popover), FALSE);
   }
 
-  /* attach and popup */
-  gtk_menu_attach_to_widget(GTK_MENU(menu), widget, NULL);
-  gtk_menu_popup_at_pointer(GTK_MENU(menu), (GdkEvent*)event);
+  gtk_popover_set_pointing_to(GTK_POPOVER(priv->image_popover),
+                              &(GdkRectangle){.x = (int)x, .y = (int)y, .width = 1, .height = 1});
+  gtk_popover_popup(GTK_POPOVER(priv->image_popover));
 }
 
-static gboolean cb_zathura_page_widget_popup_menu(GtkWidget* widget) {
-  zathura_page_widget_popup_menu(widget, NULL);
-
-  return TRUE;
-}
-
-static void cb_menu_image_copy(GtkMenuItem* item, ZathuraPageWidget* page) {
-  g_return_if_fail(item != NULL);
+static void cb_menu_image_copy(GSimpleAction* UNUSED(action), GVariant* UNUSED(parameter), gpointer data) {
+  ZathuraPageWidget* page = ZATHURA_PAGE_WIDGET(data);
   g_return_if_fail(page != NULL);
   ZathuraPageWidgetPrivate* priv = zathura_page_widget_get_instance_private(page);
-  g_return_if_fail(priv->images.current != NULL);
+  if (priv->images.current == NULL) {
+    return;
+  }
 
   cairo_surface_t* surface = zathura_page_image_get_cairo(priv->page, priv->images.current, NULL);
   if (surface == NULL) {
     return;
   }
 
-  const int width  = cairo_image_surface_get_width(surface);
-  const int height = cairo_image_surface_get_height(surface);
+  /* build a GdkTexture from the cairo image surface */
+  /* the image-selected signal carries a texture for the gtk4 clipboard */
+  cairo_surface_flush(surface);
+  if (cairo_image_surface_get_format(surface) != CAIRO_FORMAT_ARGB32) {
+    /* plugins commonly return RGB24; convert so the copy still works */
+    cairo_surface_t* converted = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, cairo_image_surface_get_width(surface),
+                                                            cairo_image_surface_get_height(surface));
+    if (cairo_surface_status(converted) != CAIRO_STATUS_SUCCESS) {
+      cairo_surface_destroy(converted);
+      cairo_surface_destroy(surface);
+      priv->images.current = NULL;
+      return;
+    }
+    cairo_t* cr = cairo_create(converted);
+    cairo_set_source_surface(cr, surface, 0, 0);
+    cairo_paint(cr);
+    cairo_destroy(cr);
+    cairo_surface_flush(converted);
+    cairo_surface_destroy(surface);
+    surface = converted;
+  }
+  const int width      = cairo_image_surface_get_width(surface);
+  const int height     = cairo_image_surface_get_height(surface);
+  const int stride     = cairo_image_surface_get_stride(surface);
+  const guchar* pixels = cairo_image_surface_get_data(surface);
+  /* cairo native-endian ARGB32 maps to b8g8r8a8 on little endian and a8r8g8b8 on big endian */
+#if G_BYTE_ORDER == G_LITTLE_ENDIAN
+  const GdkMemoryFormat format = GDK_MEMORY_B8G8R8A8_PREMULTIPLIED;
+#else
+  const GdkMemoryFormat format = GDK_MEMORY_A8R8G8B8_PREMULTIPLIED;
+#endif
+  GBytes* bytes       = g_bytes_new(pixels, (gsize)stride * (gsize)height);
+  GdkTexture* texture = gdk_memory_texture_new(width, height, format, bytes, (gsize)stride);
+  g_bytes_unref(bytes);
 
-  GdkPixbuf* pixbuf = gdk_pixbuf_get_from_surface(surface, 0, 0, width, height);
-  if (pixbuf != NULL) {
-    g_signal_emit(page, signals[IMAGE_SELECTED], 0, pixbuf);
-    g_object_unref(pixbuf);
+  if (texture != NULL) {
+    g_signal_emit(page, signals[IMAGE_SELECTED], 0, texture);
+    g_object_unref(texture);
   }
   cairo_surface_destroy(surface);
 
-  /* reset */
   priv->images.current = NULL;
 }
 
-static void cb_menu_image_save(GtkMenuItem* item, ZathuraPageWidget* page) {
-  g_return_if_fail(item != NULL);
+static void cb_menu_image_save(GSimpleAction* UNUSED(action), GVariant* UNUSED(parameter), gpointer data) {
+  ZathuraPageWidget* page = ZATHURA_PAGE_WIDGET(data);
   g_return_if_fail(page != NULL);
   ZathuraPageWidgetPrivate* priv = zathura_page_widget_get_instance_private(page);
-  g_return_if_fail(priv->images.current != NULL);
-  g_return_if_fail(priv->images.list != NULL);
+  if (priv->images.current == NULL || priv->images.list == NULL) {
+    return;
+  }
 
-  /* generate image identifier */
+  /* generate the image identifier used by :export */
   unsigned int page_id  = zathura_page_get_index(priv->page) + 1;
   unsigned int image_id = 1;
-
   for (size_t idx = 0; idx != girara_list_size(priv->images.list); ++idx, ++image_id) {
     zathura_image_t* image_it = girara_list_nth(priv->images.list, idx);
     if (image_it == priv->images.current) {
@@ -1316,12 +1325,10 @@ static void cb_menu_image_save(GtkMenuItem* item, ZathuraPageWidget* page) {
     }
   }
 
-  /* set command */
-  char* export_command                  = g_strdup_printf(":export image-p%d-%d ", page_id, image_id);
-  g_autofree girara_argument_t argument = {.n = 0, .data = export_command};
+  g_autofree char* export_command = g_strdup_printf(":export image-p%d-%d ", page_id, image_id);
+  girara_argument_t argument      = {.n = 0, .data = export_command};
   sc_focus_inputbar(priv->zathura->ui.session, &argument, NULL, 0);
 
-  /* reset */
   priv->images.current = NULL;
 }
 
@@ -1366,10 +1373,19 @@ zathura_page_t* zathura_page_widget_get_page(ZathuraPageWidget* widget) {
 
 void zathura_page_widget_set_size_request(ZathuraPageWidget* widget, int width, int height) {
   g_return_if_fail(widget != NULL);
+  ZathuraPageWidgetPrivate* priv = zathura_page_widget_get_instance_private(widget);
   gtk_widget_set_size_request(GTK_WIDGET(widget), width, height);
+  if (priv->drawing_area != NULL) {
+    gtk_widget_set_size_request(priv->drawing_area, width, height);
+  }
 
   zathura_page_widget_abort_render_request(widget);
   zathura_page_widget_update_surface(widget, NULL, true);
+
+  /* queue_resize does not imply queue_draw in gtk4, ensure the drawing area runs cb_page_draw */
+  if (priv->drawing_area != NULL) {
+    gtk_widget_queue_draw(priv->drawing_area);
+  }
 }
 
 void zathura_page_widget_clear_thumbnail(ZathuraPageWidget* widget) {

--- a/zathura/page-widget.h
+++ b/zathura/page-widget.h
@@ -16,11 +16,11 @@
  * to TRUE at least one time.
  * */
 struct zathura_page_widget_s {
-  GtkDrawingArea parent;
+  GtkWidget parent;
 };
 
 struct zathura_page_widget_class_s {
-  GtkDrawingAreaClass parent_class;
+  GtkWidgetClass parent_class;
 };
 
 #define ZATHURA_TYPE_PAGE_WIDGET (zathura_page_widget_get_type())
@@ -105,5 +105,13 @@ void zathura_page_widget_set_size_request(ZathuraPageWidget* widget, int width, 
  * @param widget the widget
  */
 void zathura_page_widget_clear_thumbnail(ZathuraPageWidget* widget);
+
+/* scaled-button-release signal payload */
+typedef struct scaled_button_release_event_s {
+  double x;              /**< x in page coordinates */
+  double y;              /**< y in page coordinates */
+  guint button;          /**< button number */
+  GdkModifierType state; /**< modifier state */
+} scaled_button_release_event_t;
 
 #endif

--- a/zathura/render.c
+++ b/zathura/render.c
@@ -893,6 +893,41 @@ static bool render(render_job_t* job, ZathuraRenderRequest* request, ZathuraRend
   return true;
 }
 
+/* render a page synchronously and return its surface */
+cairo_surface_t* zathura_renderer_render_page(ZathuraRenderer* renderer, zathura_page_t* page) {
+  g_return_val_if_fail(ZATHURA_IS_RENDERER(renderer) == TRUE, NULL);
+  g_return_val_if_fail(page != NULL, NULL);
+
+  ZathuraRendererPrivate* priv = zathura_renderer_get_instance_private(renderer);
+  zathura_document_t* document = zathura_page_get_document(page);
+
+  unsigned int page_width = 0, page_height = 0;
+  const double real_scale = page_calc_height_width(document, page, &page_height, &page_width, false);
+
+  const zathura_device_factors_t device_factors = zathura_document_get_device_factors(document);
+  page_width *= device_factors.x;
+  page_height *= device_factors.y;
+
+  const cairo_format_t format = priv->recolor.enabled ? CAIRO_FORMAT_ARGB32 : CAIRO_FORMAT_RGB24;
+  cairo_surface_t* surface    = cairo_image_surface_create(format, page_width, page_height);
+  cairo_surface_set_device_scale(surface, device_factors.x, device_factors.y);
+  if (cairo_surface_status(surface) != CAIRO_STATUS_SUCCESS) {
+    cairo_surface_destroy(surface);
+    return NULL;
+  }
+
+  if (render_to_cairo_surface(surface, page, renderer, real_scale) != true) {
+    cairo_surface_destroy(surface);
+    return NULL;
+  }
+
+  if (priv->recolor.enabled == true) {
+    recolor(priv, page, page_width, page_height, surface, device_factors);
+  }
+
+  return surface;
+}
+
 static void render_job(void* data, void* user_data) {
   render_job_t* job             = data;
   ZathuraRenderRequest* request = job->request;

--- a/zathura/render.h
+++ b/zathura/render.h
@@ -38,6 +38,10 @@ GType zathura_renderer_get_type(void) G_GNUC_CONST;
  */
 ZathuraRenderer* zathura_renderer_new(size_t cache_size);
 
+/* Render a page synchronously through the same locked path as the render thread.
+ * The caller owns the returned surface and must destroy it. */
+cairo_surface_t* zathura_renderer_render_page(ZathuraRenderer* renderer, zathura_page_t* page);
+
 /**
  * Return whether recoloring is enabled.
  * @param renderer a renderer object

--- a/zathura/seccomp-filters.c
+++ b/zathura/seccomp-filters.c
@@ -16,8 +16,9 @@
 #include <sys/ioctl.h>   /* for TIOCSTI */
 #include <termios.h>
 
+#include <gtk/gtk.h>
 #ifdef GDK_WINDOWING_X11
-#include <gtk/gtkx.h>
+#include <gdk/x11/gdkx.h>
 #endif
 
 #define ADD_RULE(str_action, action, call, ...)                                                                        \

--- a/zathura/shortcuts.c
+++ b/zathura/shortcuts.c
@@ -23,6 +23,7 @@
 #include "document.h"
 #include "page-widget.h"
 #include "page.h"
+#include "plugin.h"
 #include "print.h"
 #include "render.h"
 #include "utils.h"
@@ -207,7 +208,7 @@ bool sc_copy_filepath(girara_session_t* session, girara_argument_t* UNUSED(argum
     return false;
   }
 
-  g_autofree GdkAtom* selection = get_selection(zathura);
+  GdkClipboard* selection = get_selection(zathura);
   if (selection == NULL) {
     return false;
   }
@@ -219,7 +220,7 @@ bool sc_copy_filepath(girara_session_t* session, girara_argument_t* UNUSED(argum
   }
 
   girara_debug("Copying file path to clipboard");
-  gtk_clipboard_set_text(gtk_clipboard_get(*selection), file_path, -1);
+  gdk_clipboard_set_text(selection, file_path);
 
   bool notification = true;
   girara_setting_get(session, "selection-notification", &notification);
@@ -298,17 +299,17 @@ bool sc_focus_inputbar(girara_session_t* session, girara_argument_t* argument, g
   zathura_document_set_adjust_mode(zathura->document, ZATHURA_ADJUST_INPUTBAR);
 
   if (gtk_widget_get_visible(GTK_WIDGET(session->gtk.inputbar)) == false) {
-    gtk_widget_show(GTK_WIDGET(session->gtk.inputbar));
+    gtk_widget_set_visible(GTK_WIDGET(session->gtk.inputbar), TRUE);
   }
 
   if (gtk_widget_get_visible(GTK_WIDGET(session->gtk.notification_area)) == true) {
-    gtk_widget_hide(GTK_WIDGET(session->gtk.notification_area));
+    gtk_widget_set_visible(GTK_WIDGET(session->gtk.notification_area), FALSE);
   }
 
   gtk_widget_grab_focus(GTK_WIDGET(session->gtk.inputbar_entry));
 
   if (argument->data != NULL) {
-    gtk_entry_set_text(session->gtk.inputbar_entry, (char*)argument->data);
+    gtk_editable_set_text(GTK_EDITABLE(session->gtk.inputbar_entry), (char*)argument->data);
 
     /* append filepath */
     if (argument->n == APPEND_FILEPATH && zathura->document != NULL) {
@@ -322,24 +323,10 @@ bool sc_focus_inputbar(girara_session_t* session, girara_argument_t* argument, g
       g_autofree char* tmp =
           g_strdup_printf("%s%s/", (char*)argument->data, (g_strcmp0(path, "/") == 0) ? "" : escaped);
 
-      gtk_entry_set_text(session->gtk.inputbar_entry, tmp);
-    }
-
-    g_autofree GdkAtom* selection = get_selection(zathura);
-
-    /* we save the X clipboard that will be clear by "grab_focus" */
-    g_autofree gchar* x_clipboard_text = NULL;
-
-    if (selection != NULL) {
-      x_clipboard_text = gtk_clipboard_wait_for_text(gtk_clipboard_get(*selection));
+      gtk_editable_set_text(GTK_EDITABLE(session->gtk.inputbar_entry), tmp);
     }
 
     gtk_editable_set_position(GTK_EDITABLE(session->gtk.inputbar_entry), -1);
-
-    if (x_clipboard_text != NULL && selection != NULL) {
-      /* we reset the X clipboard with saved text */
-      gtk_clipboard_set_text(gtk_clipboard_get(*selection), x_clipboard_text, -1);
-    }
   }
 
   return true;
@@ -420,6 +407,9 @@ bool sc_mouse_scroll(girara_session_t* session, girara_argument_t* argument, gir
 
     zathura_adjustment_set_value(x_adj, gtk_adjustment_get_value(x_adj) - (event->x - zathura->shortcut.mouse.x));
     zathura_adjustment_set_value(y_adj, gtk_adjustment_get_value(y_adj) - (event->y - zathura->shortcut.mouse.y));
+    /* save the current cursor position so the next motion event measures only the new movement */
+    zathura->shortcut.mouse.x = event->x;
+    zathura->shortcut.mouse.y = event->y;
     break;
 
     /* unhandled events */
@@ -953,6 +943,68 @@ bool sc_search(girara_session_t* session, girara_argument_t* argument, girara_ev
   return search_document(zathura, argument, false);
 }
 
+/* helper: get the current row index from the column view selection */
+/* expand a tree-list row and recursively expand all its descendants by iterating the flat model */
+static void index_expand_subtree(GListModel* flat_model, GtkTreeListRow* anchor) {
+  if (anchor == NULL) {
+    return;
+  }
+  gtk_tree_list_row_set_expanded(anchor, TRUE);
+  /* fix-point: repeatedly scan and expand any descendant of anchor that is collapsed.
+     each set_expanded inserts new rows into the flat model so we restart the scan. */
+  guint anchor_pos = gtk_tree_list_row_get_position(anchor);
+  gboolean changed;
+  do {
+    changed = FALSE;
+    guint n = g_list_model_get_n_items(flat_model);
+    for (guint i = anchor_pos + 1; i < n; i++) {
+      g_autoptr(GtkTreeListRow) r = g_list_model_get_item(flat_model, i);
+      if (r == NULL) {
+        continue;
+      }
+      /* is r a descendant of anchor? walk up its parent chain */
+      gboolean is_descendant        = FALSE;
+      g_autoptr(GtkTreeListRow) cur = g_object_ref(r);
+      while (TRUE) {
+        g_autoptr(GtkTreeListRow) parent = gtk_tree_list_row_get_parent(cur);
+        if (parent == NULL) {
+          break;
+        }
+        if (parent == anchor) {
+          is_descendant = TRUE;
+          break;
+        }
+        g_set_object(&cur, parent);
+      }
+      if (!is_descendant) {
+        continue;
+      }
+      if (gtk_tree_list_row_is_expandable(r) && !gtk_tree_list_row_get_expanded(r)) {
+        gtk_tree_list_row_set_expanded(r, TRUE);
+        changed = TRUE;
+        break; /* restart scan since model size changed */
+      }
+    }
+  } while (changed);
+}
+
+static guint index_get_position(GtkListView* view) {
+  GtkSelectionModel* sel = gtk_list_view_get_model(view);
+  GtkBitset* selected    = gtk_selection_model_get_selection(sel);
+  guint pos              = 0;
+  if (!gtk_bitset_is_empty(selected)) {
+    pos = gtk_bitset_get_minimum(selected);
+  }
+  gtk_bitset_unref(selected);
+  return pos;
+}
+
+static void index_select(GtkListView* view, guint pos) {
+  GtkSelectionModel* sel = gtk_list_view_get_model(view);
+  gtk_selection_model_select_item(sel, pos, TRUE);
+  gtk_list_view_scroll_to(view, pos, GTK_LIST_SCROLL_FOCUS | GTK_LIST_SCROLL_SELECT, NULL);
+}
+
 bool sc_navigate_index(girara_session_t* session, girara_argument_t* argument, girara_event_t* UNUSED(event),
                        unsigned int t) {
   g_return_val_if_fail(session != NULL, false);
@@ -965,159 +1017,204 @@ bool sc_navigate_index(girara_session_t* session, girara_argument_t* argument, g
     return false;
   }
 
-  GList* tree_children   = gtk_container_get_children(GTK_CONTAINER(zathura->ui.index));
-  GtkTreeView* tree_view = tree_children->data;
-  g_list_free(tree_children);
-  GtkTreePath* path       = NULL;
-  GtkTreePath* start_path = NULL;
-  GtkTreePath* end_path   = NULL;
-
-  gtk_tree_view_get_cursor(tree_view, &path, NULL);
-  if (path == NULL) {
+  GtkListView* view            = GTK_LIST_VIEW(gtk_scrolled_window_get_child(GTK_SCROLLED_WINDOW(zathura->ui.index)));
+  GtkSelectionModel* selection = gtk_list_view_get_model(view);
+  GListModel* model            = G_LIST_MODEL(selection);
+  const guint n_items          = g_list_model_get_n_items(model);
+  if (n_items == 0) {
     return false;
   }
 
-  if (gtk_tree_view_get_visible_range(tree_view, &start_path, &end_path) != TRUE) {
-    girara_error("Cannot get visible range for index");
-    goto free_and_return;
-  }
-
-  GtkTreeModel* model = gtk_tree_view_get_model(tree_view);
-  GtkTreeIter iter, child_iter, parent_iter;
-
-  gboolean need_to_scroll = FALSE;
+  guint pos                     = index_get_position(view);
+  g_autoptr(GtkTreeListRow) row = g_list_model_get_item(model, pos);
 
   switch (argument->n) {
   case TOP:
-    /* go to the first node */
-    gtk_tree_path_free(path);
-    path = gtk_tree_path_new_first();
+    pos = 0;
     break;
   case BOTTOM:
-    /* go to the last visible node */
-    gtk_tree_path_free(path);
-    path = gtk_tree_path_new_from_indices(gtk_tree_model_iter_n_children(model, NULL) - 1, -1);
-    gtk_tree_model_get_iter(model, &iter, path);
-    while (gtk_tree_model_iter_has_child(model, &iter) == TRUE && gtk_tree_view_row_expanded(tree_view, path) == TRUE) {
-      gtk_tree_path_append_index(path, gtk_tree_model_iter_n_children(model, &iter) - 1);
-    }
+    pos = n_items - 1;
     break;
   case UP:
-    for (int n = (t == 0 ? 1 : t); n > 0; n--) {
-      if (gtk_tree_path_prev(path)) {
-        while (gtk_tree_view_row_expanded(tree_view, path)) {
-          gtk_tree_model_get_iter(model, &iter, path);
-          /* select last child */
-          gtk_tree_model_iter_nth_child(model, &child_iter, &iter, gtk_tree_model_iter_n_children(model, &iter) - 1);
-          gtk_tree_path_free(path);
-          path = gtk_tree_model_get_path(model, &child_iter);
-        }
-        continue;
-      }
-      gtk_tree_model_get_iter(model, &iter, path);
-      if (gtk_tree_model_iter_parent(model, &parent_iter, &iter)) {
-        gtk_tree_path_free(path);
-        path = gtk_tree_model_get_path(model, &parent_iter);
-      } else {
-        break;
-      }
+    for (int n = (t == 0 ? 1 : t); n > 0 && pos > 0; n--) {
+      pos--;
     }
     break;
   case DOWN:
-    for (int n = (t == 0 ? 1 : t); n > 0; n--) {
-      if (gtk_tree_view_row_expanded(tree_view, path)) {
-        gtk_tree_path_down(path);
-        continue;
-      }
-
-      gtk_tree_model_get_iter(model, &iter, path);
-      if (gtk_tree_model_iter_next(model, &iter)) {
-        gtk_tree_path_free(path);
-        path = gtk_tree_model_get_path(model, &iter);
-        continue;
-      }
-
-      gtk_tree_model_get_iter(model, &iter, path);
-      while (gtk_tree_model_iter_parent(model, &parent_iter, &iter)) {
-        iter = parent_iter;
-        if (gtk_tree_model_iter_next(model, &parent_iter)) {
-          gtk_tree_path_free(path);
-          path = gtk_tree_model_get_path(model, &parent_iter);
-          break;
-        }
-      }
+    for (int n = (t == 0 ? 1 : t); n > 0 && pos + 1 < n_items; n--) {
+      pos++;
     }
     break;
   case HALF_UP:
   case PARTIAL_UP:
-    gtk_tree_path_free(path);
-    path           = gtk_tree_path_copy(start_path);
-    need_to_scroll = TRUE;
-    break;
   case HALF_DOWN:
-  case PARTIAL_DOWN:
-    gtk_tree_path_free(path);
-    path           = gtk_tree_path_copy(end_path);
-    need_to_scroll = TRUE;
+  case PARTIAL_DOWN: {
+    /* compute number of rows currently in viewport from the vertical adjustment */
+    GtkAdjustment* vadj = gtk_scrollable_get_vadjustment(GTK_SCROLLABLE(view));
+    double page_size    = vadj != NULL ? gtk_adjustment_get_page_size(vadj) : 0.0;
+    double upper        = vadj != NULL ? gtk_adjustment_get_upper(vadj) : 0.0;
+    guint step          = (upper > 0.0) ? (guint)((page_size / upper) * (double)n_items) : 1;
+    if (step == 0) {
+      step = 1;
+    }
+    if (argument->n == HALF_UP || argument->n == PARTIAL_UP) {
+      pos = pos > step ? pos - step : 0;
+    } else {
+      pos = pos + step < n_items ? pos + step : n_items - 1;
+    }
     break;
+  }
   case EXPAND:
-    if (gtk_tree_view_expand_row(tree_view, path, FALSE)) {
-      gtk_tree_path_down(path);
-    }
-    break;
-  case EXPAND_RECURSIVE:
-    if (gtk_tree_view_expand_row(tree_view, path, TRUE)) {
-      gtk_tree_path_down(path);
-    }
-    break;
-  case EXPAND_ALL:
-    gtk_tree_view_expand_all(tree_view);
-    need_to_scroll = TRUE;
-    break;
-  case COLLAPSE:
-    if (gtk_tree_view_collapse_row(tree_view, path) == FALSE && gtk_tree_path_get_depth(path) > 1) {
-      gtk_tree_path_up(path);
-      gtk_tree_view_collapse_row(tree_view, path);
-    }
-    break;
-  case COLLAPSE_RECURSIVE:
-    while (gtk_tree_path_get_depth(path) > 1) {
-      gtk_tree_path_up(path);
-    }
-    gtk_tree_view_collapse_row(tree_view, path);
-    break;
-  case COLLAPSE_ALL:
-    gtk_tree_view_collapse_all(tree_view);
-    while (gtk_tree_path_get_depth(path) > 1) {
-      gtk_tree_path_up(path);
-    }
-    break;
-  case TOGGLE:
-    gtk_tree_model_get_iter(model, &iter, path);
-    if (gtk_tree_model_iter_has_child(model, &iter) == TRUE) {
-      if (gtk_tree_view_row_expanded(tree_view, path) == TRUE) {
-        gtk_tree_view_collapse_row(tree_view, path);
-      } else {
-        gtk_tree_view_expand_row(tree_view, path, FALSE);
+    if (row != NULL && gtk_tree_list_row_is_expandable(row)) {
+      if (!gtk_tree_list_row_get_expanded(row)) {
+        gtk_tree_list_row_set_expanded(row, TRUE);
+      }
+      /* move cursor to the first child */
+      if (pos + 1 < g_list_model_get_n_items(model)) {
+        pos++;
       }
     }
     break;
+  case EXPAND_RECURSIVE:
+    if (row != NULL && gtk_tree_list_row_is_expandable(row)) {
+      index_expand_subtree(model, row);
+      if (pos + 1 < g_list_model_get_n_items(model)) {
+        pos++;
+      }
+    }
+    break;
+  case EXPAND_ALL: {
+    /* fix-point expansion of every expandable row in the model */
+    gboolean changed;
+    do {
+      changed = FALSE;
+      guint n = g_list_model_get_n_items(model);
+      for (guint i = 0; i < n; i++) {
+        g_autoptr(GtkTreeListRow) r = g_list_model_get_item(model, i);
+        if (r != NULL && gtk_tree_list_row_is_expandable(r) && !gtk_tree_list_row_get_expanded(r)) {
+          gtk_tree_list_row_set_expanded(r, TRUE);
+          changed = TRUE;
+          break;
+        }
+      }
+    } while (changed);
+    pos = 0;
+    break;
+  }
+  case COLLAPSE:
+    if (row != NULL) {
+      if (gtk_tree_list_row_get_expanded(row)) {
+        gtk_tree_list_row_set_expanded(row, FALSE);
+      } else {
+        g_autoptr(GtkTreeListRow) parent = gtk_tree_list_row_get_parent(row);
+        if (parent != NULL) {
+          gtk_tree_list_row_set_expanded(parent, FALSE);
+          pos = gtk_tree_list_row_get_position(parent);
+        }
+      }
+    }
+    break;
+  case COLLAPSE_RECURSIVE:
+    if (row != NULL) {
+      g_autoptr(GtkTreeListRow) walk = g_object_ref(row);
+      while (TRUE) {
+        g_autoptr(GtkTreeListRow) parent = gtk_tree_list_row_get_parent(walk);
+        if (parent == NULL) {
+          break;
+        }
+        g_set_object(&walk, parent);
+      }
+      gtk_tree_list_row_set_expanded(walk, FALSE);
+      pos = gtk_tree_list_row_get_position(walk);
+    }
+    break;
+  case COLLAPSE_ALL: {
+    /* walk current row up to its top-level ancestor */
+    if (row != NULL) {
+      g_autoptr(GtkTreeListRow) walk = g_object_ref(row);
+      while (TRUE) {
+        g_autoptr(GtkTreeListRow) parent = gtk_tree_list_row_get_parent(walk);
+        if (parent == NULL) {
+          break;
+        }
+        g_set_object(&walk, parent);
+      }
+      pos = gtk_tree_list_row_get_position(walk);
+    }
+    /* collapsing a row hides all its descendants in the flat model, so collapsing
+       every depth-0 row is sufficient to hide all descendants */
+    guint n = g_list_model_get_n_items(model);
+    for (guint i = 0; i < n; i++) {
+      g_autoptr(GtkTreeListRow) r = g_list_model_get_item(model, i);
+      if (r != NULL && gtk_tree_list_row_get_depth(r) == 0 && gtk_tree_list_row_get_expanded(r)) {
+        gtk_tree_list_row_set_expanded(r, FALSE);
+      }
+    }
+    break;
+  }
+  case TOGGLE:
+    if (row != NULL && gtk_tree_list_row_is_expandable(row)) {
+      gtk_tree_list_row_set_expanded(row, !gtk_tree_list_row_get_expanded(row));
+    }
+    break;
   case SELECT:
-    cb_index_row_activated(tree_view, path, NULL, zathura);
-    goto free_and_return;
+    cb_index_row_activated(view, pos, zathura);
+    return false;
   }
 
-  gtk_tree_view_set_cursor(tree_view, path, NULL, FALSE);
-  if (need_to_scroll == TRUE) {
-    gtk_tree_view_scroll_to_cell(tree_view, path, NULL, TRUE, 0.5, 0.0);
-  }
-
-free_and_return:
-  gtk_tree_path_free(path);
-  gtk_tree_path_free(start_path);
-  gtk_tree_path_free(end_path);
-
+  index_select(view, pos);
   return false;
+}
+
+/* factory: build a complete index row (expander with title, page target, alt page) */
+static void index_row_setup(GtkSignalListItemFactory* UNUSED(factory), GObject* listitem, gpointer UNUSED(data)) {
+  GtkWidget* box      = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 12);
+  GtkWidget* expander = gtk_tree_expander_new();
+  GtkWidget* title    = gtk_label_new(NULL);
+  gtk_label_set_xalign(GTK_LABEL(title), 0.0f);
+  gtk_label_set_ellipsize(GTK_LABEL(title), PANGO_ELLIPSIZE_END);
+  gtk_label_set_use_markup(GTK_LABEL(title), TRUE);
+  gtk_tree_expander_set_child(GTK_TREE_EXPANDER(expander), title);
+  gtk_widget_set_hexpand(expander, TRUE);
+
+  GtkWidget* page = gtk_label_new(NULL);
+  gtk_label_set_xalign(GTK_LABEL(page), 1.0f);
+
+  GtkWidget* alt = gtk_label_new(NULL);
+  gtk_label_set_xalign(GTK_LABEL(alt), 0.0f);
+
+  gtk_box_append(GTK_BOX(box), expander);
+  gtk_box_append(GTK_BOX(box), page);
+  gtk_box_append(GTK_BOX(box), alt);
+  gtk_list_item_set_child(GTK_LIST_ITEM(listitem), box);
+}
+
+static void index_row_bind(GtkSignalListItemFactory* UNUSED(factory), GObject* listitem, gpointer UNUSED(data)) {
+  GtkWidget* box                = gtk_list_item_get_child(GTK_LIST_ITEM(listitem));
+  GtkWidget* expander           = gtk_widget_get_first_child(box);
+  GtkWidget* page               = gtk_widget_get_next_sibling(expander);
+  GtkWidget* alt                = gtk_widget_get_next_sibling(page);
+  GtkTreeListRow* row           = gtk_list_item_get_item(GTK_LIST_ITEM(listitem));
+  ZathuraIndexElementObject* it = gtk_tree_list_row_get_item(row);
+
+  gtk_tree_expander_set_list_row(GTK_TREE_EXPANDER(expander), row);
+  gtk_label_set_markup(GTK_LABEL(gtk_tree_expander_get_child(GTK_TREE_EXPANDER(expander))), it->title);
+  gtk_label_set_text(GTK_LABEL(page), it->page_label ? it->page_label : "");
+  gtk_label_set_text(GTK_LABEL(alt), it->page_alt ? it->page_alt : "");
+  g_object_unref(it);
+}
+
+/* GtkTreeListModelCreateModelFunc */
+static GListModel* index_create_child_model(gpointer item, gpointer UNUSED(user_data)) {
+  ZathuraIndexElementObject* obj = item;
+  if (obj->children == NULL) {
+    return NULL;
+  }
+  return G_LIST_MODEL(g_object_ref(obj->children));
+}
+
+static void cb_index_activate(GtkListView* view, guint position, gpointer user_data) {
+  cb_index_row_activated(view, position, user_data);
 }
 
 bool sc_toggle_index(girara_session_t* session, girara_argument_t* UNUSED(argument), girara_event_t* UNUSED(event),
@@ -1129,91 +1226,51 @@ bool sc_toggle_index(girara_session_t* session, girara_argument_t* UNUSED(argume
     return false;
   }
 
-  GtkWidget* treeview        = NULL;
-  GtkTreeModel* model        = NULL;
-  GtkCellRenderer* renderer  = NULL;
-  GtkCellRenderer* renderer2 = NULL;
-
   if (zathura->ui.index == NULL) {
     /* create new index widget */
-    zathura->ui.index = gtk_scrolled_window_new(NULL, NULL);
-
+    zathura->ui.index = gtk_scrolled_window_new();
     if (zathura->ui.index == NULL) {
       goto error_ret;
     }
-
     gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(zathura->ui.index), GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
 
-    /* create index */
     g_autoptr(girara_tree_node_t) document_index = zathura_document_index_generate(zathura->document, NULL);
     if (document_index == NULL) {
       girara_notify(session, GIRARA_WARNING, _("This document does not contain any index"));
       goto error_free;
     }
 
-    model = GTK_TREE_MODEL(gtk_tree_store_new(4, G_TYPE_STRING, G_TYPE_STRING, G_TYPE_STRING, G_TYPE_POINTER));
-    if (model == NULL) {
-      goto error_free;
-    }
+    GListModel* root            = document_index_build_model(session, document_index);
+    GtkTreeListModel* tree      = gtk_tree_list_model_new(root, FALSE, FALSE, index_create_child_model, NULL, NULL);
+    GtkSingleSelection* sel     = gtk_single_selection_new(G_LIST_MODEL(tree));
+    GtkListItemFactory* factory = gtk_signal_list_item_factory_new();
+    g_signal_connect(factory, "setup", G_CALLBACK(index_row_setup), NULL);
+    g_signal_connect(factory, "bind", G_CALLBACK(index_row_bind), NULL);
+    GtkListView* view = GTK_LIST_VIEW(gtk_list_view_new(GTK_SELECTION_MODEL(sel), factory));
 
-    treeview = gtk_tree_view_new_with_model(model);
-    if (treeview == NULL) {
-      goto error_free;
-    }
+    gtk_widget_add_css_class(GTK_WIDGET(view), "indexmode");
 
-    gtk_style_context_add_class(gtk_widget_get_style_context(treeview), "indexmode");
+    g_signal_connect(view, "activate", G_CALLBACK(cb_index_activate), zathura);
 
-    g_object_unref(model);
+    /* the tree list model, selection, and list view consume their model/factory references */
 
-    renderer = gtk_cell_renderer_text_new();
-    if (renderer == NULL) {
-      goto error_free;
-    }
-
-    renderer2 = gtk_cell_renderer_text_new();
-    if (renderer2 == NULL) {
-      goto error_free;
-    }
-
-    document_index_build(session, model, NULL, document_index);
-
-    /* setup widget */
-    gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(treeview), 0, "Title", renderer, "markup", 0, NULL);
-    gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(treeview), 1, "Target", renderer2, "text", 1, NULL);
-    gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(treeview), 2, "(alt)", renderer2, "text", 2, NULL);
-
-    gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(treeview), FALSE);
-    g_object_set(G_OBJECT(renderer), "ellipsize", PANGO_ELLIPSIZE_END, NULL);
-    g_object_set(G_OBJECT(gtk_tree_view_get_column(GTK_TREE_VIEW(treeview), 0)), "expand", TRUE, NULL);
-    gtk_tree_view_column_set_alignment(gtk_tree_view_get_column(GTK_TREE_VIEW(treeview), 1), 1.0f);
-    gtk_tree_view_set_search_equal_func(GTK_TREE_VIEW(treeview), search_equal_func_index, treeview, NULL);
-    gtk_tree_view_set_enable_search(GTK_TREE_VIEW(treeview), FALSE);
-    g_signal_connect(G_OBJECT(treeview), "row-activated", G_CALLBACK(cb_index_row_activated), zathura);
-
-    gtk_widget_set_visible(treeview, true);
-    gtk_container_add(GTK_CONTAINER(zathura->ui.index), treeview);
+    gtk_widget_set_visible(GTK_WIDGET(view), TRUE);
+    gtk_scrolled_window_set_child(GTK_SCROLLED_WINDOW(zathura->ui.index), GTK_WIDGET(view));
   }
 
   if (girara_mode_get(session) == zathura->modes.index) {
     girara_set_view(zathura->ui.session, zathura->ui.view);
     girara_mode_set(zathura->ui.session, zathura->modes.normal);
-
-    /* refresh view */
     refresh_view(zathura);
   } else {
-    /* save current position to the jumplist */
     zathura_jumplist_add(zathura);
 
     const zathura_adjust_mode_t adjust_mode = zathura_document_get_adjust_mode(zathura->document);
-
-    /* zathura goes to the first page when toggling index mode if this isn't done */
     if (adjust_mode == ZATHURA_ADJUST_INPUTBAR) {
       zathura_document_set_adjust_mode(zathura->document, ZATHURA_ADJUST_NONE);
     }
 
     girara_set_view(session, zathura->ui.index);
-    // GtkTreeView* tree_view = gtk_container_get_children(GTK_CONTAINER(zathura->ui.index))->data;
-    // gtk_widget_grab_focus(GTK_WIDGET(tree_view));
     index_scroll_to_current_page(zathura);
     girara_mode_set(zathura->ui.session, zathura->modes.index);
   }
@@ -1221,14 +1278,17 @@ bool sc_toggle_index(girara_session_t* session, girara_argument_t* UNUSED(argume
   return false;
 
 error_free:
-
   if (zathura->ui.index != NULL) {
-    g_object_ref_sink(zathura->ui.index);
+    GtkWidget* index_parent = gtk_widget_get_parent(zathura->ui.index);
+    if (GTK_IS_STACK(index_parent)) {
+      gtk_stack_remove(GTK_STACK(index_parent), zathura->ui.index);
+    } else {
+      g_object_ref_sink(zathura->ui.index);
+      g_object_unref(zathura->ui.index);
+    }
     zathura->ui.index = NULL;
   }
-
 error_ret:
-
   return false;
 }
 
@@ -1320,11 +1380,11 @@ bool sc_toggle_presentation(girara_session_t* session, girara_argument_t* UNUSED
 
     /* show status bar if it was enabled */
     if (zathura->shortcut.toggle_presentation_mode.is_status_bar_visible) {
-      gtk_widget_show(GTK_WIDGET(session->gtk.statusbar));
+      gtk_widget_set_visible(GTK_WIDGET(session->gtk.statusbar), TRUE);
     }
     /* show input bar if if was enabled */
     if (zathura->shortcut.toggle_presentation_mode.is_input_bar_visible) {
-      gtk_widget_show(GTK_WIDGET(session->gtk.inputbar));
+      gtk_widget_set_visible(GTK_WIDGET(session->gtk.inputbar), TRUE);
     }
 
     /* set full screen */
@@ -1360,6 +1420,10 @@ bool sc_toggle_presentation(girara_session_t* session, girara_argument_t* UNUSED
       g_object_set(zathura->ui.document_widget, "layout-mode", DOCUMENT_WIDGET_SINGLE, NULL);
     }
 
+    /* the gtk4 grid does not honor single-page layout yet, so force one column for a usable presentation */
+    const unsigned int presentation_pages_per_row = 1;
+    girara_setting_set(session, "pages-per-row", &presentation_pages_per_row);
+
     /* adjust window */
     girara_argument_t argument = {.n = ZATHURA_ADJUST_BESTFIT, .data = NULL};
     sc_adjust_window(session, &argument, NULL, 0);
@@ -1370,8 +1434,8 @@ bool sc_toggle_presentation(girara_session_t* session, girara_argument_t* UNUSED
         gtk_widget_get_visible(GTK_WIDGET(session->gtk.inputbar));
 
     /* hide status and inputbar */
-    gtk_widget_hide(GTK_WIDGET(session->gtk.inputbar));
-    gtk_widget_hide(GTK_WIDGET(session->gtk.statusbar));
+    gtk_widget_set_visible(GTK_WIDGET(session->gtk.inputbar), FALSE);
+    gtk_widget_set_visible(GTK_WIDGET(session->gtk.statusbar), FALSE);
 
     /* set full screen */
     gtk_window_fullscreen(GTK_WINDOW(session->gtk.window));
@@ -1411,11 +1475,13 @@ bool sc_toggle_single_page_mode(girara_session_t* session, girara_argument_t* UN
 bool sc_quit(girara_session_t* session, girara_argument_t* UNUSED(argument), girara_event_t* UNUSED(event),
              unsigned int UNUSED(t)) {
   g_return_val_if_fail(session != NULL, false);
+  g_return_val_if_fail(session->global.data != NULL, false);
+  zathura_t* zathura = session->global.data;
 
   girara_argument_t arg = {.n = GIRARA_HIDE, .data = NULL};
   girara_isc_completion(session, &arg, NULL, 0);
 
-  cb_destroy(NULL, NULL);
+  cb_destroy(NULL, zathura);
 
   return false;
 }
@@ -1628,36 +1694,73 @@ bool sc_snap_to_page(girara_session_t* session, girara_argument_t* UNUSED(argume
   return page_set(zathura, page);
 }
 
+/* async callback invoked after the user picks a file or cancels the dialog */
+static void cb_file_chooser_open(GObject* source, GAsyncResult* result, gpointer user_data) {
+  GtkFileDialog* dialog   = GTK_FILE_DIALOG(source);
+  zathura_t* zathura      = user_data;
+  g_autoptr(GError) error = NULL;
+  g_autoptr(GFile) file   = gtk_file_dialog_open_finish(dialog, result, &error);
+  if (file == NULL) {
+    /* user cancelled, do not warn */
+    if (error != NULL && !g_error_matches(error, GTK_DIALOG_ERROR, GTK_DIALOG_ERROR_DISMISSED)) {
+      girara_notify(zathura->ui.session, GIRARA_ERROR, "%s", error->message);
+    }
+    return;
+  }
+
+  g_autofree char* path = g_file_get_path(file);
+  if (path == NULL) {
+    girara_notify(zathura->ui.session, GIRARA_ERROR, _("Could not get path from file."));
+    return;
+  }
+
+  if (zathura_has_document(zathura) == true) {
+    document_close(zathura, false);
+  }
+  document_open_idle(zathura, path, NULL, ZATHURA_PAGE_NUMBER_UNSPECIFIED, NULL, NULL, NULL, NULL);
+}
+
 bool sc_file_chooser(girara_session_t* session, girara_argument_t* UNUSED(argument), girara_event_t* UNUSED(event),
                      unsigned int UNUSED(t)) {
   g_return_val_if_fail(session != NULL, false);
   g_return_val_if_fail(session->global.data != NULL, false);
   zathura_t* zathura = session->global.data;
 
-  g_autoptr(GtkFileChooserNative) native =
-      gtk_file_chooser_native_new(_("Open file"), NULL, GTK_FILE_CHOOSER_ACTION_OPEN, NULL, NULL);
-  GtkFileChooser* chooser = GTK_FILE_CHOOSER(native);
+  g_autoptr(GtkFileDialog) dialog = gtk_file_dialog_new();
+  gtk_file_dialog_set_title(dialog, _("Open document"));
 
-  girara_list_t* mime_types = zathura_plugin_manager_get_content_types(zathura->plugins.manager);
-  if (mime_types) {
-    GtkFileFilter* filter = gtk_file_filter_new();
-    for (size_t idx = 0; idx != girara_list_size(mime_types); ++idx) {
-      const char* mime_type = girara_list_nth(mime_types, idx);
-      girara_debug("adding mime type to %s to filter", mime_type);
-      gtk_file_filter_add_mime_type(filter, mime_type);
+  /* build a filter for all mime types supported by loaded plugins */
+  zathura_plugin_manager_t* manager = zathura->plugins.manager;
+  girara_list_t* types              = zathura_plugin_manager_get_content_types(manager);
+  if (types != NULL && girara_list_size(types) > 0) {
+    g_autoptr(GListStore) filters      = g_list_store_new(GTK_TYPE_FILE_FILTER);
+    g_autoptr(GtkFileFilter) supported = gtk_file_filter_new();
+    gtk_file_filter_set_name(supported, _("Supported documents"));
+    for (size_t idx = 0; idx != girara_list_size(types); ++idx) {
+      gtk_file_filter_add_mime_type(supported, girara_list_nth(types, idx));
     }
-    gtk_file_chooser_add_filter(chooser, filter);
+    g_list_store_append(filters, supported);
+
+    g_autoptr(GtkFileFilter) all = gtk_file_filter_new();
+    gtk_file_filter_set_name(all, _("All files"));
+    gtk_file_filter_add_pattern(all, "*");
+    g_list_store_append(filters, all);
+
+    gtk_file_dialog_set_filters(dialog, G_LIST_MODEL(filters));
+    gtk_file_dialog_set_default_filter(dialog, supported);
   }
 
-  const gint res = gtk_native_dialog_run(GTK_NATIVE_DIALOG(native));
-  if (res == GTK_RESPONSE_ACCEPT) {
-    if (zathura_has_document(zathura) && !document_close(zathura, false)) {
-      return false;
+  /* seed the dialog with the folder of the currently open document */
+  zathura_document_t* document = zathura_get_document(zathura);
+  if (document != NULL) {
+    const char* current_path = zathura_document_get_path(document);
+    if (current_path != NULL) {
+      g_autoptr(GFile) current = g_file_new_for_path(current_path);
+      gtk_file_dialog_set_initial_file(dialog, current);
     }
-
-    g_autofree char* filename = gtk_file_chooser_get_filename(chooser);
-    return document_open(zathura, filename, NULL, NULL, 0, NULL);
   }
 
+  GtkWindow* parent = GTK_WINDOW(session->gtk.window);
+  gtk_file_dialog_open(dialog, parent, NULL, cb_file_chooser_open, zathura);
   return true;
 }

--- a/zathura/utils.c
+++ b/zathura/utils.c
@@ -55,14 +55,40 @@ bool file_valid_extension(zathura_t* zathura, const char* path) {
   return zathura_plugin_manager_get_plugin(zathura->plugins.manager, content_type) != NULL;
 }
 
-static void index_element_free(void* data, GObject* UNUSED(object)) {
-  zathura_index_element_t* element = data;
-  zathura_index_element_free(element);
+G_DEFINE_TYPE(ZathuraIndexElementObject, zathura_index_element_object, G_TYPE_OBJECT)
+
+static void zathura_index_element_object_dispose(GObject* object) {
+  ZathuraIndexElementObject* self = ZATHURA_INDEX_ELEMENT_OBJECT(object);
+  g_clear_object(&self->children);
+  G_OBJECT_CLASS(zathura_index_element_object_parent_class)->dispose(object);
 }
 
-void document_index_build(girara_session_t* session, GtkTreeModel* model, GtkTreeIter* parent,
-                          girara_tree_node_t* tree) {
-  girara_list_t* list = girara_node_get_children(tree);
+static void zathura_index_element_object_finalize(GObject* object) {
+  ZathuraIndexElementObject* self = ZATHURA_INDEX_ELEMENT_OBJECT(object);
+  g_clear_pointer(&self->title, g_free);
+  g_clear_pointer(&self->page_label, g_free);
+  g_clear_pointer(&self->page_alt, g_free);
+  if (self->element != NULL) {
+    zathura_index_element_free(self->element);
+    self->element = NULL;
+  }
+  G_OBJECT_CLASS(zathura_index_element_object_parent_class)->finalize(object);
+}
+
+static void zathura_index_element_object_class_init(ZathuraIndexElementObjectClass* klass) {
+  GObjectClass* object_class = G_OBJECT_CLASS(klass);
+  object_class->dispose      = zathura_index_element_object_dispose;
+  object_class->finalize     = zathura_index_element_object_finalize;
+}
+
+static void zathura_index_element_object_init(ZathuraIndexElementObject* UNUSED(self)) {}
+
+/* build children store from a girara tree node */
+static GListStore* index_element_build_children(girara_session_t* session, girara_tree_node_t* tree) {
+  GListStore* store            = g_list_store_new(ZATHURA_TYPE_INDEX_ELEMENT_OBJECT);
+  girara_list_t* list          = girara_node_get_children(tree);
+  zathura_t* zathura           = session->global.data;
+  zathura_document_t* document = zathura != NULL ? zathura_get_document(zathura) : NULL;
 
   for (size_t idx = 0; idx != girara_list_size(list); ++idx) {
     girara_tree_node_t* node               = girara_list_nth(list, idx);
@@ -70,148 +96,151 @@ void document_index_build(girara_session_t* session, GtkTreeModel* model, GtkTre
     const zathura_link_type_t type         = zathura_link_get_type(index_element->link);
     const zathura_link_target_t target     = zathura_link_get_target(index_element->link);
 
-    g_autofree gchar* description  = NULL;
-    g_autofree gchar* description2 = NULL;
+    g_autofree char* page_label = NULL;
+    g_autofree char* page_alt   = NULL;
 
     if (type == ZATHURA_LINK_GOTO_DEST) {
-      zathura_t* zathura   = session->global.data;
-      zathura_page_t* page = zathura_document_get_page(zathura_get_document(zathura), target.page_number);
-      const char* label    = zathura_page_get_label(page, NULL);
-
+      zathura_page_t* page = document != NULL ? zathura_document_get_page(document, target.page_number) : NULL;
+      const char* label    = page != NULL ? zathura_page_get_label(page, NULL) : NULL;
       if (label != NULL) {
-        description  = g_strdup_printf("Page %s", label);
-        description2 = g_strdup_printf("(%d)", target.page_number + 1);
+        page_label = g_strdup_printf("Page %s", label);
+        page_alt   = g_strdup_printf("(%d)", target.page_number + 1);
       } else {
-        description = g_strdup_printf("Page %d", target.page_number + 1);
+        page_label = g_strdup_printf("Page %d", target.page_number + 1);
       }
     } else {
-      description = g_strdup(target.value);
+      page_label = g_strdup(target.value);
     }
 
-    GtkTreeIter tree_iter;
-    gtk_tree_store_append(GTK_TREE_STORE(model), &tree_iter, parent);
-    g_autofree gchar* markup = g_markup_escape_text(index_element->title, -1);
-    gtk_tree_store_set(GTK_TREE_STORE(model), &tree_iter, 0, markup, 1, description, 2, description2, 3, index_element,
-                       -1);
-    g_object_weak_ref(G_OBJECT(model), index_element_free, index_element);
+    ZathuraIndexElementObject* item = g_object_new(ZATHURA_TYPE_INDEX_ELEMENT_OBJECT, NULL);
+    item->title                     = g_markup_escape_text(index_element->title, -1);
+    item->page_label                = g_steal_pointer(&page_label);
+    item->page_alt                  = g_steal_pointer(&page_alt);
+    /* the girara tree nodes are released right after this function returns, so we
+       take ownership of the index_element pointer for our wrapper's lifetime */
+    item->element = index_element;
 
     if (girara_node_get_num_children(node) > 0) {
-      document_index_build(session, model, &tree_iter, node);
+      item->children = G_LIST_STORE(index_element_build_children(session, node));
     }
+
+    g_list_store_append(store, item);
+    g_object_unref(item);
+  }
+  return store;
+}
+
+GListModel* document_index_build_model(girara_session_t* session, girara_tree_node_t* tree) {
+  return G_LIST_MODEL(index_element_build_children(session, tree));
+}
+
+static GtkListView* get_list_view(zathura_t* zathura) {
+  return GTK_LIST_VIEW(gtk_scrolled_window_get_child(GTK_SCROLLED_WINDOW(zathura->ui.index)));
+}
+
+/* descend the hierarchy recording the deepest element whose target page <= current_page;
+   the path is built up from the root and stored as a chain of ZathuraIndexElementObject pointers */
+typedef struct {
+  ZathuraIndexElementObject** items;
+  size_t depth;
+  size_t capacity;
+} index_path_t;
+
+static void index_path_append(index_path_t* path, ZathuraIndexElementObject* item) {
+  if (path->depth == path->capacity) {
+    path->capacity = path->capacity == 0 ? 8 : path->capacity * 2;
+    path->items    = g_realloc(path->items, path->capacity * sizeof(*path->items));
+  }
+  path->items[path->depth++] = item;
+}
+
+static void index_path_copy(index_path_t* dst, const index_path_t* src) {
+  dst->depth = 0;
+  for (size_t i = 0; i < src->depth; i++) {
+    index_path_append(dst, src->items[i]);
   }
 }
 
-typedef struct {
-  GtkTreeIter current_iter;
-  unsigned int current_page;
-} search_data_t;
-
-static gboolean search_current_index(GtkTreeModel* model, GtkTreePath* UNUSED(path), GtkTreeIter* iter, gpointer data) {
-  search_data_t* search_data = data;
-  zathura_index_element_t* index_element;
-  gtk_tree_model_get(model, iter, 3, &index_element, -1);
-  zathura_link_target_t target = zathura_link_get_target(index_element->link);
-  if (target.page_number > search_data->current_page) {
-    return TRUE; // terminate foreach loop
+/* returns TRUE to signal early termination (matches gtk_tree_model_foreach semantics
+   where the callback returning TRUE stops the entire walk) */
+static gboolean find_deepest_path(GListModel* level, unsigned int current_page, index_path_t* current,
+                                  index_path_t* best) {
+  guint n = g_list_model_get_n_items(level);
+  for (guint i = 0; i < n; i++) {
+    g_autoptr(ZathuraIndexElementObject) item = g_list_model_get_item(level, i);
+    if (item == NULL || item->element == NULL) {
+      continue;
+    }
+    zathura_link_target_t target = zathura_link_get_target(item->element->link);
+    if (target.page_number > current_page) {
+      return TRUE;
+    }
+    index_path_append(current, item);
+    index_path_copy(best, current);
+    if (item->children != NULL) {
+      if (find_deepest_path(G_LIST_MODEL(item->children), current_page, current, best)) {
+        current->depth--;
+        return TRUE;
+      }
+    }
+    current->depth--;
   }
-  search_data->current_iter = *iter;
   return FALSE;
 }
 
-static bool find_substring(const char* source_str, const char* search_str) {
-  g_autofree gchar* normalized_source_str = g_utf8_normalize(source_str, -1, G_NORMALIZE_ALL);
-  g_autofree gchar* normalized_search_str = g_utf8_normalize(search_str, -1, G_NORMALIZE_ALL);
-  if (normalized_search_str && normalized_source_str) {
-    g_autofree gchar* case_normalized_source_str = g_utf8_casefold(normalized_source_str, -1);
-    g_autofree gchar* case_normalized_search_str = g_utf8_casefold(normalized_search_str, -1);
-
-    return strstr(case_normalized_source_str, case_normalized_search_str) != NULL;
-  }
-  return false;
-}
-
-static bool search_equal_iter(GtkTreeModel* model, gint column, const gchar* key, GtkTreeIter* iter) {
-  g_auto(GValue) value = G_VALUE_INIT;
-  gtk_tree_model_get_value(model, iter, column, &value);
-
-  g_auto(GValue) transformed = G_VALUE_INIT;
-  g_value_init(&transformed, G_TYPE_STRING);
-
-  const gboolean ret = g_value_transform(&value, &transformed);
-  if (!ret) {
-    return true;
-  }
-
-  const gchar* source_string = g_value_get_string(&transformed);
-  if (!source_string) {
-    return true;
-  }
-
-  return !find_substring(source_string, key);
-}
-
-gboolean search_equal_func_index(GtkTreeModel* model, gint column, const gchar* key, GtkTreeIter* iter,
-                                 gpointer search_data) {
-
-  GtkTreeView* tree_view              = GTK_TREE_VIEW(search_data);
-  g_autoptr(GtkTreePath) current_path = gtk_tree_model_get_path(model, iter);
-  if (!(search_equal_iter(model, column, key, iter))) {
-    return FALSE;
-  }
-  if (!(gtk_tree_model_iter_has_child(model, iter)) || gtk_tree_view_row_expanded(tree_view, current_path)) {
-    return TRUE;
-  }
-
-  gtk_tree_view_expand_row(tree_view, current_path, FALSE);
-
-  GtkTreeIter child_iter;
-  gtk_tree_model_iter_children(model, &child_iter, iter);
-
-  do {
-    if (!search_equal_func_index(model, column, key, &child_iter, tree_view)) {
-      g_autoptr(GtkTreePath) child_path = gtk_tree_model_get_path(model, &child_iter);
-      gtk_tree_view_scroll_to_cell(tree_view, child_path, NULL, TRUE, 0.5, 0.0);
-      return TRUE;
+/* walk the flat tree-list model expanding ancestors along the captured path;
+   return the resulting flat-model position of the deepest item */
+static guint resolve_path_position(GListModel* flat, const index_path_t* path) {
+  guint pos = 0;
+  for (size_t level = 0; level < path->depth; level++) {
+    ZathuraIndexElementObject* want = path->items[level];
+    guint n                         = g_list_model_get_n_items(flat);
+    for (guint i = 0; i < n; i++) {
+      g_autoptr(GtkTreeListRow) r = g_list_model_get_item(flat, i);
+      if (r == NULL) {
+        continue;
+      }
+      g_autoptr(ZathuraIndexElementObject) it = gtk_tree_list_row_get_item(r);
+      if (it == want) {
+        pos = i;
+        if (level + 1 < path->depth) {
+          gtk_tree_list_row_set_expanded(r, TRUE);
+        }
+        break;
+      }
     }
-  } while (gtk_tree_model_iter_next(model, &child_iter));
-  gtk_tree_view_collapse_row(tree_view, current_path);
-
-  return TRUE;
+  }
+  return pos;
 }
 
-static GtkTreeView* get_tree_view(zathura_t* zathura) {
-  g_autoptr(GList) index_children = gtk_container_get_children(GTK_CONTAINER(zathura->ui.index));
-  GtkTreeView* tree_view          = index_children->data;
-  return tree_view;
-}
-
-static gboolean tree_view_scroll_to_cell(void* data) {
-  zathura_t* zathura     = data;
-  GtkTreeView* tree_view = get_tree_view(zathura);
-  gtk_tree_view_scroll_to_cell(tree_view, zathura->global.current_index_path, NULL, TRUE, 0.5, 0.0);
+static gboolean scroll_index_to_cursor(void* data) {
+  zathura_t* zathura = data;
+  GtkListView* view  = get_list_view(zathura);
+  gtk_list_view_scroll_to(view, zathura->global.current_index_position, GTK_LIST_SCROLL_FOCUS | GTK_LIST_SCROLL_SELECT,
+                          NULL);
   return G_SOURCE_REMOVE;
 }
 
 void index_scroll_to_current_page(zathura_t* zathura) {
-  GtkTreeView* tree_view = get_tree_view(zathura);
-  GtkTreeModel* model    = gtk_tree_view_get_model(tree_view);
+  GtkListView* view            = get_list_view(zathura);
+  GtkSelectionModel* selection = gtk_list_view_get_model(view);
+  unsigned int current_page    = zathura_document_get_current_page_number(zathura_get_document(zathura));
 
-  search_data_t search_data;
-  gtk_tree_model_get_iter_first(model, &search_data.current_iter);
-  search_data.current_page = zathura_document_get_current_page_number(zathura_get_document(zathura));
-  gtk_tree_model_foreach(model, search_current_index, &search_data);
+  /* the selection wraps a GtkTreeListModel; its underlying model is the root GListStore */
+  GtkTreeListModel* tree_model = GTK_TREE_LIST_MODEL(gtk_single_selection_get_model(GTK_SINGLE_SELECTION(selection)));
+  GListModel* root             = gtk_tree_list_model_get_model(tree_model);
 
-  g_autoptr(GtkTreePath) current_path = gtk_tree_model_get_path(model, &search_data.current_iter);
-  if (zathura->global.current_index_path != NULL) {
-    gtk_tree_path_free(zathura->global.current_index_path);
-  }
-  zathura->global.current_index_path = gtk_tree_path_copy(current_path);
-  gtk_tree_view_expand_to_path(tree_view, current_path);
+  index_path_t current = {0};
+  index_path_t best    = {0};
+  find_deepest_path(root, current_page, &current, &best);
+  guint pos = resolve_path_position(G_LIST_MODEL(selection), &best);
 
-  g_idle_add(tree_view_scroll_to_cell, zathura);
-  gtk_tree_view_set_cursor(tree_view, current_path, NULL, FALSE);
+  g_free(current.items);
+  g_free(best.items);
+
+  zathura->global.current_index_position = pos;
+  g_idle_add(scroll_index_to_cursor, zathura);
 }
-
 static zathura_rectangle_t rotate_rectangle(zathura_rectangle_t rectangle, unsigned int degree, double height,
                                             double width) {
   zathura_rectangle_t tmp;
@@ -325,7 +354,7 @@ char* zathura_get_version_string(const zathura_plugin_manager_t* plugin_manager,
   return g_string_free_and_steal(string);
 }
 
-GdkAtom* get_selection(zathura_t* zathura) {
+GdkClipboard* get_selection(zathura_t* zathura) {
   g_return_val_if_fail(zathura != NULL, NULL);
 
   g_autofree char* value = NULL;
@@ -334,23 +363,17 @@ GdkAtom* get_selection(zathura_t* zathura) {
     return NULL;
   }
 
-  g_autofree GdkAtom* selection = g_try_malloc(sizeof(GdkAtom));
-  if (selection == NULL) {
-    return NULL;
-  }
-
+  GdkDisplay* display = gtk_widget_get_display(GTK_WIDGET(zathura->ui.session->gtk.window));
   if (g_strcmp0(value, "primary") == 0) {
-    *selection = GDK_SELECTION_PRIMARY;
+    return gdk_display_get_primary_clipboard(display);
   } else if (g_strcmp0(value, "clipboard") == 0) {
-    *selection = GDK_SELECTION_CLIPBOARD;
+    return gdk_display_get_clipboard(display);
   } else if (g_strcmp0(value, "false") == 0) {
     return NULL;
-  } else {
-    girara_error("Invalid value for the selection-clipboard setting");
-    return NULL;
   }
 
-  return g_steal_pointer(&selection);
+  girara_error("Invalid value for the selection-clipboard setting");
+  return NULL;
 }
 
 static char* write_first_page_column_list(unsigned int* first_page_columns, unsigned int size) {

--- a/zathura/utils.h
+++ b/zathura/utils.h
@@ -26,30 +26,27 @@ typedef struct page_offset_s {
 bool file_valid_extension(zathura_t* zathura, const char* path);
 
 /**
- * Generates the document index based upon the list retrieved from the document
- * object.
+ * build a tree of index elements from the document outline
  *
  * @param session The session
- * @param model The tree model
- * @param parent The tree iterator parent
- * @param tree The Tree iterator
+ * @param tree the document index tree
+ * @return root list model of ZathuraIndexElement objects
  */
-void document_index_build(girara_session_t* session, GtkTreeModel* model, GtkTreeIter* parent,
-                          girara_tree_node_t* tree);
+/* GObject wrapping zathura_index_element_t so it can live in a GListModel */
+#define ZATHURA_TYPE_INDEX_ELEMENT_OBJECT (zathura_index_element_object_get_type())
+G_DECLARE_FINAL_TYPE(ZathuraIndexElementObject, zathura_index_element_object, ZATHURA, INDEX_ELEMENT_OBJECT, GObject)
 
-/**
- * A custom search equal function for the index tree view, so that
- * when interactively searching, the string will be recursively compared
- * to all the children of visible entries
- *
- * @param model The tree model
- * @param column The column of the entry
- * @param key The keyword to be compared
- * @param iter The tree iterator
- * @param search_data User data pointer
- */
-gboolean search_equal_func_index(GtkTreeModel* model, gint column, const gchar* key, GtkTreeIter* iter,
-                                 gpointer search_data);
+struct _ZathuraIndexElementObject {
+  GObject parent_instance;
+  char* title;                      /* escaped markup for column 1 */
+  char* page_label;                 /* primary page string for column 2 */
+  char* page_alt;                   /* alt page string for column 3 */
+  zathura_index_element_t* element; /* link target */
+  GListStore* children;             /* NULL for leaves */
+};
+
+GListModel* document_index_build_model(girara_session_t* session, girara_tree_node_t* tree);
+
 /**
  * Scrolls the document index to the current page
  *
@@ -97,14 +94,13 @@ void document_draw_search_results(zathura_t* zathura, bool value);
 char* zathura_get_version_string(const zathura_plugin_manager_t* plugin_manager, bool markup);
 
 /**
- * Get a pointer to the GdkAtom of the current clipboard.
+ * Get a pointer to the GdkClipboard of the current clipboard.
  *
  * @param zathura The zathura instance
  *
- * @return A pointer to a GdkAtom object correspoinding to the current
- * clipboard, or NULL.
+ * @return the current GdkClipboard, or NULL
  */
-GdkAtom* get_selection(zathura_t* zathura);
+GdkClipboard* get_selection(zathura_t* zathura);
 
 /**
  * Returns the valid zoom value which needs to lie in the interval of zoom_min

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -18,9 +18,6 @@
 #include <girara/template.h>
 #include <glib/gstdio.h>
 #include <glib/gi18n.h>
-#ifdef GDK_WINDOWING_WAYLAND
-#include <gdk/gdkwayland.h>
-#endif
 #ifdef G_OS_UNIX
 #include <glib-unix.h>
 #include <gio/gunixinputstream.h>
@@ -149,16 +146,17 @@ void zathura_update_view_ppi(zathura_t* zathura) {
   }
 
   /* get view widget GdkMonitor */
-  GdkWindow* window = gtk_widget_get_window(zathura->ui.session->gtk.view); // NULL if not realized
-  if (window == NULL) {
+  GtkNative* native = gtk_widget_get_native(zathura->ui.session->gtk.view);
+  if (native == NULL) {
     return;
   }
+  GdkSurface* surface = gtk_native_get_surface(native);
   GdkDisplay* display = gtk_widget_get_display(zathura->ui.session->gtk.view);
-  if (display == NULL) {
+  if (surface == NULL || display == NULL) {
     return;
   }
 
-  GdkMonitor* monitor = gdk_display_get_monitor_at_window(display, window);
+  GdkMonitor* monitor = gdk_display_get_monitor_at_surface(display, surface);
   if (monitor == NULL) {
     return;
   }
@@ -180,20 +178,7 @@ void zathura_update_view_ppi(zathura_t* zathura) {
     ppi = monitor_geom.width * 25.4 / width_mm;
   }
 
-#ifdef GDK_WINDOWING_WAYLAND
-  /* work around apparent bug in GDK: on Wayland, monitor geometry doesn't
-   * return values in application pixels as documented, but in device pixels.
-   * */
-  if (GDK_IS_WAYLAND_DISPLAY(display)) {
-    /* not using the cached value for the scale factor here to avoid issues
-     * if this function is called before the cached value is updated */
-    const int device_factor = gtk_widget_get_scale_factor(zathura->ui.session->gtk.view);
-    girara_debug("on Wayland, correcting PPI for device scale factor = %d", device_factor);
-    if (device_factor != 0) {
-      ppi /= device_factor;
-    }
-  }
-#endif
+  /* gtk4 reports logical monitor pixels so ppi needs no device scale correction */
 
   zathura_document_t* document = zathura_get_document(zathura);
   const double current_ppi     = zathura_document_get_viewport_ppi(document);
@@ -204,10 +189,6 @@ void zathura_update_view_ppi(zathura_t* zathura) {
     zathura_document_widget_render_all(zathura->ui.document_widget);
     refresh_view(zathura);
   }
-}
-
-static void weak_ref_object_unref(void* data, GObject* UNUSED(object)) {
-  g_object_unref(data);
 }
 
 static bool init_ui(zathura_t* zathura) {
@@ -225,11 +206,11 @@ static bool init_ui(zathura_t* zathura) {
   zathura->ui.session->events.unknown_command = cb_unknown_command;
 
   /* gestures */
-  GtkGesture* zoom = gtk_gesture_zoom_new(GTK_WIDGET(zathura->ui.session->gtk.view));
+  GtkGesture* zoom = gtk_gesture_zoom_new();
   g_signal_connect(zoom, "scale-changed", G_CALLBACK(cb_gesture_zoom_scale_changed), zathura);
   g_signal_connect(zoom, "begin", G_CALLBACK(cb_gesture_zoom_begin), zathura);
   gtk_event_controller_set_propagation_phase(GTK_EVENT_CONTROLLER(zoom), GTK_PHASE_BUBBLE);
-  g_object_weak_ref(G_OBJECT(zathura->ui.session->gtk.view), weak_ref_object_unref, zoom);
+  gtk_widget_add_controller(GTK_WIDGET(zathura->ui.session->gtk.view), GTK_EVENT_CONTROLLER(zoom));
 
   /* zathura signals */
   zathura->signals.refresh_view = g_signal_new("refresh-view", GTK_TYPE_WIDGET, G_SIGNAL_RUN_LAST, 0, NULL, NULL,
@@ -240,17 +221,16 @@ static bool init_ui(zathura_t* zathura) {
   g_signal_connect(G_OBJECT(zathura->ui.session->gtk.view), "notify::scale-factor", G_CALLBACK(cb_scale_factor),
                    zathura);
 
-  g_signal_connect(G_OBJECT(zathura->ui.session->gtk.view), "screen-changed", G_CALLBACK(cb_widget_screen_changed),
-                   zathura);
-
-  g_signal_connect(G_OBJECT(zathura->ui.session->gtk.window), "configure-event", G_CALLBACK(cb_widget_configured),
-                   zathura);
-
-  /* initialize the screen-changed handler to 0 (i.e. invalid) */
-  zathura->signals.monitors_changed_handler = 0;
+  /* update the view PPI whenever the monitor configuration changes */
+  GdkDisplay* display = gtk_widget_get_display(zathura->ui.session->gtk.view);
+  if (display != NULL) {
+    GListModel* monitors = gdk_display_get_monitors(display);
+    zathura->signals.monitors_handler =
+        g_signal_connect(monitors, "items-changed", G_CALLBACK(cb_monitors_changed), zathura);
+  }
 
   /* page view */
-  zathura->ui.view = gtk_scrolled_window_new(NULL, NULL);
+  zathura->ui.view = gtk_scrolled_window_new();
 
   /* document widget */
   GtkWidget* widget = zathura_document_widget_new(zathura);
@@ -260,7 +240,7 @@ static bool init_ui(zathura_t* zathura) {
   }
 
   zathura->ui.document_widget = ZATHURA_DOCUMENT_WIDGET(widget);
-  gtk_container_add(GTK_CONTAINER(zathura->ui.view), widget);
+  gtk_scrolled_window_set_child(GTK_SCROLLED_WINDOW(zathura->ui.view), widget);
   girara_set_view(zathura->ui.session, zathura->ui.view);
 
   /* load scrollbar settings */
@@ -287,7 +267,7 @@ static bool init_ui(zathura_t* zathura) {
   g_signal_connect(G_OBJECT(vadjustment), "changed", G_CALLBACK(cb_view_vadjustment_changed), zathura);
 
   /* page view alignment */
-  gtk_widget_show(widget);
+  gtk_widget_set_visible(widget, TRUE);
 
   /* statusbar */
   zathura->ui.statusbar.file = girara_statusbar_item_add(zathura->ui.session, TRUE, TRUE, TRUE);
@@ -317,7 +297,8 @@ static bool init_ui(zathura_t* zathura) {
   girara_statusbar_item_set_text(zathura->ui.session, zathura->ui.statusbar.file, _("[No name]"));
 
   /* signals */
-  g_signal_connect(G_OBJECT(zathura->ui.session->gtk.window), "destroy", G_CALLBACK(cb_destroy), zathura);
+  zathura->signals.destroy_handler =
+      g_signal_connect(G_OBJECT(zathura->ui.session->gtk.window), "destroy", G_CALLBACK(cb_destroy), zathura);
 
   return true;
 }
@@ -493,6 +474,21 @@ void zathura_free(zathura_t* zathura) {
   }
 #endif
 
+  if (zathura->signals.monitors_handler > 0 && zathura->ui.session != NULL && zathura->ui.session->gtk.window != NULL) {
+    GdkDisplay* display = gtk_widget_get_display(zathura->ui.session->gtk.view);
+    if (display != NULL) {
+      g_signal_handler_disconnect(gdk_display_get_monitors(display), zathura->signals.monitors_handler);
+    }
+    zathura->signals.monitors_handler = 0;
+  }
+
+  /* on a quit that did not close the window first, disconnect cb_destroy so the app's later window disposal can't run
+   * it on freed zathura */
+  if (zathura->signals.destroy_handler > 0 && zathura->ui.session != NULL && zathura->ui.session->gtk.window != NULL) {
+    g_signal_handler_disconnect(zathura->ui.session->gtk.window, zathura->signals.destroy_handler);
+    zathura->signals.destroy_handler = 0;
+  }
+
   /* stop D-Bus */
   g_clear_object(&zathura->dbus);
 
@@ -533,12 +529,6 @@ void zathura_free(zathura_t* zathura) {
   zathura_jumplist_free(zathura);
 
   g_free(zathura);
-}
-
-void zathura_set_xid(zathura_t* zathura, Window xid) {
-  g_return_if_fail(zathura != NULL);
-
-  zathura->ui.session->gtk.embed = xid;
 }
 
 void zathura_set_config_dir(zathura_t* zathura, const char* dir) {
@@ -583,7 +573,7 @@ void zathura_set_argv(zathura_t* zathura, char** argv) {
   zathura->global.arguments = argv;
 }
 
-static bool setup_renderer(zathura_t* zathura, zathura_document_t* document) {
+static bool setup_renderer(zathura_t* zathura, zathura_document_t* UNUSED(document)) {
   /* page cache size */
   unsigned int cache_size = 0;
   girara_setting_get(zathura->ui.session, "page-cache-size", &cache_size);
@@ -616,18 +606,6 @@ static bool setup_renderer(zathura_t* zathura, zathura_document_t* document) {
   zathura_renderer_enable_recolor_adjust_lightness(renderer, recolor);
 
   zathura->sync.render_thread = renderer;
-
-  /* create render request to render window icon */
-  bool window_icon = false;
-  girara_setting_get(zathura->ui.session, "window-icon-document", &window_icon);
-  if (window_icon == true) {
-    girara_debug("starting render request for window icon");
-    ZathuraRenderRequest* request = zathura_render_request_new(renderer, zathura_document_get_page(document, 0));
-    g_signal_connect(request, "completed", G_CALLBACK(cb_window_update_icon), zathura);
-    zathura_render_request_set_render_plain(request, true);
-    zathura_render_request(request, 0);
-    zathura->window_icon_render_request = request;
-  }
 
   return true;
 }
@@ -867,7 +845,7 @@ bool document_open(zathura_t* zathura, const char* path, const char* uri, const 
       password_dialog_info->path    = g_strdup(path);
       password_dialog_info->uri     = g_strdup(uri);
       if (password_dialog_info->path != NULL) {
-        gdk_threads_add_idle(document_open_password_dialog, password_dialog_info);
+        g_idle_add(document_open_password_dialog, password_dialog_info);
         goto error_out;
       } else {
         g_free(password_dialog_info->uri);
@@ -1152,7 +1130,7 @@ bool document_open(zathura_t* zathura, const char* path, const char* uri, const 
     zathura_page_widget_set_size_request(ZATHURA_PAGE_WIDGET(widget), page_width, page_height);
 
     /* show widget */
-    gtk_widget_show(widget);
+    gtk_widget_set_visible(widget, TRUE);
   }
 
   /* Set page */
@@ -1171,9 +1149,7 @@ bool document_open(zathura_t* zathura, const char* path, const char* uri, const 
   zathura_show_signature_information(zathura, show_signature_information);
   update_visible_pages(zathura);
 
-  /* this needs to run at the end since it will refresh the view via zathura_view_update_ppi */
-  /* call screen-changed callback to connect monitors-changed signal on initial screen */
-  cb_widget_screen_changed(zathura->ui.session->gtk.view, NULL, zathura);
+  zathura_update_view_ppi(zathura);
 
   return true;
 
@@ -1234,7 +1210,7 @@ void document_open_idle(zathura_t* zathura, const char* path, const char* passwo
     document_info->search_string = g_strdup(search_string);
   }
 
-  gdk_threads_add_idle(document_info_open, document_info);
+  g_idle_add(document_info_open, document_info);
 }
 
 bool document_save(zathura_t* zathura, const char* path, bool overwrite) {
@@ -1341,14 +1317,8 @@ bool document_close(zathura_t* zathura, bool keep_monitor) {
     return false;
   }
 
-  /* reset window icon */
-  if (zathura->ui.session != NULL && zathura->window_icon_render_request != NULL) {
-    girara_set_window_icon(zathura->ui.session, "org.pwmt.zathura");
-  }
-
   /* stop rendering */
   zathura_renderer_stop(zathura->sync.render_thread);
-  g_clear_object(&zathura->window_icon_render_request);
 
   /* remove monitor */
   if (keep_monitor == false) {
@@ -1400,8 +1370,10 @@ bool document_close(zathura_t* zathura, bool keep_monitor) {
   }
 #endif
 
-  /* remove widgets */
-  zathura_document_widget_clear_pages(ZATHURA_DOCUMENT_WIDGET(zathura->ui.document_widget));
+  /* skip when the document widget is already gone (window being destroyed) */
+  if (zathura->ui.document_widget != NULL) {
+    zathura_document_widget_clear_pages(ZATHURA_DOCUMENT_WIDGET(zathura->ui.document_widget));
+  }
 
   if (!override_predecessor) {
     for (unsigned int i = 0; i < zathura_document_get_number_of_pages(document); i++) {
@@ -1421,19 +1393,26 @@ bool document_close(zathura_t* zathura, bool keep_monitor) {
     zathura->document             = NULL;
   }
 
+  /* the rest only refreshes the UI; skip it when the window is gone (being destroyed) */
+  if (zathura->ui.session == NULL || zathura->ui.session->gtk.window == NULL) {
+    return true;
+  }
+
   /* remove index */
   if (zathura->ui.index != NULL) {
-    g_object_ref_sink(zathura->ui.index);
+    GtkWidget* index_parent = gtk_widget_get_parent(zathura->ui.index);
+    if (GTK_IS_STACK(index_parent)) {
+      gtk_stack_remove(GTK_STACK(index_parent), zathura->ui.index);
+    } else {
+      g_object_ref_sink(zathura->ui.index);
+      g_object_unref(zathura->ui.index);
+    }
     zathura->ui.index = NULL;
   }
 
-  /* free current index path */
-  if (zathura->global.current_index_path != NULL) {
-    gtk_tree_path_free(zathura->global.current_index_path);
-    zathura->global.current_index_path = NULL;
-  }
+  zathura->global.current_index_position = 0;
 
-  gtk_widget_hide(GTK_WIDGET(zathura->ui.document_widget));
+  gtk_widget_set_visible(GTK_WIDGET(zathura->ui.document_widget), FALSE);
 
   statusbar_page_number_update(zathura);
 
@@ -1459,6 +1438,7 @@ bool page_set(zathura_t* zathura, unsigned int page_id) {
   }
 
   zathura_document_set_current_page_number(document, page_id);
+  zathura_document_widget_update_mode(ZATHURA_DOCUMENT_WIDGET(zathura->ui.document_widget));
 
   bool continuous_hist_save = false;
   girara_setting_get(zathura->ui.session, "continuous-hist-save", &continuous_hist_save);
@@ -1649,13 +1629,13 @@ error_ret:
 }
 
 #ifdef G_OS_UNIX
-static gboolean zathura_signal_sigterm(gpointer data) {
-  if (data != NULL) {
-    zathura_t* zathura = data;
-    cb_destroy(NULL, zathura);
+static gboolean zathura_signal_sigterm(gpointer UNUSED(data)) {
+  GApplication* app = g_application_get_default();
+  if (app != NULL) {
+    g_application_quit(app);
   }
 
-  return TRUE;
+  return G_SOURCE_CONTINUE;
 }
 #endif
 

--- a/zathura/zathura.h
+++ b/zathura/zathura.h
@@ -10,9 +10,6 @@
 #ifdef WITH_SYNCTEX
 #include <synctex/synctex_parser.h>
 #endif
-#ifdef GDK_WINDOWING_X11
-#include <gtk/gtkx.h>
-#endif
 #include "macros.h"
 #include "types.h"
 #include "jumplist.h"
@@ -150,7 +147,7 @@ struct zathura_s {
     GdkModifierType synctex_edit_modmask; /**< Modifier to trigger synctex edit */
     GdkModifierType highlighter_modmask;  /**< Modifier to draw with a highlighter */
     bool double_click_follow;             /**< Double/Single click to follow link */
-    GtkTreePath* current_index_path;      /**< Current index path */
+    guint current_index_position;         /**< current row in index */
     int current_search_result;
     int total_search_results;
   } global;
@@ -174,21 +171,20 @@ struct zathura_s {
 #ifdef G_OS_UNIX
     guint sigterm;
 #endif
-
-    gulong monitors_changed_handler; /**< Signal handler for monitors-changed */
+    gulong monitors_handler; /**< Signal handler for monitors items-changed */
+    gulong destroy_handler;  /**< Signal handler for the window's destroy signal */
   } signals;
 
   struct {
     gchar* file;
   } stdin_support;
 
-  zathura_document_t* document;                     /**< The current document */
-  zathura_document_t* predecessor_document;         /**< The document from before a reload */
-  GtkWidget** pages;                                /**< The page widgets */
-  GtkWidget** predecessor_pages;                    /**< The page widgets from before a reload */
-  zathura_database_t* database;                     /**< The database */
-  ZathuraDbus* dbus;                                /**< D-Bus service */
-  ZathuraRenderRequest* window_icon_render_request; /**< Render request for window icon */
+  zathura_document_t* document;             /**< The current document */
+  zathura_document_t* predecessor_document; /**< The document from before a reload */
+  GtkWidget** pages;                        /**< The page widgets */
+  GtkWidget** predecessor_pages;            /**< The page widgets from before a reload */
+  zathura_database_t* database;             /**< The database */
+  ZathuraDbus* dbus;                        /**< D-Bus service */
 
   /**
    * File monitor
@@ -273,15 +269,6 @@ bool zathura_init(zathura_t* zathura);
 void zathura_free(zathura_t* zathura);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(zathura_t, zathura_free)
-
-/**
- * Set parent window id. This does not have an effect if the underlying Gtk
- * backend is not X11.
- *
- * @param zathura The zathura session
- * @param xid The window id
- */
-void zathura_set_xid(zathura_t* zathura, Window xid);
 
 /**
  * Set the path to the configuration directory


### PR DESCRIPTION
This PR is to port zathura from gtk3 to gtk4. Fixes #871 #931 #905

the gtk4 code from libzathura-gtk that applies to zathura has been adopted where possible and most functions have been migrated according to the upstream documentation.

Changes compared to gtk3:

- GTK4 dropped XEmbed so the reparent option for embedding is gone
- GTK4 has no pixbuf window icons so window-icon-document is removed
- gtk-mac-integration is GTK3 only with no GTK4 port so there is no macOS menu