### PR TITLE
Create page widgets in the background

### DIFF
--- a/zathura/callbacks.c
+++ b/zathura/callbacks.c
@@ -75,8 +75,17 @@ void update_visible_pages(zathura_t* zathura) {
   const unsigned int pages_per_row   = zathura_document_widget_get_pages_per_row(zathura->ui.document_widget);
 
   for (unsigned int page_id = 0; page_id < number_of_pages; page_id++) {
-    zathura_page_t* page                   = zathura_document_get_page(document, page_id);
-    GtkWidget* page_widget                 = zathura_page_get_widget(zathura, page);
+    zathura_page_t* page = zathura_document_get_page(document, page_id);
+
+    /* create the widget for a page scrolled into view during the background fill */
+    if (page_is_visible(zathura, page_id) == true) {
+      create_page_widget(zathura, page_id);
+    }
+
+    GtkWidget* page_widget = zathura_page_get_widget(zathura, page);
+    if (page_widget == NULL) {
+      continue;
+    }
     ZathuraPageWidget* zathura_page_widget = ZATHURA_PAGE_WIDGET(page_widget);
 
     if (page_is_visible(zathura, page_id) == true) {
@@ -90,12 +99,16 @@ void update_visible_pages(zathura_t* zathura) {
       // consider pages_per_row pages before and after, with the more recents ones close to the page itself
       for (unsigned int i = pages_per_row; i; --i) {
         if (page_id >= i) {
-          zathura_page_widget_update_view_time(
-              ZATHURA_PAGE_WIDGET(zathura_page_get_widget_by_number(zathura, page_id - i)));
+          GtkWidget* prev = zathura_page_get_widget_by_number(zathura, page_id - i);
+          if (prev != NULL) {
+            zathura_page_widget_update_view_time(ZATHURA_PAGE_WIDGET(prev));
+          }
         }
         if (page_id + i < number_of_pages) {
-          zathura_page_widget_update_view_time(
-              ZATHURA_PAGE_WIDGET(zathura_page_get_widget_by_number(zathura, page_id + i)));
+          GtkWidget* next = zathura_page_get_widget_by_number(zathura, page_id + i);
+          if (next != NULL) {
+            zathura_page_widget_update_view_time(ZATHURA_PAGE_WIDGET(next));
+          }
         }
       }
 
@@ -309,6 +322,11 @@ void cb_scale_factor(GObject* object, GParamSpec* UNUSED(pspec), gpointer data) 
     zathura_document_set_device_factors(document, new_factor, new_factor);
     girara_debug("New device scale factor: %d", new_factor);
     zathura_update_view_ppi(zathura);
+    /* the viewport is not yet resized for the new scale, the size allocation that follows renders it */
+    if (zathura->sync.initial_render_held == true) {
+      zathura->sync.scale_settled = true;
+      return;
+    }
     zathura_document_widget_render_all(zathura->ui.document_widget);
   }
 }
@@ -793,6 +811,9 @@ void cb_hide_links(GtkWidget* widget, gpointer data) {
     }
 
     GtkWidget* page_widget = zathura_page_get_widget(zathura, page);
+    if (page_widget == NULL) {
+      continue;
+    }
     g_object_set(G_OBJECT(page_widget), "draw-links", FALSE, NULL);
   }
 }

--- a/zathura/commands.c
+++ b/zathura/commands.c
@@ -409,6 +409,14 @@ bool cmd_search(girara_session_t* session, const char* input, girara_argument_t*
     return false;
   }
 
+  /* the search needs every page widget so wait until the background preload is done */
+  if (zathura->sync.widgets_loaded == false) {
+    g_free(zathura->sync.pending_search_input);
+    zathura->sync.pending_search_input     = g_strdup(input);
+    zathura->sync.pending_search_direction = argument->n;
+    return true;
+  }
+
   zathura_error_t error = ZATHURA_ERROR_OK;
 
   /* set search direction */

--- a/zathura/document-widget.c
+++ b/zathura/document-widget.c
@@ -366,6 +366,11 @@ static void zathura_document_widget_size_allocate(GtkWidget* widget, int width, 
       zathura_document_set_viewport_height(z_document, height);
       zathura_document_set_viewport_width(z_document, width);
       adjust_view(priv->zathura);
+      /* the scale settled and the zoom is now fit so release the held render in this same frame */
+      if (priv->zathura->sync.initial_render_held == true && priv->zathura->sync.scale_settled == true) {
+        priv->zathura->sync.initial_render_held = false;
+        render_focused_page_now(priv->zathura);
+      }
     }
     update_visible_pages(priv->zathura);
   }
