### PR TITLE
Adding setting to start in single page mode

### DIFF
--- a/zathura/config.c
+++ b/zathura/config.c
@@ -609,6 +609,8 @@ void config_load_default(zathura_t* zathura) {
   girara_setting_add(gsession, "show-signature-information", &bool_value,  BOOLEAN, false, _("Disable additional information for signatures embedded in the document."), cb_show_signature_info, NULL);
   bool_value = true;
   girara_setting_add(gsession, "open-link-confirm",          &bool_value,  BOOLEAN, false, _("Enable prompt to confirm when opening links"), NULL, NULL);
+  bool_value = false;
+  girara_setting_add(gsession, "single-page-mode",           &bool_value,  BOOLEAN, false, _("Display a single page at a time"), NULL, NULL);
 
   // clang-format on
   // apply some color settings that need their callbacks to run

--- a/zathura/document-widget.c
+++ b/zathura/document-widget.c
@@ -312,6 +312,10 @@ void zathura_document_widget_update_mode(ZathuraDocumentWidget* document) {
     gtk_adjustment_set_value(priv->vadjustment, 0);
   } else {
     zathura_document_widget_compute_layout(document);
+    unsigned int pos_x = 0, pos_y = 0;
+    zathura_document_widget_get_cell_pos(document, page_id, &pos_x, &pos_y);
+    gtk_adjustment_set_value(priv->hadjustment, pos_x);
+    gtk_adjustment_set_value(priv->vadjustment, pos_y);
   }
 
   gtk_widget_queue_resize(GTK_WIDGET(document));

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -243,6 +243,17 @@ static bool init_ui(zathura_t* zathura) {
   gtk_scrolled_window_set_child(GTK_SCROLLED_WINDOW(zathura->ui.view), widget);
   girara_set_view(zathura->ui.session, zathura->ui.view);
 
+  /* single page mode: apply the startup preference once; layout-mode persists on the widget */
+  bool single_page_mode = false;
+  girara_setting_get(zathura->ui.session, "single-page-mode", &single_page_mode);
+
+  {
+    g_auto(GValue) layout_mode_value = G_VALUE_INIT;
+    g_value_init(&layout_mode_value, G_TYPE_INT);
+    g_value_set_int(&layout_mode_value, single_page_mode ? DOCUMENT_WIDGET_SINGLE : DOCUMENT_WIDGET_GRID);
+    g_object_set_property(G_OBJECT(zathura->ui.document_widget), "layout-mode", &layout_mode_value);
+  }
+
   /* load scrollbar settings */
   g_autofree char* view_options = NULL;
   girara_setting_get(zathura->ui.session, "guioptions", &view_options);


### PR DESCRIPTION
## link to original post 
[904](https://github.com/pwmt/zathura/issues/904#issuecomment-4750212994)

Adding `set single-page-mode true/false` to your config lets you toggle on single page mode on start up
