### PR TITLE
replace sha256 with XXH3-128

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ The following dependencies are required:
 * `girara` (>= 2026.01.30)
 * `libmagic` from file(1): for mime-type detection
 * `json-glib`
-* `sqlite3` (>= 3.6.23): sqlite3 database backend
+* `sqlite3` (>= 3.25.0): sqlite3 database backend
+* `libxxhash`: file hashing
 
 The following dependencies are optional:
 * `libsynctex` from TeXLive (>= 2): SyncTeX support

--- a/meson.build
+++ b/meson.build
@@ -52,7 +52,7 @@ gtk4 = dependency('gtk4', version: '>=4.12', include_type: 'system')
 json_glib = dependency('json-glib-1.0')
 cairo = dependency('cairo')
 magic = dependency('libmagic')
-sqlite = dependency('sqlite3', version: '>=3.25.0')
+sqlite = dependency('sqlite3', version: '>=3.35.0')
 xxhash = dependency('libxxhash')
 
 build_dependencies = [libm, girara, glib, gio, gthread, gmodule, gtk4, cairo, magic, json_glib, xxhash]

--- a/meson.build
+++ b/meson.build
@@ -52,9 +52,10 @@ gtk4 = dependency('gtk4', version: '>=4.12', include_type: 'system')
 json_glib = dependency('json-glib-1.0')
 cairo = dependency('cairo')
 magic = dependency('libmagic')
-sqlite = dependency('sqlite3', version: '>=3.6.23')
+sqlite = dependency('sqlite3', version: '>=3.25.0')
+xxhash = dependency('libxxhash')
 
