### PR TITLE
Feature/913 link opening confirmation optional

### DIFF
--- a/zathura/config.c
+++ b/zathura/config.c
@@ -607,6 +607,8 @@ void config_load_default(zathura_t* zathura) {
   girara_setting_add(gsession, "selection-keep-highlight",   &bool_value,  BOOLEAN, false, _("Keep selection highlighted after mouse release"), NULL, NULL);
   bool_value = false;
   girara_setting_add(gsession, "show-signature-information", &bool_value,  BOOLEAN, false, _("Disable additional information for signatures embedded in the document."), cb_show_signature_info, NULL);
+  bool_value = true;
+  girara_setting_add(gsession, "open-link-confirm", &bool_value, BOOLEAN, false, _("Enable prompt to confirm when opening links"), NULL, NULL);
 
   // clang-format on
   // apply some color settings that need their callbacks to run

--- a/zathura/links.c
+++ b/zathura/links.c
@@ -330,10 +330,17 @@ void zathura_link_evaluate(zathura_t* zathura, zathura_link_t* link) {
     girara_debug("Going to remote destination: %s", link->target.value);
     link_confirm(zathura, link->type, link->target.value);
     break;
-  case ZATHURA_LINK_URI:
+  case ZATHURA_LINK_URI: {
+    bool confirm = true;
+    girara_setting_get(zathura->ui.session, "open-link-confirm", &confirm);
     girara_debug("Opening URI: %s", link->target.value);
-    link_confirm(zathura, link->type, link->target.value);
+    if (confirm) {
+      link_confirm(zathura, link->type, link->target.value);
+    } else {
+      link_launch(zathura, link->target.value);
+    }
     break;
+  }
   case ZATHURA_LINK_LAUNCH:
     girara_debug("Launching link: %s", link->target.value);
     link_confirm(zathura, link->type, link->target.value);


### PR DESCRIPTION
## Link to original feature request 
[939](https://github.com/pwmt/zathura/issues/939#issuecomment-4595940489)

## Overview
Add a configuration option for skipping the confirmation dialog when opening external links in a document

`:set disable-link-confirm false` is default and keeps behavior the same as before which was providing a dialog that can be accepted by 'y' or 'enter' but anything else cancels opening the link in the browser

 `set disable-link-confirm true` removes the dialogue prompt and just opens the link in the browser

## Changes
- Added the setting via `girara_setting_add` in `config.c`
- Updated `cb_link_confirm` to allow entry to be NULL in `links.c`
- Updated `link_confirm_spawn` to pass entry in as NULL to `cb_link_confirm` in the event that `disable_link_confirm` is true 