### PR TITLE
implement lazy parsing

### DIFF
--- a/zathura/commands.c
+++ b/zathura/commands.c
@@ -436,9 +436,7 @@ bool cmd_search(girara_session_t* session, const char* input, girara_argument_t*
     GObject* obj_page_widget = G_OBJECT(page_widget);
     g_object_set(obj_page_widget, "draw-links", FALSE, NULL);
 
-    zathura_renderer_lock(zathura->sync.render_thread);
     girara_list_t* result = zathura_page_search_text(page, input, &error);
-    zathura_renderer_unlock(zathura->sync.render_thread);
 
     if (result == NULL || girara_list_size(result) == 0) {
       girara_list_free(result);

--- a/zathura/completion.c
+++ b/zathura/completion.c
@@ -20,6 +20,8 @@
 #include "utils.h"
 #include "page.h"
 #include "database.h"
+#include "render.h"
+#include "zathura.h"
 
 static int compare_case_insensitive(const void* data1, const void* data2) {
   const char* str1 = data1;

--- a/zathura/document.c
+++ b/zathura/document.c
@@ -55,6 +55,11 @@ struct zathura_document_s {
    * Used plugin
    */
   const zathura_plugin_t* plugin;
+
+  /**
+   * Serializes lazy page parsing
+   */
+  GMutex lock;
 };
 
 static bool hash_file(uint8_t* dst, const char* path) {
@@ -132,6 +137,8 @@ zathura_document_t* zathura_document_open(zathura_t* zathura, const char* path, 
     return NULL;
   }
 
+  g_mutex_init(&document->lock);
+
   document->file_path = g_steal_pointer(&real_path);
   document->uri       = g_strdup(uri);
   if (document->uri == NULL) {
@@ -162,7 +169,7 @@ zathura_document_t* zathura_document_open(zathura_t* zathura, const char* path, 
     return NULL;
   }
 
-  /* read all pages */
+  /* allocate the pages without parsing them */
   document->pages = g_try_malloc0_n(document->number_of_pages, sizeof(zathura_page_t*));
   if (document->pages == NULL) {
     zathura_check_set_error(error, ZATHURA_ERROR_OUT_OF_MEMORY);
@@ -205,6 +212,7 @@ zathura_error_t zathura_document_free(zathura_document_t* document) {
   g_free(document->file_path);
   g_free(document->uri);
   g_free(document->basename);
+  g_mutex_clear(&document->lock);
   g_free(document);
 
   return error;
@@ -571,4 +579,16 @@ const zathura_plugin_t* zathura_document_get_plugin(zathura_document_t* document
   g_return_val_if_fail(document != NULL, NULL);
 
   return document->plugin;
+}
+
+void zathura_document_lock(zathura_document_t* document) {
+  g_return_if_fail(document != NULL);
+
+  g_mutex_lock(&document->lock);
+}
+
+void zathura_document_unlock(zathura_document_t* document) {
+  g_return_if_fail(document != NULL);
+
+  g_mutex_unlock(&document->lock);
 }

--- a/zathura/internal.h
+++ b/zathura/internal.h
@@ -29,4 +29,14 @@ struct zathura_document_information_entry_s {
  */
 const zathura_plugin_t* zathura_document_get_plugin(zathura_document_t* document);
 
+/* Locks/unlocks the document while a page is parsed on first use. */
+void zathura_document_lock(zathura_document_t* document);
+void zathura_document_unlock(zathura_document_t* document);
+
+/* Parses the page with its plugin on first use, taking the document lock internally. */
+bool zathura_page_load(zathura_page_t* page, zathura_error_t* error);
+
+/* Returns true once the page has been parsed by its plugin. */
+bool zathura_page_is_loaded(zathura_page_t* page);
+
 #endif // INTERNAL_H

--- a/zathura/page-widget.c
+++ b/zathura/page-widget.c
@@ -13,6 +13,7 @@
 
 #include "links-internal.h"
 #include "page.h"
+#include "adjustment.h"
 #include "render.h"
 #include "utils.h"
 #include "shortcuts.h"
@@ -877,6 +878,33 @@ static void cb_update_surface(ZathuraRenderRequest* UNUSED(request), cairo_surfa
   ZathuraPageWidget* widget = data;
   g_return_if_fail(ZATHURA_IS_PAGE_WIDGET(widget));
   zathura_page_widget_update_surface(widget, surface, false);
+
+  if (surface == NULL) {
+    return;
+  }
+
+  /* the page is now parsed, correct its size if it differs from the placeholder */
+  ZathuraPageWidgetPrivate* priv = zathura_page_widget_get_instance_private(widget);
+  zathura_document_t* document   = zathura_page_get_document(priv->page);
+  unsigned int page_width = 0, page_height = 0;
+  page_calc_height_width(document, priv->page, &page_height, &page_width, true);
+
+  int cur_width = 0, cur_height = 0;
+  gtk_widget_get_size_request(GTK_WIDGET(widget), &cur_width, &cur_height);
+  if ((int)page_width != cur_width || (int)page_height != cur_height) {
+    /* resize directly to keep the fresh surface, it was already rendered at the corrected size */
+    gtk_widget_set_size_request(GTK_WIDGET(widget), (int)page_width, (int)page_height);
+    if (priv->drawing_area != NULL) {
+      gtk_widget_set_size_request(priv->drawing_area, (int)page_width, (int)page_height);
+      gtk_widget_queue_draw(priv->drawing_area);
+    }
+  }
+
+  /* refresh the statusbar so the label of a freshly parsed current page shows up */
+  if (zathura_page_label_is_number(priv->page) == false && zathura_page_get_label(priv->page, NULL) != NULL &&
+      zathura_page_get_index(priv->page) == zathura_document_get_current_page_number(document)) {
+    statusbar_page_number_update(priv->zathura);
+  }
 }
 
 static void cb_cache_added(ZathuraRenderRequest* UNUSED(request), void* data) {

--- a/zathura/page.c
+++ b/zathura/page.c
@@ -23,6 +23,7 @@ struct zathura_page_s {
   unsigned int index;           /**< Page number */
   bool visible;                 /**< Page is visible */
   bool label_is_number;         /**< Page label is the same as the page number */
+  gint loaded;                  /**< Page has been parsed by the plugin, atomic */
 };
 
 zathura_page_t* zathura_page_new(zathura_document_t* document, unsigned int index, zathura_error_t* error) {
@@ -43,33 +44,66 @@ zathura_page_t* zathura_page_new(zathura_document_t* document, unsigned int inde
   page->document        = document;
   page->label_is_number = false;
   page->zoom            = 1.0;
+  page->loaded          = 0;
+
+  /* the page is parsed later when it is used, not here */
+  return g_steal_pointer(&page);
+}
+
+bool zathura_page_load(zathura_page_t* page, zathura_error_t* error) {
+  if (page == NULL || page->document == NULL) {
+    zathura_check_set_error(error, ZATHURA_ERROR_INVALID_ARGUMENTS);
+    return false;
+  }
+
+  if (g_atomic_int_get(&page->loaded) == 1) {
+    return true;
+  }
+
+  zathura_document_lock(page->document);
+
+  /* another thread may have parsed the page while waiting for the lock */
+  if (g_atomic_int_get(&page->loaded) == 1) {
+    zathura_document_unlock(page->document);
+    return true;
+  }
 
   /* init plugin */
-  const zathura_plugin_t* plugin              = zathura_document_get_plugin(document);
+  const zathura_plugin_t* plugin              = zathura_document_get_plugin(page->document);
   const zathura_plugin_functions_t* functions = zathura_plugin_get_functions(plugin);
 
   zathura_error_t ret = functions->page_init(page);
   if (ret != ZATHURA_ERROR_OK) {
+    girara_error("Failed to initialize page %u: %d", page->index + 1, ret);
     zathura_check_set_error(error, ret);
-    return NULL;
+    zathura_document_unlock(page->document);
+    return false;
   }
 
-  /* get label if there is one */
+  /* get the label from the plugin */
   if (functions->page_get_label != NULL) {
     ret = functions->page_get_label(page, page->data, &page->label);
     if (ret != ZATHURA_ERROR_OK) {
+      girara_info("Failed to get label of page %u: %d", page->index + 1, ret);
       zathura_check_set_error(error, ret);
-      return NULL;
+      zathura_document_unlock(page->document);
+      return false;
     }
 
     if (page->label != NULL) {
       char page_number_string[G_ASCII_DTOSTR_BUF_SIZE];
-      g_ascii_dtostr(page_number_string, G_ASCII_DTOSTR_BUF_SIZE, index + 1);
+      g_ascii_dtostr(page_number_string, G_ASCII_DTOSTR_BUF_SIZE, page->index + 1);
       page->label_is_number = g_strcmp0(page->label, page_number_string) == 0;
     }
   }
 
-  return g_steal_pointer(&page);
+  g_atomic_int_set(&page->loaded, 1);
+  zathura_document_unlock(page->document);
+  return true;
+}
+
+bool zathura_page_is_loaded(zathura_page_t* page) {
+  return page != NULL && g_atomic_int_get(&page->loaded) == 1;
 }
 
 zathura_error_t zathura_page_free(zathura_page_t* page) {
@@ -85,7 +119,11 @@ zathura_error_t zathura_page_free(zathura_page_t* page) {
   const zathura_plugin_t* plugin              = zathura_document_get_plugin(page->document);
   const zathura_plugin_functions_t* functions = zathura_plugin_get_functions(plugin);
 
-  zathura_error_t error = functions->page_clear(page, page->data);
+  /* the plugin only has data to clear when the page has been parsed */
+  zathura_error_t error = ZATHURA_ERROR_OK;
+  if (g_atomic_int_get(&page->loaded) == 1) {
+    error = functions->page_clear(page, page->data);
+  }
 
   g_free(page->label);
   g_free(page);
@@ -114,6 +152,8 @@ double zathura_page_get_width(zathura_page_t* page) {
     return -1;
   }
 
+  zathura_page_load(page, NULL);
+
   return page->width;
 }
 
@@ -134,6 +174,8 @@ double zathura_page_get_height(zathura_page_t* page) {
   if (page == NULL) {
     return -1;
   }
+
+  zathura_page_load(page, NULL);
 
   return page->height;
 }
@@ -212,6 +254,10 @@ girara_list_t* zathura_page_search_text(zathura_page_t* page, const char* text, 
     return NULL;
   }
 
+  if (zathura_page_load(page, error) == false) {
+    return NULL;
+  }
+
   return functions->page_search_text(page, page->data, text, error);
 }
 
@@ -225,6 +271,10 @@ girara_list_t* zathura_page_links_get(zathura_page_t* page, zathura_error_t* err
   const zathura_plugin_functions_t* functions = zathura_plugin_get_functions(plugin);
   if (functions->page_links_get == NULL) {
     zathura_check_set_error(error, ZATHURA_ERROR_NOT_IMPLEMENTED);
+    return NULL;
+  }
+
+  if (zathura_page_load(page, error) == false) {
     return NULL;
   }
 
@@ -268,6 +318,10 @@ girara_list_t* zathura_page_images_get(zathura_page_t* page, zathura_error_t* er
     return NULL;
   }
 
+  if (zathura_page_load(page, error) == false) {
+    return NULL;
+  }
+
   return functions->page_images_get(page, page->data, error);
 }
 
@@ -300,6 +354,10 @@ char* zathura_page_get_text(zathura_page_t* page, zathura_rectangle_t rectangle,
     return NULL;
   }
 
+  if (zathura_page_load(page, error) == false) {
+    return NULL;
+  }
+
   return functions->page_get_text(page, page->data, rectangle, error);
 }
 
@@ -316,12 +374,21 @@ girara_list_t* zathura_page_get_selection(zathura_page_t* page, zathura_rectangl
     return NULL;
   }
 
+  if (zathura_page_load(page, error) == false) {
+    return NULL;
+  }
+
   return functions->page_get_selection(page, page->data, rectangle, error);
 }
 
 zathura_error_t zathura_page_render(zathura_page_t* page, cairo_t* cairo, bool printing) {
   if (page == NULL || page->document == NULL || cairo == NULL) {
     return ZATHURA_ERROR_INVALID_ARGUMENTS;
+  }
+
+  zathura_error_t error = ZATHURA_ERROR_OK;
+  if (zathura_page_load(page, &error) == false) {
+    return error;
   }
 
   const zathura_plugin_t* plugin              = zathura_document_get_plugin(page->document);
@@ -333,6 +400,10 @@ zathura_error_t zathura_page_render(zathura_page_t* page, cairo_t* cairo, bool p
 const char* zathura_page_get_label(zathura_page_t* page, zathura_error_t* error) {
   if (page == NULL || page->document == NULL) {
     zathura_check_set_error(error, ZATHURA_ERROR_INVALID_ARGUMENTS);
+    return NULL;
+  }
+
+  if (zathura_page_load(page, error) == false) {
     return NULL;
   }
 
@@ -360,7 +431,11 @@ girara_list_t* zathura_page_get_signatures(zathura_page_t* page, zathura_error_t
     return NULL;
   }
 
-  zathura_error_t e            = ZATHURA_ERROR_OK;
+  zathura_error_t e = ZATHURA_ERROR_OK;
+  if (zathura_page_load(page, error) == false) {
+    return NULL;
+  }
+
   g_autoptr(girara_list_t) ret = functions->page_get_signatures(page, page->data, &e);
   if (e != ZATHURA_ERROR_OK) {
     zathura_check_set_error(error, e);

--- a/zathura/print.c
+++ b/zathura/print.c
@@ -10,6 +10,7 @@
 #include "document.h"
 #include "render.h"
 #include "page.h"
+#include "internal.h"
 
 static void cb_print_end(GtkPrintOperation* UNUSED(print_operation), GtkPrintContext* UNUSED(context),
                          zathura_t* zathura) {
@@ -120,8 +121,12 @@ static void cb_print_request_page_setup(GtkPrintOperation* UNUSED(print_operatio
   }
 
   zathura_page_t* page = zathura_document_get_page(zathura_get_document(zathura), page_number);
-  double width         = zathura_page_get_width(page);
-  double height        = zathura_page_get_height(page);
+  if (page == NULL) {
+    return;
+  }
+
+  double width  = zathura_page_get_width(page);
+  double height = zathura_page_get_height(page);
 
   if (width > height) {
     gtk_page_setup_set_orientation(setup, GTK_PAGE_ORIENTATION_LANDSCAPE);

--- a/zathura/render.c
+++ b/zathura/render.c
@@ -15,6 +15,7 @@
 #include "page.h"
 #include "page-widget.h"
 #include "utils.h"
+#include "internal.h"
 
 /* private data for ZathuraRenderer */
 typedef struct private_s {
@@ -823,6 +824,11 @@ static bool render(render_job_t* job, ZathuraRenderRequest* request, ZathuraRend
   ZathuraRenderRequestPrivate* request_priv = zathura_render_request_get_instance_private(request);
   zathura_page_t* page                      = request_priv->page;
 
+  /* parse the page on first render */
+  if (zathura_renderer_load_page(renderer, page) == false) {
+    return false;
+  }
+
   /* create cairo surface */
   unsigned int page_width  = 0;
   unsigned int page_height = 0;
@@ -893,6 +899,13 @@ static bool render(render_job_t* job, ZathuraRenderRequest* request, ZathuraRend
   return true;
 }
 
+bool zathura_renderer_load_page(ZathuraRenderer* renderer, zathura_page_t* page) {
+  g_return_val_if_fail(ZATHURA_IS_RENDERER(renderer) == TRUE, false);
+
+  /* zathura_page_load takes the document lock internally */
+  return zathura_page_load(page, NULL);
+}
+
 /* render a page synchronously and return its surface */
 cairo_surface_t* zathura_renderer_render_page(ZathuraRenderer* renderer, zathura_page_t* page) {
   g_return_val_if_fail(ZATHURA_IS_RENDERER(renderer), NULL);
@@ -900,6 +913,11 @@ cairo_surface_t* zathura_renderer_render_page(ZathuraRenderer* renderer, zathura
 
   ZathuraRendererPrivate* priv = zathura_renderer_get_instance_private(renderer);
   zathura_document_t* document = zathura_page_get_document(page);
+
+  /* parse the page on first render */
+  if (zathura_renderer_load_page(renderer, page) == false) {
+    return NULL;
+  }
 
   unsigned int page_width = 0, page_height = 0;
   const double real_scale = page_calc_height_width(document, page, &page_height, &page_width, false);

--- a/zathura/render.h
+++ b/zathura/render.h
@@ -42,6 +42,9 @@ ZathuraRenderer* zathura_renderer_new(size_t cache_size);
  * The caller owns the returned surface and must destroy it. */
 cairo_surface_t* zathura_renderer_render_page(ZathuraRenderer* renderer, zathura_page_t* page);
 
+/* Parses the page with its plugin if needed, taking the render lock internally. */
+bool zathura_renderer_load_page(ZathuraRenderer* renderer, zathura_page_t* page);
+
 /**
  * Return whether recoloring is enabled.
  * @param renderer a renderer object

--- a/zathura/utils.c
+++ b/zathura/utils.c
@@ -22,6 +22,7 @@
 #include "document.h"
 #include "document-widget.h"
 #include "page.h"
+#include "render.h"
 #include "plugin.h"
 #include "content-type.h"
 #include "index-element-object.h"

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -44,6 +44,7 @@
 #include "resources.h"
 #include "synctex.h"
 #include "content-type.h"
+#include "internal.h"
 
 typedef struct zathura_document_info_s {
   zathura_t* zathura;
@@ -940,6 +941,25 @@ bool document_open(zathura_t* zathura, const char* path, const char* uri, const 
   if (always_first_page == true) {
     girara_debug("setting current page: 0 (always open first page)");
     zathura_document_set_current_page_number(document, 0);
+  }
+
+  /* parse the displayed page and size the others from it until they are parsed */
+  const unsigned int current_page_number = zathura_document_get_current_page_number(document);
+  zathura_page_t* current_page           = zathura_document_get_page(document, current_page_number);
+  /* no render lock is needed here, the render thread does not exist yet */
+  if (current_page == NULL || zathura_page_load(current_page, NULL) == false) {
+    girara_notify(zathura->ui.session, GIRARA_ERROR, _("Failed to parse the displayed page of the document"));
+    goto error_free;
+  }
+
+  const double width  = zathura_page_get_width(current_page);
+  const double height = zathura_page_get_height(current_page);
+  for (unsigned int page_id = 0; page_id < number_of_pages; page_id++) {
+    zathura_page_t* page = zathura_document_get_page(document, page_id);
+    if (page != NULL && page != current_page) {
+      zathura_page_set_width(page, width);
+      zathura_page_set_height(page, height);
+    }
   }
 
   /* apply open adjustment */


### PR DESCRIPTION
Instead of parsing all pages before rendering the first page, this now parses only the displayed pages and everything else on demand. parsing is relatively fast but it adds a delay if 15k pages are all parsed before the document is shown. The lazy parsing seems to be fine for the subsequent pages as I could not find any relevant performance impact. In theory we could make the other pages preload the parsing but that would add complexity for (as far as I see) nothing measurable.

There is one relevant side effect:
Previously the layout was build based on the size of all pages in the document, which isn't possible with lazy parsing. While this isn't relevant for most files, it changes the behavior for files with pages of different layout/size and automatically changes the layout once a page with a different layout from the first page(s) is parsed and rendered.

Partly addresses #953 

