### PR TITLE
Add open-link-confirm option to zathurarc

### DIFF
--- a/doc/man/zathurarc.5.rst
+++ b/doc/man/zathurarc.5.rst
@@ -796,6 +796,12 @@ The settings described here can be changed with ``set``.
   * Value type: Boolean
   * Default value: false
 
+*open-link-confirm*
+  Show a confirmation dialog when opening external links.
+
+  * Value type: Boolean
+  * Default value: true
+
 *page-cache-size*
   Defines the maximum number of pages that could be kept in the page cache. When
   the cache is full and a new page that isn't cached becomes visible, the least


### PR DESCRIPTION
Mention the open-link-confirm option (introduced at #940 ) in zathurarc.