### PR TITLE
fix feedkeys

### DIFF
--- a/girara-gtk/callbacks.c
+++ b/girara-gtk/callbacks.c
@@ -214,6 +214,24 @@ gboolean girara_process_view_key(girara_session_t* session, guint keyval, guint 
   return FALSE;
 }
 
+gboolean girara_process_inputbar_key(girara_session_t* session, guint keyval, guint clean) {
+  g_return_val_if_fail(session != NULL, FALSE);
+
+  for (size_t idx = 0; idx != girara_list_size(session->bindings.inputbar_shortcuts); ++idx) {
+    girara_inputbar_shortcut_t* inputbar_shortcut = girara_list_nth(session->bindings.inputbar_shortcuts, idx);
+    if (inputbar_shortcut->key == keyval && inputbar_shortcut->mask == clean) {
+      girara_debug("found shortcut for key %u and mask %x", keyval, clean);
+      if (inputbar_shortcut->function != NULL) {
+        inputbar_shortcut->function(session, &(inputbar_shortcut->argument), NULL, 0);
+      }
+
+      return TRUE;
+    }
+  }
+
+  return FALSE;
+}
+
 gboolean girara_callback_view_button_press_event(GtkGestureClick* gesture, gint n_press, gdouble x, gdouble y,
                                                  girara_session_t* session) {
   g_return_val_if_fail(session != NULL, false);
@@ -500,18 +518,8 @@ gboolean girara_callback_inputbar_key_press_event(GtkEventControllerKey* control
   }
   girara_debug("Proccessing key %u with mask %x.", keyval, clean);
 
-  if (custom_ret == false) {
-    for (size_t idx = 0; idx != girara_list_size(session->bindings.inputbar_shortcuts); ++idx) {
-      girara_inputbar_shortcut_t* inputbar_shortcut = girara_list_nth(session->bindings.inputbar_shortcuts, idx);
-      if (inputbar_shortcut->key == keyval && inputbar_shortcut->mask == clean) {
-        girara_debug("found shortcut for key %u and mask %x", keyval, clean);
-        if (inputbar_shortcut->function != NULL) {
-          inputbar_shortcut->function(session, &(inputbar_shortcut->argument), NULL, 0);
-        }
-
-        return true;
-      }
-    }
+  if (custom_ret == false && girara_process_inputbar_key(session, keyval, clean) == TRUE) {
+    return true;
   }
 
   if ((session->gtk.results != NULL) && (gtk_widget_get_visible(GTK_WIDGET(session->gtk.results)) == TRUE) &&

--- a/girara-gtk/callbacks.h
+++ b/girara-gtk/callbacks.h
@@ -72,6 +72,9 @@ gboolean girara_callback_view_button_release_event(GtkGestureClick* gesture, gin
  */
 gboolean girara_process_view_key(girara_session_t* session, guint keyval, guint clean);
 
+/* run a bound inputbar shortcut for the key */
+gboolean girara_process_inputbar_key(girara_session_t* session, guint keyval, guint clean);
+
 gboolean girara_callback_view_button_motion_notify_event(GtkEventControllerMotion* controller, gdouble x, gdouble y,
                                                          girara_session_t* session);
 

--- a/girara-gtk/shortcuts.c
+++ b/girara-gtk/shortcuts.c
@@ -375,6 +375,28 @@ static int update_state_by_keyval(int state, int keyval) {
   return state;
 }
 
+/* type one synthetic key into the inputbar entry */
+static void feed_key_to_inputbar(girara_session_t* session, guint keyval, guint state) {
+  if (girara_process_inputbar_key(session, keyval, state) == TRUE) {
+    return;
+  }
+
+  GtkWidget* entry = GTK_WIDGET(session->gtk.inputbar_entry);
+  if (keyval == GDK_KEY_Return || keyval == GDK_KEY_KP_Enter) {
+    g_signal_emit_by_name(entry, "activate");
+    return;
+  }
+
+  const gunichar codepoint = gdk_keyval_to_unicode(keyval);
+  if (codepoint != 0 && g_unichar_isprint(codepoint) == TRUE) {
+    char buffer[6];
+    const int length = g_unichar_to_utf8(codepoint, buffer);
+    int position     = gtk_editable_get_position(GTK_EDITABLE(entry));
+    gtk_editable_insert_text(GTK_EDITABLE(entry), buffer, length, &position);
+    gtk_editable_set_position(GTK_EDITABLE(entry), position);
+  }
+}
+
 bool girara_sc_feedkeys(girara_session_t* session, girara_argument_t* argument, girara_event_t* UNUSED(event),
                         unsigned int t) {
   if (session == NULL || argument == NULL) {
@@ -453,7 +475,15 @@ bool girara_sc_feedkeys(girara_session_t* session, girara_argument_t* argument, 
 
     single_key:
       state = update_state_by_keyval(state, keyval);
-      girara_process_view_key(session, keyval, state);
+      /* send the key to the widget that would receive a real key press */
+      GtkWidget* entry = GTK_WIDGET(session->gtk.inputbar_entry);
+      GtkRoot* root    = gtk_widget_get_root(entry);
+      GtkWidget* focus = root != NULL ? gtk_root_get_focus(root) : NULL;
+      if (focus != NULL && (focus == entry || gtk_widget_is_ancestor(focus, entry))) {
+        feed_key_to_inputbar(session, keyval, state);
+      } else {
+        girara_process_view_key(session, keyval, state);
+      }
     }
   }
 


### PR DESCRIPTION
GTK4 removed the  old event injection and now send every fed key to the normal mode handler. Route each key to the widget that holds the focus instead.

Fixes #976 

(EDIT: referenced wrong issue)