### PR TITLE
Apply open-link-confirm to all external link types

### DIFF
--- a/zathura/links.c
+++ b/zathura/links.c
@@ -329,23 +329,9 @@ void zathura_link_evaluate(zathura_t* zathura, zathura_link_t* link) {
   case ZATHURA_LINK_GOTO_REMOTE:
   case ZATHURA_LINK_URI:
   case ZATHURA_LINK_LAUNCH:
-    bool confirm           = true;
-    const char* debug_text = "";
-    switch (link->type) {
-    case ZATHURA_LINK_GOTO_REMOTE:
-      debug_text = "Going to remote destination";
-      break;
-    case ZATHURA_LINK_URI:
-      debug_text = "Opening URI";
-      break;
-    case ZATHURA_LINK_LAUNCH:
-      debug_text = "Launching link";
-      break;
-    default:
-      break;
-    }
+    bool confirm = true;
     girara_setting_get(zathura->ui.session, "open-link-confirm", &confirm);
-    girara_debug("%s: %s", debug_text, link->target.value);
+    girara_debug("Opening link: %s (type = %u)", link->target.value, (unsigned int)link->target.destination_type);
     if (confirm) {
       link_confirm(zathura, link->type, link->target.value);
     } else if (link->type == ZATHURA_LINK_GOTO_REMOTE) {

--- a/zathura/links.c
+++ b/zathura/links.c
@@ -327,23 +327,32 @@ void zathura_link_evaluate(zathura_t* zathura, zathura_link_t* link) {
     break;
 #ifndef WITH_SANDBOX
   case ZATHURA_LINK_GOTO_REMOTE:
-    girara_debug("Going to remote destination: %s", link->target.value);
-    link_confirm(zathura, link->type, link->target.value);
-    break;
-  case ZATHURA_LINK_URI: {
-    bool confirm = true;
+  case ZATHURA_LINK_URI:
+  case ZATHURA_LINK_LAUNCH:
+    bool confirm           = true;
+    const char* debug_text = "";
+    switch (link->type) {
+    case ZATHURA_LINK_GOTO_REMOTE:
+      debug_text = "Going to remote destination";
+      break;
+    case ZATHURA_LINK_URI:
+      debug_text = "Opening URI";
+      break;
+    case ZATHURA_LINK_LAUNCH:
+      debug_text = "Launching link";
+      break;
+    default:
+      break;
+    }
     girara_setting_get(zathura->ui.session, "open-link-confirm", &confirm);
-    girara_debug("Opening URI: %s", link->target.value);
+    girara_debug("%s: %s", debug_text, link->target.value);
     if (confirm) {
       link_confirm(zathura, link->type, link->target.value);
+    } else if (link->type == ZATHURA_LINK_GOTO_REMOTE) {
+      link_remote(zathura, link->target.value);
     } else {
       link_launch(zathura, link->target.value);
     }
-    break;
-  }
-  case ZATHURA_LINK_LAUNCH:
-    girara_debug("Launching link: %s", link->target.value);
-    link_confirm(zathura, link->type, link->target.value);
     break;
 #endif
   default:


### PR DESCRIPTION
## Description
`open-link-confirm` now works for launch and Go to remote paths 

Changes to address this comment https://github.com/pwmt/zathura/pull/940#issuecomment-5249625098

## Result
URI, Go to remote, and link launch all are affected by open-link-confirm. Leaving Go to dest as the only type of link not affected by `open-link-confirm`