### PR TITLE
Improve quit action

### DIFF
--- a/zathura/callbacks.c
+++ b/zathura/callbacks.c
@@ -27,22 +27,9 @@
 #include "synctex.h"
 #include "dbus-interface.h"
 
-gboolean cb_destroy(GtkWidget* widget, zathura_t* zathura) {
-  /* genuine "destroy": the window and its child widgets are being finalized, so drop the borrowed pointers first */
-  if (widget != NULL && zathura != NULL && zathura->ui.session != NULL) {
-    zathura->ui.document_widget     = NULL;
-    zathura->ui.session->gtk.window = NULL;
-  }
-
-  if (zathura_has_document(zathura) == true) {
-    document_close(zathura, false);
-  }
-
-  GApplication* app = g_application_get_default();
-  if (app != NULL) {
-    g_application_quit(app);
-  }
-
+gboolean cb_destroy(GtkWidget* UNUSED(widget), zathura_t* zathura) {
+  /* on quit the kernel reclaims everything on exit, so persist state and go */
+  zathura_quit(zathura);
   return TRUE;
 }
 

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -1289,6 +1289,21 @@ static void save_fileinfo_to_db(zathura_t* zathura) {
   g_free(file_info.first_page_column_list);
 }
 
+void zathura_quit(zathura_t* zathura) {
+  if (zathura != NULL) {
+    /* persist the per document state that the kernel will not write for us */
+    if (zathura_has_document(zathura) == true) {
+      save_fileinfo_to_db(zathura);
+    }
+    /* delete the temporary file used for stdin input if there was one */
+    if (zathura->stdin_support.file != NULL) {
+      g_unlink(zathura->stdin_support.file);
+    }
+  }
+  /* the remaining teardown only returns memory the kernel reclaims on exit, so skip it */
+  exit(0);
+}
+
 bool document_predecessor_free(zathura_t* zathura) {
   if (zathura == NULL || (zathura->predecessor_document == NULL && zathura->predecessor_pages == NULL)) {
     return false;

--- a/zathura/zathura.h
+++ b/zathura/zathura.h
@@ -417,6 +417,14 @@ bool document_predecessor_free(zathura_t* zathura);
 bool document_close(zathura_t* zathura, bool keep_monitor);
 
 /**
+ * Persists the document state and exits the process immediately, skipping the
+ * in memory teardown that the kernel reclaims on exit anyway. Used on quit.
+ *
+ * @param zathura The zathura session
+ */
+void zathura_quit(zathura_t* zathura);
+
+/**
  * Opens the page with the given number
  *
  * @param zathura The zathura session


### PR DESCRIPTION
Currently, zathura handles the quit action the same as the close document action.
However, that results in a lot of memory cleanup that is only needed when a document is closed while keeping the process.
As a consequence, pressing quit on a large document, can cause a delay of about a second until zathura actually closes.
If I didnt overlook anything here, this seems easy to avoid by using a dedicated quit path that skips the cleanup since the process dies anyway. With this patch, zathura quits immediately as expected