@@ -394,6 +399,9 @@ static void zathura_document_widget_size_allocate(GtkWidget* widget, int width, 
       size_allocate_single(document, width, height, baseline);
       return;
     }
+
+    /* align tall documents to the top so the first page stays visible while the grid fills */
+    gtk_widget_set_valign(priv->grid, (int)doc_h > height ? GTK_ALIGN_START : GTK_ALIGN_CENTER);
 
     const int x                    = -(int)gtk_adjustment_get_value(priv->hadjustment);
     const int y                    = -(int)gtk_adjustment_get_value(priv->vadjustment);
@@ -505,6 +513,29 @@ void zathura_document_widget_refresh_layout(ZathuraDocumentWidget* document) {
 
   /* the cached visibility flags are stale after pages move */
   update_visible_pages(priv->zathura);
+}
+
+void zathura_document_widget_attach_page(ZathuraDocumentWidget* document, unsigned int page_index) {
+  g_return_if_fail(document != NULL);
+
+  ZathuraDocumentWidgetPrivate* priv = zathura_document_widget_get_instance_private(document);
+  if (priv->grid == NULL || priv->ncol == 0) {
+    return;
+  }
+
+  zathura_page_t* page   = zathura_document_get_page(zathura_get_document(priv->zathura), page_index);
+  GtkWidget* page_widget = zathura_page_get_widget(priv->zathura, page);
+  if (page_widget == NULL || gtk_widget_get_parent(page_widget) == priv->grid) {
+    return;
+  }
+
+  unsigned int row = 0;
+  unsigned int col = 0;
+  zathura_document_widget_get_page_position(document, page_index, &row, &col);
+  const unsigned int x  = priv->pages_right_to_left ? priv->ncol - 1 - col : col;
+  const GtkAlign halign = priv->ncol == 1 ? GTK_ALIGN_CENTER : (x == 0 ? GTK_ALIGN_END : GTK_ALIGN_START);
+  gtk_widget_set_halign(page_widget, halign);
+  gtk_grid_attach(GTK_GRID(priv->grid), page_widget, (int)x, (int)row, 1, 1);
 }
 
 void zathura_document_widget_compute_layout(ZathuraDocumentWidget* document) {
@@ -635,7 +666,10 @@ void zathura_document_widget_clear_pages(ZathuraDocumentWidget* document) {
     zathura_page_t* page   = zathura_document_get_page(z_document, i);
     GtkWidget* page_widget = zathura_page_get_widget(priv->zathura, page);
 
-    gtk_widget_unparent(page_widget);
+    /* the widget exists only if the background fill already created it */
+    if (page_widget != NULL) {
+      gtk_widget_unparent(page_widget);
+    }
   }
 }
 
@@ -650,7 +684,10 @@ void zathura_document_widget_clear_thumbnails(ZathuraDocumentWidget* document) {
     zathura_page_t* page   = zathura_document_get_page(z_document, i);
     GtkWidget* page_widget = zathura_page_get_widget(priv->zathura, page);
 
-    zathura_page_widget_clear_thumbnail(ZATHURA_PAGE_WIDGET(page_widget));
+    /* the widget exists only if the background fill already created it */
+    if (page_widget != NULL) {
+      zathura_page_widget_clear_thumbnail(ZATHURA_PAGE_WIDGET(page_widget));
+    }
   }
 }
 

--- a/zathura/document-widget.h
+++ b/zathura/document-widget.h
@@ -50,6 +50,9 @@ GtkWidget* zathura_document_widget_new(zathura_t* zathura);
  */
 void zathura_document_widget_refresh_layout(ZathuraDocumentWidget* document);
 
