### PR TITLE
Fix scroll sensitivity

### DIFF
--- a/girara-gtk/callbacks.c
+++ b/girara-gtk/callbacks.c
@@ -358,13 +358,15 @@ gboolean girara_callback_view_scroll_event(GtkEventControllerScroll* controller,
   /* only wheel units are discrete steps so touchpad deltas stay smooth */
   if (gtk_event_controller_scroll_get_unit(controller) != GDK_SCROLL_UNIT_WHEEL) {
     event.type = GIRARA_EVENT_SCROLL_BIDIRECTIONAL;
-    event.x    = dx;
-    event.y    = dy;
 #ifdef __APPLE__
     /* Apple has much higher deltas */
-    event.x /= 50;
-    event.y /= 50;
+    const double surface_to_wheel = 50.0;
+#else
+    /* gtk4 sends raw pixels */
+    const double surface_to_wheel = 10.0;
 #endif
+    event.x = dx / surface_to_wheel;
+    event.y = dy / surface_to_wheel;
   } else if (dx == 0.0 && dy < 0.0) {
     event.type = GIRARA_EVENT_SCROLL_UP;
   } else if (dx == 0.0 && dy > 0.0) {


### PR DESCRIPTION
GTK4 sends touchpad deltas as raw pixels, but the code still expects GTK3 deltas which were 10 times smaller.

Fixes https://github.com/pwmt/zathura/issues/974