-build_dependencies = [libm, girara, glib, gio, gthread, gmodule, gtk4, cairo, magic, json_glib]
+build_dependencies = [libm, girara, glib, gio, gthread, gmodule, gtk4, cairo, magic, json_glib, xxhash]
 
 # defines
 defines = [

--- a/zathura/database-sqlite.c
+++ b/zathura/database-sqlite.c
@@ -12,7 +12,7 @@
 #include "utils.h"
 
 /* version of the database layout */
-#define DATABASE_VERSION 3
+#define DATABASE_VERSION 4
 
 static char* sqlite3_column_text_dup(sqlite3_stmt* stmt, int col) {
   return g_strdup((const char*)sqlite3_column_text(stmt, col));
@@ -193,7 +193,7 @@ static void sqlite_db_check_layout(sqlite3* session, const int database_version,
                                           "position_y FLOAT,"
                                           "time TIMESTAMP,"
                                           "page_right_to_left INTEGER,"
-                                          "sha256 BLOB,"
+                                          "hash BLOB,"
                                           "adjust_mode INTEGER"
                                           ");";
 
@@ -229,6 +229,9 @@ static void sqlite_db_check_layout(sqlite3* session, const int database_version,
 
   /* update fileinfo table (part 6) */
   static const char SQL_FILEINFO_ALTER6[] = "ALTER TABLE fileinfo ADD COLUMN sha256 BLOB;";
+
+  /* update fileinfo table (part 7): the column now holds a generic file hash */
+  static const char SQL_FILEINFO_ALTER7[] = "ALTER TABLE fileinfo RENAME COLUMN sha256 TO hash;";
 
   /* update bookmark table */
   static const char SQL_BOOKMARK_ALTER[] = "ALTER TABLE bookmarks ADD COLUMN hadj_ratio FLOAT;"
@@ -339,6 +342,12 @@ static void sqlite_db_check_layout(sqlite3* session, const int database_version,
   if (database_version < 2) {
     if (sqlite3_exec(session, SQL_FILEINFO_ALTER6, NULL, 0, NULL) != SQLITE_OK) {
       girara_warning("failed to update database table layout: sha256");
+      all_updates_ok = false;
+    }
+  }
+  if (database_version < 4) {
+    if (sqlite3_exec(session, SQL_FILEINFO_ALTER7, NULL, 0, NULL) != SQLITE_OK) {
+      girara_warning("failed to update database table layout: hash");
       all_updates_ok = false;
     }
   }
@@ -754,7 +763,7 @@ static bool sqlite_set_fileinfo(zathura_database_t* db, const char* file, const 
 
   static const char SQL_FILEINFO_SET[] =
       "REPLACE INTO fileinfo (file, page, offset, zoom, rotation, pages_per_row, first_page_column, position_x, "
-      "position_y, time, page_right_to_left, sha256) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, DATETIME('now'), ?, ?);";
+      "position_y, time, page_right_to_left, hash) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, DATETIME('now'), ?, ?);";
 
   sqlite3_stmt* stmt = prepare_statement(priv->session, SQL_FILEINFO_SET);
   if (stmt == NULL) {
@@ -771,7 +780,7 @@ static bool sqlite_set_fileinfo(zathura_database_t* db, const char* file, const 
       sqlite3_bind_double(stmt, 8, file_info->position_x) != SQLITE_OK ||
       sqlite3_bind_double(stmt, 9, file_info->position_y) != SQLITE_OK ||
       sqlite3_bind_int(stmt, 10, file_info->page_right_to_left) != SQLITE_OK ||
-      sqlite3_bind_blob(stmt, 11, hash_sha256, 32, SQLITE_STATIC) != SQLITE_OK) {
+      sqlite3_bind_blob(stmt, 11, hash_sha256, 16, SQLITE_STATIC) != SQLITE_OK) {
     sqlite3_finalize(stmt);
     girara_error("Failed to bind arguments.");
     return false;
@@ -794,7 +803,7 @@ static bool sqlite_get_fileinfo(zathura_database_t* db, const char* file, const 
 
   static const char SQL_FILEINFO_GET[] =
       "SELECT page, offset, zoom, rotation, pages_per_row, first_page_column, position_x, position_y, "
-      "page_right_to_left FROM fileinfo WHERE file = ? OR sha256 = ? ORDER BY time DESC LIMIT 1;";
+      "page_right_to_left FROM fileinfo WHERE file = ? OR hash = ? ORDER BY time DESC LIMIT 1;";
 
   sqlite3_stmt* stmt = prepare_statement(priv->session, SQL_FILEINFO_GET);
   if (stmt == NULL) {
@@ -802,7 +811,7 @@ static bool sqlite_get_fileinfo(zathura_database_t* db, const char* file, const 
   }
 
   if (sqlite3_bind_text(stmt, 1, file, -1, SQLITE_STATIC) != SQLITE_OK ||
-      sqlite3_bind_blob(stmt, 2, hash_sha256, 32, SQLITE_STATIC) != SQLITE_OK) {
+      sqlite3_bind_blob(stmt, 2, hash_sha256, 16, SQLITE_STATIC) != SQLITE_OK) {
     sqlite3_finalize(stmt);
     girara_error("Failed to bind arguments.");
     return false;

--- a/zathura/database-sqlite.c
+++ b/zathura/database-sqlite.c
@@ -230,8 +230,9 @@ static void sqlite_db_check_layout(sqlite3* session, const int database_version,
   /* update fileinfo table (part 6) */
   static const char SQL_FILEINFO_ALTER6[] = "ALTER TABLE fileinfo ADD COLUMN sha256 BLOB;";
 
-  /* update fileinfo table (part 7): the column now holds a generic file hash */
-  static const char SQL_FILEINFO_ALTER7[] = "ALTER TABLE fileinfo RENAME COLUMN sha256 TO hash;";
+  /* update fileinfo table (part 7) */
+  static const char SQL_FILEINFO_ALTER7[] = "ALTER TABLE fileinfo DROP COLUMN sha256;"
+                                            "ALTER TABLE fileinfo ADD COLUMN hash BLOB;";
 
   /* update bookmark table */
   static const char SQL_BOOKMARK_ALTER[] = "ALTER TABLE bookmarks ADD COLUMN hadj_ratio FLOAT;"

--- a/zathura/document.c
+++ b/zathura/document.c
@@ -8,6 +8,7 @@
 #include <glib.h>
 #include <gio/gio.h>
 #include <math.h>
+#include <xxhash.h>
 
 #include <girara/datastructures.h>
 #include <girara/log.h>
@@ -19,7 +20,7 @@
 #include "content-type.h"
 #include "internal.h"
 
-#define DIGEST_SIZE 32
+#define DIGEST_SIZE 16
 
 /**
  * Document
@@ -29,7 +30,8 @@ struct zathura_document_s {
   char* file_path;                         /**< File path of the document */
   char* uri;                               /**< URI of the document */
   char* basename;                          /**< Basename of the document */
-  uint8_t hash_sha256[DIGEST_SIZE];        /**< SHA256 hash of the document */
+  uint8_t hash[DIGEST_SIZE];               /**< XXH3 hash of the document */
+  bool hash_computed;                      /**< Whether the hash has been computed yet */
   const char* password;                    /**< Password of the document */
   unsigned int current_page_number;        /**< Current page number */
   unsigned int number_of_pages;            /**< Number of pages */
@@ -55,7 +57,7 @@ struct zathura_document_s {
   const zathura_plugin_t* plugin;
 };
 
-static bool hash_file_sha256(uint8_t* dst, const char* path) {
+static bool hash_file(uint8_t* dst, const char* path) {
   g_autoptr(GFile) f = g_file_new_for_path(path);
   if (f == NULL) {
     return false;
@@ -66,24 +68,28 @@ static bool hash_file_sha256(uint8_t* dst, const char* path) {
     return false;
   }
 
-  g_autoptr(GChecksum) checksum = g_checksum_new(G_CHECKSUM_SHA256);
-  if (checksum == NULL) {
+  XXH3_state_t* state = XXH3_createState();
+  if (state == NULL) {
     return false;
   }
+  XXH3_128bits_reset(state);
 
   uint8_t buf[MAX(BUFSIZ, 4096)];
   gssize read;
   while ((read = g_input_stream_read(G_INPUT_STREAM(stream), buf, sizeof(buf), NULL, NULL)) > 0) {
-    g_checksum_update(checksum, buf, read);
+    XXH3_128bits_update(state, buf, read);
   }
 
-  if (read < 0) {
-    return false;
+  /* read == 0 marks a clean EOF; a negative value is a read error */
+  const bool success = read == 0;
+  if (success == true) {
+    XXH128_canonical_t canonical;
+    XXH128_canonicalFromHash(&canonical, XXH3_128bits_digest(state));
+    memcpy(dst, canonical.digest, DIGEST_SIZE);
   }
 
-  gsize dst_size = DIGEST_SIZE;
-  g_checksum_get_digest(checksum, dst, &dst_size);
-  return true;
+  XXH3_freeState(state);
+  return success;
 }
 
 zathura_document_t* zathura_document_open(zathura_t* zathura, const char* path, const char* uri, const char* password,
@@ -134,9 +140,6 @@ zathura_document_t* zathura_document_open(zathura_t* zathura, const char* path, 
   } else {
     g_autoptr(GFile) gf = g_file_new_for_uri(document->uri);
     document->basename  = g_file_get_basename(gf);
-  }
-  if (hash_file_sha256(document->hash_sha256, document->file_path) == false) {
-    girara_warning("Failed to hash file '%s'; fileinfo lookup may be unreliable.", document->file_path);
   }
   document->password         = password;
   document->zoom             = 1.0;
@@ -228,7 +231,14 @@ const uint8_t* zathura_document_get_hash(zathura_document_t* document) {
     return NULL;
   }
 
-  return document->hash_sha256;
+  if (document->hash_computed == false) {
+    document->hash_computed = true;
+    if (hash_file(document->hash, document->file_path) == false) {
+      girara_warning("Failed to hash file '%s'; fileinfo lookup may be unreliable.", document->file_path);
+    }
+  }
+
+  return document->hash;
 }
 
 const char* zathura_document_get_uri(zathura_document_t* document) {

--- a/zathura/document.c
+++ b/zathura/document.c
@@ -22,6 +22,8 @@
 
 #define DIGEST_SIZE 16
 
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(XXH3_state_t, XXH3_freeState)
+
 /**
  * Document
  */
@@ -68,7 +70,7 @@ static bool hash_file(uint8_t* dst, const char* path) {
     return false;
   }
 
-  XXH3_state_t* state = XXH3_createState();
+  g_autoptr(XXH3_state_t) state = XXH3_createState();
   if (state == NULL) {
     return false;
   }
@@ -80,16 +82,15 @@ static bool hash_file(uint8_t* dst, const char* path) {
     XXH3_128bits_update(state, buf, read);
   }
 
-  /* read == 0 marks a clean EOF; a negative value is a read error */
-  const bool success = read == 0;
-  if (success == true) {
-    XXH128_canonical_t canonical;
-    XXH128_canonicalFromHash(&canonical, XXH3_128bits_digest(state));
-    memcpy(dst, canonical.digest, DIGEST_SIZE);
+  /* read is zero on a clean end of stream and negative on an error */
+  if (read != 0) {
+    return false;
   }
 
-  XXH3_freeState(state);
-  return success;
+  XXH128_canonical_t canonical;
+  XXH128_canonicalFromHash(&canonical, XXH3_128bits_digest(state));
+  memcpy(dst, canonical.digest, DIGEST_SIZE);
+  return true;
 }
 
 zathura_document_t* zathura_document_open(zathura_t* zathura, const char* path, const char* uri, const char* password,

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -1275,14 +1275,12 @@ zathura_fileinfo_t zathura_get_prefileinfo(zathura_t* zathura) {
 static void save_fileinfo_to_db(zathura_t* zathura) {
   zathura_document_t* document = zathura_get_document(zathura);
   const char* path             = zathura_document_get_path(document);
+  const uint8_t* file_hash     = zathura_document_get_hash(document);
 
   zathura_fileinfo_t file_info = zathura_get_fileinfo(zathura);
 
   /* save file info */
-  if (!ZATHURA_IS_NULLDATABASE(zathura->database)) {
-    const uint8_t* file_hash = zathura_document_get_hash(document);
-    zathura_db_set_fileinfo(zathura->database, path, file_hash, &file_info);
-  }
+  zathura_db_set_fileinfo(zathura->database, path, file_hash, &file_info);
   /* save jumplist */
   zathura_db_save_jumplist(zathura->database, path, zathura->jumplist.list);
   /* save quickmarks */

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -886,7 +886,7 @@ bool document_open(zathura_t* zathura, const char* path, const char* uri, const 
   bool known_file = file_info_p != NULL;
   if (file_info_p) {
     file_info = *file_info_p;
-  } else {
+  } else if (!ZATHURA_IS_NULLDATABASE(zathura->database)) {
     const uint8_t* file_hash = zathura_document_get_hash(document);
     known_file               = zathura_db_get_fileinfo(zathura->database, file_path, file_hash, &file_info);
   }
@@ -1275,12 +1275,14 @@ zathura_fileinfo_t zathura_get_prefileinfo(zathura_t* zathura) {
 static void save_fileinfo_to_db(zathura_t* zathura) {
   zathura_document_t* document = zathura_get_document(zathura);
   const char* path             = zathura_document_get_path(document);
-  const uint8_t* file_hash     = zathura_document_get_hash(document);
 
   zathura_fileinfo_t file_info = zathura_get_fileinfo(zathura);
 
   /* save file info */
-  zathura_db_set_fileinfo(zathura->database, path, file_hash, &file_info);
+  if (!ZATHURA_IS_NULLDATABASE(zathura->database)) {
+    const uint8_t* file_hash = zathura_document_get_hash(document);
+    zathura_db_set_fileinfo(zathura->database, path, file_hash, &file_info);
+  }
   /* save jumplist */
   zathura_db_save_jumplist(zathura->database, path, zathura->jumplist.list);
   /* save quickmarks */


### PR DESCRIPTION
Currently zathura uses sha256 for file identification in the database, which can take a significant amount of time to calculate for larger files before the parsing even starts. We dont need a cryptographic secure hash for this use case and the alternative XXH3-128 from libxxhash is much faster. This patch also skips the calculation entirely when the db is not used (eg. when running zathura-sandbox)
```

 file size            SHA-256        XXH3-128
 5 MB                 20 ms          0.5 ms
 50 MB                200 ms         8.5 ms
 500 MB               2000 ms        85 ms
```

Partly addresses #953 