+/* attach a single page widget at its computed grid position without rearranging the grid */
+void zathura_document_widget_attach_page(ZathuraDocumentWidget* document, unsigned int page_index);
+
 void zathura_document_widget_update_mode(ZathuraDocumentWidget* document);
 
 /**

--- a/zathura/page-widget.c
+++ b/zathura/page-widget.c
@@ -516,7 +516,8 @@ static void cb_page_draw(GtkDrawingArea* GIRARA_UNUSED(area), cairo_t* cairo, in
   if (zathura->predecessor_document != NULL && zathura->predecessor_pages != NULL && !surface_exists) {
     unsigned int page_index = zathura_page_get_index(priv->page);
 
-    if (page_index < zathura_document_get_number_of_pages(priv->zathura->predecessor_document)) {
+    if (page_index < zathura_document_get_number_of_pages(priv->zathura->predecessor_document) &&
+        priv->zathura->predecessor_pages[page_index] != NULL) {
       /* render real page */
       if (page_widget_on_screen(widget) == true) {
         zathura_render_request(priv->render_request, g_get_real_time());
@@ -580,7 +581,7 @@ static void cb_page_draw(GtkDrawingArea* GIRARA_UNUSED(area), cairo_t* cairo, in
       /* All but the last jobs requested here are aborted during zooming.
        * Processing and aborting smaller jobs first improves responsiveness. */
       const gint64 penalty = (gint64)pwidth * (gint64)pheight;
-      if (page_widget_on_screen(widget) == true) {
+      if (page_widget_on_screen(widget) == true && priv->zathura->sync.initial_render_held == false) {
         zathura_render_request(priv->render_request, g_get_real_time() + penalty);
       }
       return;
@@ -717,7 +718,7 @@ static void cb_page_draw(GtkDrawingArea* GIRARA_UNUSED(area), cairo_t* cairo, in
   } else {
     /* No cached surface yet, render the on-screen page synchronously. All other rendering is asynchronous
      * This makes the rendering of the first page much faster and avoids the "Loading..." message as well */
-    if (page_widget_on_screen(widget) == true) {
+    if (page_widget_on_screen(widget) == true && priv->zathura->sync.initial_render_held == false) {
       cairo_surface_t* rendered = zathura_renderer_render_page(zathura->sync.render_thread, priv->page);
       if (rendered != NULL) {
         zathura_page_widget_update_surface(page, rendered, false);
@@ -760,7 +761,7 @@ static void cb_page_draw(GtkDrawingArea* GIRARA_UNUSED(area), cairo_t* cairo, in
     }
 
     /* request a render for every page that intersects the view */
-    if (page_widget_on_screen(widget) == true) {
+    if (page_widget_on_screen(widget) == true && priv->zathura->sync.initial_render_held == false) {
       zathura_render_request(priv->render_request, g_get_real_time());
     }
   }
@@ -995,6 +996,8 @@ static void rotate_point(zathura_t* zathura, unsigned int page, double orig_x, d
 }
 
 void zathura_page_widget_clear_selection(ZathuraPageWidget* widget) {
+  g_return_if_fail(widget != NULL);
+
   ZathuraPageWidgetPrivate* priv = zathura_page_widget_get_instance_private(widget);
   if (priv->selection.list != NULL) {
     girara_list_free(priv->selection.list);
@@ -1036,6 +1039,10 @@ static void cb_zathura_page_widget_button_press_event(GtkGestureClick* gesture, 
         if (document != NULL) {
           unsigned int number_of_pages = zathura_document_get_number_of_pages(document);
           for (unsigned int i = 0; i < number_of_pages; i++) {
+            /* the widget exists only if the background fill already created it */
+            if (priv->zathura->pages[i] == NULL) {
+              continue;
+            }
             ZathuraPageWidget* other_page        = ZATHURA_PAGE_WIDGET(priv->zathura->pages[i]);
             ZathuraPageWidgetPrivate* other_priv = zathura_page_widget_get_instance_private(other_page);
 
@@ -1367,7 +1374,8 @@ void zathura_page_widget_update_view_time(ZathuraPageWidget* widget) {
   if (zathura_page_get_visibility(priv->page) == true) {
     zathura_render_request_update_view_time(priv->render_request);
   }
-  if (priv->surface == NULL) {
+  /* do not kick the initial render while it is held */
+  if (priv->surface == NULL && priv->zathura->sync.initial_render_held == false) {
     zathura_render_request(priv->render_request, g_get_real_time());
   }
 }

--- a/zathura/shortcuts.c
+++ b/zathura/shortcuts.c
@@ -43,7 +43,11 @@ static bool draw_links(zathura_t* zathura) {
       continue;
     }
 
-    GtkWidget* page_widget   = zathura_page_get_widget(zathura, page);
+    GtkWidget* page_widget = zathura_page_get_widget(zathura, page);
+    /* the widget exists only if the background fill already created it */
+    if (page_widget == NULL) {
+      continue;
+    }
     GObject* obj_page_widget = G_OBJECT(page_widget);
     g_object_set(obj_page_widget, "draw-search-results", FALSE, NULL);
     if (zathura_page_get_visibility(page) == true) {
@@ -103,7 +107,11 @@ bool sc_abort(girara_session_t* session, girara_argument_t* UNUSED(argument), gi
         continue;
       }
 
-      GtkWidget* page_widget   = zathura_page_get_widget(zathura, page);
+      GtkWidget* page_widget = zathura_page_get_widget(zathura, page);
+      /* the widget exists only if the background fill already created it */
+      if (page_widget == NULL) {
+        continue;
+      }
       GObject* obj_page_widget = G_OBJECT(page_widget);
       zathura_page_widget_clear_selection(ZATHURA_PAGE_WIDGET(page_widget));
       g_object_set(obj_page_widget, "draw-links", FALSE, NULL);

--- a/zathura/synctex.c
+++ b/zathura/synctex.c
@@ -245,6 +245,11 @@ void synctex_highlight_rects(zathura_t* zathura, unsigned int page, girara_list_
   zathura_document_t* document       = zathura_get_document(zathura);
   const unsigned int number_of_pages = zathura_document_get_number_of_pages(document);
 
+  /* the highlight needs every page widget so do nothing until the preload is done */
+  if (zathura->sync.widgets_loaded == false) {
+    return;
+  }
+
   for (unsigned int p = 0; p != number_of_pages; ++p) {
     GObject* widget = G_OBJECT(zathura_page_get_widget_by_number(zathura, p));
 

--- a/zathura/utils.c
+++ b/zathura/utils.c
@@ -292,10 +292,15 @@ void document_draw_search_results(zathura_t* zathura, bool value) {
     return;
   }
 
+  /* nothing to highlight until the preload is done */
+  if (zathura->sync.widgets_loaded == false) {
+    return;
+  }
+
   unsigned int number_of_pages = zathura_document_get_number_of_pages(zathura_get_document(zathura));
   for (unsigned int page_id = 0; page_id < number_of_pages; page_id++) {
-    g_object_set(G_OBJECT(zathura_page_get_widget_by_number(zathura, page_id)), "draw-search-results",
-                 (value == true) ? TRUE : FALSE, NULL);
+    GObject* page_widget = G_OBJECT(zathura_page_get_widget_by_number(zathura, page_id));
+    g_object_set(page_widget, "draw-search-results", (value == true) ? TRUE : FALSE, NULL);
   }
 }
 
@@ -593,6 +598,11 @@ girara_list_t* flatten_rectangles(girara_list_t* rectangles) {
 bool search_document(zathura_t* zathura, girara_argument_t* argument, bool disable_notify) {
   g_return_val_if_fail(argument != NULL, false);
   g_return_val_if_fail(zathura->document != NULL, false);
+
+  /* navigating results needs every page widget so do nothing until the preload is done */
+  if (zathura->sync.widgets_loaded == false) {
+    return false;
+  }
 
   girara_session_t* session = zathura->ui.session;
 

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -825,6 +825,165 @@ char* get_formatted_filename(zathura_t* zathura, bool statusbar) {
   }
 }
 
+/* create the page widget if missing, then attach it to the grid */
+void create_page_widget(zathura_t* zathura, unsigned int page_id) {
+  if (zathura->pages == NULL || zathura->document == NULL) {
+    return;
+  }
+
+  /* a saved or requested page number can exceed the page count so guard the array access */
+  if (page_id >= zathura_document_get_number_of_pages(zathura->document)) {
+    return;
+  }
+
+  if (zathura->pages[page_id] == NULL) {
+    zathura_page_t* page = zathura_document_get_page(zathura->document, page_id);
+    if (page == NULL) {
+      return;
+    }
+
+    GtkWidget* page_widget = zathura_page_widget_new(zathura, page);
+    if (page_widget == NULL) {
+      return;
+    }
+
+    g_object_ref(page_widget);
+    zathura->pages[page_id] = page_widget;
+
+    gtk_widget_set_halign(page_widget, GTK_ALIGN_CENTER);
+    gtk_widget_set_valign(page_widget, GTK_ALIGN_CENTER);
+
+    int layout_mode = DOCUMENT_WIDGET_GRID;
+    g_object_get(zathura->ui.document_widget, "layout-mode", &layout_mode, NULL);
+    /* in the single page layout only the current page may be shown */
+    const bool show =
+        layout_mode != DOCUMENT_WIDGET_SINGLE || page_id == zathura_document_get_current_page_number(zathura->document);
+    gtk_widget_set_visible(page_widget, show);
+
+    unsigned int page_height = 0;
+    unsigned int page_width  = 0;
+    page_calc_height_width(zathura->document, page, &page_height, &page_width, true);
+    zathura_page_widget_set_size_request(ZATHURA_PAGE_WIDGET(page_widget), page_width, page_height);
+
+    g_signal_connect(G_OBJECT(page_widget), "text-selected", G_CALLBACK(cb_page_widget_text_selected), zathura);
+    g_signal_connect(G_OBJECT(page_widget), "image-selected", G_CALLBACK(cb_page_widget_image_selected), zathura);
+    g_signal_connect(G_OBJECT(page_widget), "enter-link", G_CALLBACK(cb_page_widget_link), (gpointer) true);
+    g_signal_connect(G_OBJECT(page_widget), "leave-link", G_CALLBACK(cb_page_widget_link), (gpointer) false);
+    g_signal_connect(G_OBJECT(page_widget), "scaled-button-release", G_CALLBACK(cb_page_widget_scaled_button_release),
+                     zathura);
+  }
+
+  zathura_document_widget_attach_page(ZATHURA_DOCUMENT_WIDGET(zathura->ui.document_widget), page_id);
+}
+
+typedef struct {
+  zathura_t* zathura;
+  unsigned int next;
+} widget_preload_state_t;
+
+/* build the page widgets beyond the initial view in the background, at low priority */
+static gboolean preload_widgets_idle(gpointer data) {
+  widget_preload_state_t* state = data;
+  zathura_t* zathura            = state->zathura;
+
+  if (zathura->document == NULL) {
+    zathura->sync.widget_preload_source = 0;
+    return G_SOURCE_REMOVE;
+  }
+
+  const unsigned int number_of_pages = zathura_document_get_number_of_pages(zathura->document);
+  const gint64 deadline              = g_get_monotonic_time() + 4000; /* work for at most 4 ms per dispatch */
+  while (state->next < number_of_pages && g_get_monotonic_time() < deadline) {
+    create_page_widget(zathura, state->next);
+    state->next++;
+  }
+
+  if (state->next >= number_of_pages) {
+    zathura_document_widget_update_mode(ZATHURA_DOCUMENT_WIDGET(zathura->ui.document_widget));
+    zathura->sync.widget_preload_source = 0;
+    zathura->sync.widgets_loaded        = true;
+    /* run a search that arrived while the widgets were still loading */
+    if (zathura->sync.pending_search_input != NULL) {
+      char* input                        = zathura->sync.pending_search_input;
+      zathura->sync.pending_search_input = NULL;
+      girara_argument_t argument         = {0};
+      argument.n                         = zathura->sync.pending_search_direction;
+      cmd_search(zathura->ui.session, input, &argument);
+      g_free(input);
+    }
+    return G_SOURCE_REMOVE;
+  }
+
+  return G_SOURCE_CONTINUE;
+}
+
+/* render the focused page once synchronously now that the scale is settled */
+void render_focused_page_now(zathura_t* zathura) {
+  if (zathura->pages == NULL || zathura->document == NULL) {
+    return;
+  }
+  zathura->sync.initial_render_done = true;
+  const unsigned int current        = zathura_document_get_current_page_number(zathura->document);
+  /* the current page may be out of range so do not index past the array */
+  if (current >= zathura_document_get_number_of_pages(zathura->document)) {
+    return;
+  }
+  zathura_page_t* page   = zathura_document_get_page(zathura->document, current);
+  GtkWidget* page_widget = zathura->pages[current];
+  if (page != NULL && page_widget != NULL) {
+    cairo_surface_t* rendered = zathura_renderer_render_page(zathura->sync.render_thread, page);
+    if (rendered != NULL) {
+      zathura_page_widget_update_surface(ZATHURA_PAGE_WIDGET(page_widget), rendered, false);
+      cairo_surface_destroy(rendered);
+    }
+  }
+}
+
+static void cb_initial_render_after_paint(GdkFrameClock* clock, zathura_t* zathura) {
+  if (zathura->sync.view_painted == false) {
+    /* the first frame is painted, request one more so a pending scale change settles before the render */
+    zathura->sync.view_painted = true;
+    gtk_widget_queue_draw(zathura->ui.view);
+    return;
+  }
+  /* the second frame is painted so the scale and viewport are settled, render the focused page once */
+  g_signal_handler_disconnect(clock, zathura->sync.initial_render_handler);
+  zathura->sync.initial_render_handler  = 0;
+  zathura->sync.initial_render_instance = NULL;
+  if (zathura->sync.initial_render_held == true) {
+    zathura->sync.initial_render_held = false;
+    render_focused_page_now(zathura);
+  }
+}
+
+/* the frame clock exists only once the view is realised so hook the first paint here */
+static void cb_initial_render_map(GtkWidget* view, zathura_t* zathura) {
+  g_signal_handler_disconnect(view, zathura->sync.initial_render_handler);
+
+  GdkFrameClock* clock = gtk_widget_get_frame_clock(view);
+  if (clock != NULL) {
+    zathura->sync.initial_render_handler =
+        g_signal_connect(clock, "after-paint", G_CALLBACK(cb_initial_render_after_paint), zathura);
+    zathura->sync.initial_render_instance = G_OBJECT(clock);
+  } else {
+    zathura->sync.initial_render_handler  = 0;
+    zathura->sync.initial_render_instance = NULL;
+    zathura->sync.initial_render_held     = false;
+    zathura->sync.initial_render_done     = true;
+  }
+}
+
+/* drop a pending first render hold and detach its release handler */
+static void initial_render_cancel_hold(zathura_t* zathura) {
+  if (zathura->sync.initial_render_instance != NULL) {
+    g_clear_signal_handler(&zathura->sync.initial_render_handler, zathura->sync.initial_render_instance);
+    zathura->sync.initial_render_instance = NULL;
+  }
+  zathura->sync.initial_render_held = false;
+  zathura->sync.scale_settled       = false;
+  zathura->sync.view_painted        = false;
+}
+
 bool document_open(zathura_t* zathura, const char* path, const char* uri, const char* password, int page_number,
                    zathura_fileinfo_t* file_info_p) {
   if (zathura == NULL || zathura->plugins.manager == NULL || path == NULL) {
@@ -877,6 +1036,24 @@ bool document_open(zathura_t* zathura, const char* path, const char* uri, const 
   }
 
   zathura->document = document;
+
+  /* hold the first render until the view is painted so it lands at the final zoom and scale */
+  if (zathura->sync.initial_render_done == false && zathura->sync.initial_render_held == false) {
+    zathura->sync.initial_render_held = true;
+    zathura->sync.scale_settled       = false;
+    zathura->sync.view_painted        = false;
+    GdkFrameClock* clock              = gtk_widget_get_frame_clock(zathura->ui.view);
+    if (clock != NULL) {
+      zathura->sync.initial_render_handler =
+          g_signal_connect(clock, "after-paint", G_CALLBACK(cb_initial_render_after_paint), zathura);
+      zathura->sync.initial_render_instance = G_OBJECT(clock);
+    } else {
+      zathura->sync.initial_render_handler =
+          g_signal_connect(zathura->ui.view, "map", G_CALLBACK(cb_initial_render_map), zathura);
+      zathura->sync.initial_render_instance = G_OBJECT(zathura->ui.view);
+    }
+    gtk_widget_queue_draw(zathura->ui.view);
+  }
 
   /* read history file */
   zathura_fileinfo_t file_info = {
@@ -1072,30 +1249,7 @@ bool document_open(zathura_t* zathura, const char* path, const char* uri, const 
     goto error_free;
   }
 
-  for (unsigned int page_id = 0; page_id < number_of_pages; page_id++) {
-    zathura_page_t* page = zathura_document_get_page(document, page_id);
-    if (page == NULL) {
-      goto error_free;
-    }
-
-    GtkWidget* page_widget = zathura_page_widget_new(zathura, page);
-    if (page_widget == NULL) {
-      goto error_free;
-    }
-
-    g_object_ref(page_widget);
-    zathura->pages[page_id] = page_widget;
-
-    gtk_widget_set_halign(page_widget, GTK_ALIGN_CENTER);
-    gtk_widget_set_valign(page_widget, GTK_ALIGN_CENTER);
-
-    g_signal_connect(G_OBJECT(page_widget), "text-selected", G_CALLBACK(cb_page_widget_text_selected), zathura);
-    g_signal_connect(G_OBJECT(page_widget), "image-selected", G_CALLBACK(cb_page_widget_image_selected), zathura);
-    g_signal_connect(G_OBJECT(page_widget), "enter-link", G_CALLBACK(cb_page_widget_link), (gpointer) true);
-    g_signal_connect(G_OBJECT(page_widget), "leave-link", G_CALLBACK(cb_page_widget_link), (gpointer) false);
-    g_signal_connect(G_OBJECT(page_widget), "scaled-button-release", G_CALLBACK(cb_page_widget_scaled_button_release),
-                     zathura);
-  }
+  /* page widgets are created on demand, not all at once */
 
   {
     /* view mode */
@@ -1139,6 +1293,7 @@ bool document_open(zathura_t* zathura, const char* path, const char* uri, const 
     g_object_set_property(G_OBJECT(zathura->ui.document_widget), "pages-right-to-left", &page_right_to_left_value);
   }
 
+  create_page_widget(zathura, zathura_document_get_current_page_number(document));
   zathura_document_widget_refresh_layout(ZATHURA_DOCUMENT_WIDGET(zathura->ui.document_widget));
   girara_set_view(zathura->ui.session, zathura->ui.view);
 
@@ -1156,6 +1311,9 @@ bool document_open(zathura_t* zathura, const char* path, const char* uri, const 
     unsigned int page_height = 0;
     unsigned int page_width  = 0;
     GtkWidget* widget        = zathura_page_get_widget(zathura, page);
+    if (widget == NULL) {
+      continue;
+    }
 
     /* adjust_view calls render_all in some cases and render_all calls
      * gtk_widget_set_size_request. To be sure that it's really called, do it
@@ -1197,9 +1355,24 @@ bool document_open(zathura_t* zathura, const char* path, const char* uri, const 
 
   zathura_update_view_ppi(zathura);
 
+  /* build the remaining page widgets in the background so opening stays fast */
+  if (zathura->sync.widget_preload_source != 0) {
+    g_source_remove(zathura->sync.widget_preload_source);
+    zathura->sync.widget_preload_source = 0;
+  }
+  widget_preload_state_t* widget_state = g_try_malloc0(sizeof(widget_preload_state_t));
+  if (widget_state != NULL) {
+    zathura->sync.widgets_loaded        = false;
+    widget_state->zathura               = zathura;
+    widget_state->next                  = 0;
+    zathura->sync.widget_preload_source = g_idle_add_full(G_PRIORITY_LOW, preload_widgets_idle, widget_state, g_free);
+  }
+
   return true;
 
 error_free:
+  /* the hold armed above must not outlive the failed open */
+  initial_render_cancel_hold(zathura);
   zathura_document_free(document);
   zathura->document = NULL;
   return false;
@@ -1332,7 +1505,9 @@ bool document_predecessor_free(zathura_t* zathura) {
 
   if (zathura->predecessor_pages != NULL) {
     for (unsigned int i = 0; i < zathura_document_get_number_of_pages(zathura->predecessor_document); i++) {
-      g_object_unref(zathura->predecessor_pages[i]);
+      if (zathura->predecessor_pages[i] != NULL) {
+        g_object_unref(zathura->predecessor_pages[i]);
+      }
     }
     g_free(zathura->predecessor_pages);
     zathura->predecessor_pages = NULL;
@@ -1355,6 +1530,18 @@ bool document_close(zathura_t* zathura, bool keep_monitor) {
 
   /* stop rendering */
   zathura_renderer_stop(zathura->sync.render_thread);
+
+  /* stop building page widgets in the background */
+  if (zathura->sync.widget_preload_source != 0) {
+    g_source_remove(zathura->sync.widget_preload_source);
+    zathura->sync.widget_preload_source = 0;
+  }
+  zathura->sync.widgets_loaded = false;
+  g_free(zathura->sync.pending_search_input);
+  zathura->sync.pending_search_input = NULL;
+
+  /* drop a first render hold that never got released */
+  initial_render_cancel_hold(zathura);
 
   /* remove monitor */
   if (keep_monitor == false) {
@@ -1386,9 +1573,10 @@ bool document_close(zathura_t* zathura, bool keep_monitor) {
 
   if (override_predecessor) {
     /* do not override predecessor buffer with empty pages */
-    unsigned int cur_page_num   = zathura_document_get_current_page_number(document);
-    ZathuraPageWidget* cur_page = ZATHURA_PAGE_WIDGET(zathura_page_get_widget_by_number(zathura, cur_page_num));
-    if (!zathura_page_widget_have_surface(cur_page)) {
+    unsigned int cur_page_num = zathura_document_get_current_page_number(document);
+    GtkWidget* cur_page       = zathura_page_get_widget_by_number(zathura, cur_page_num);
+    /* the widget exists only if the background fill already created it */
+    if (cur_page == NULL || !zathura_page_widget_have_surface(ZATHURA_PAGE_WIDGET(cur_page))) {
       override_predecessor = false;
     }
   }
@@ -1413,7 +1601,10 @@ bool document_close(zathura_t* zathura, bool keep_monitor) {
 
   if (!override_predecessor) {
     for (unsigned int i = 0; i < zathura_document_get_number_of_pages(document); i++) {
-      g_object_unref(zathura->pages[i]);
+      /* the widget exists only if the background fill already created it */
+      if (zathura->pages[i] != NULL) {
+        g_object_unref(zathura->pages[i]);
+      }
     }
     g_free(zathura->pages);
     zathura->pages = NULL;
@@ -1685,6 +1876,9 @@ void zathura_show_signature_information(zathura_t* zathura, bool show) {
   for (unsigned int page = 0; page != number_of_pages; ++page) {
     // draw signature info
     GObject* page_widget = G_OBJECT(zathura_page_get_widget_by_number(zathura, page));
+    if (page_widget == NULL) {
+      continue;
+    }
     g_object_set_property(page_widget, "draw-signatures", &show_sig_info_value);
   }
 }

--- a/zathura/zathura.h
+++ b/zathura/zathura.h
@@ -123,6 +123,16 @@ struct zathura_s {
 
   struct {
     ZathuraRenderer* render_thread; /**< The thread responsible for rendering the pages */
+    guint widget_preload_source;    /**< Idle source that builds the remaining page widgets in the background */
+    bool initial_render_held;       /**< holds the focused page first render until the view is painted */
+    bool scale_settled;       /**< set when the device scale settled so the viewport allocation renders the page */
+    bool view_painted;        /**< set after the first frame so a display that never changes scale renders next frame */
+    bool initial_render_done; /**< set once the first render has happened so later opens do not hold */
+    gulong initial_render_handler;    /**< handler id used to release the hold */
+    GObject* initial_render_instance; /**< instance the release handler is connected to */
+    bool widgets_loaded;              /**< set once the background fill has built every page widget */
+    char* pending_search_input;       /**< search query received before the widgets finished loading */
+    int pending_search_direction;     /**< direction for a search received before loading finished */
   } sync;
 
   struct {
@@ -330,6 +340,12 @@ void zathura_update_view_ppi(zathura_t* zathura);
  */
 bool document_open(zathura_t* zathura, const char* path, const char* uri, const char* password, int page_number,
                    zathura_fileinfo_t* file_info);
+
+/* create the page widget if missing then attach it to the grid */
+void create_page_widget(zathura_t* zathura, unsigned int page_id);
+
+/* render the focused page synchronously once the device scale has settled */
+void render_focused_page_now(zathura_t* zathura);
 
 /**
  * Opens a file


### PR DESCRIPTION
With this PR only the on screen page widget is created when a document is opened and the rest are created in the background at low priority, so opening documents with many pages are displayed immediately instead of taking seconds.
There is still on demand widget creation, so immediate scrolling still works as well

together with the lazy parsing PR, this reduces the display time of large documents from multiple seconds to <0.1 second