### PR TITLE
Fix shortcuts dying after focus leaves the view

### DIFF
--- a/girara-gtk/internal.h
+++ b/girara-gtk/internal.h
@@ -32,6 +32,8 @@ void girara_argument_mapping_free(girara_argument_mapping_t* argument_mapping);
 
 void girara_command_free(girara_command_t* command);
 
+void girara_focus_view(girara_session_t* session);
+
 void widget_add_class(GtkWidget* widget, const char* styleclass);
 
 void widget_remove_class(GtkWidget* widget, const char* styleclass);

--- a/girara-gtk/session.c
+++ b/girara-gtk/session.c
@@ -540,6 +540,18 @@ char* girara_buffer_get(girara_session_t* session) {
   return (session->global.buffer) ? g_strdup(session->global.buffer->str) : NULL;
 }
 
+/* the view stack is not focusable, so grabbing focus on it leaves focus outside the
+   stack and the capture-phase key controller stops seeing keys */
+void girara_focus_view(girara_session_t* session) {
+  g_return_if_fail(session != NULL && session->gtk.view != NULL);
+
+  GtkWidget* child = gtk_stack_get_visible_child(GTK_STACK(session->gtk.view));
+  if (child != NULL && gtk_widget_grab_focus(child)) {
+    return;
+  }
+  gtk_widget_grab_focus(GTK_WIDGET(session->gtk.view));
+}
+
 void girara_notify(girara_session_t* session, int level, const char* format, ...) {
   if (session == NULL || session->gtk.notification_text == NULL || session->gtk.notification_area == NULL ||
       session->gtk.inputbar == NULL || session->gtk.view == NULL) {
@@ -573,7 +585,7 @@ void girara_notify(girara_session_t* session, int level, const char* format, ...
   gtk_widget_set_visible(GTK_WIDGET(session->gtk.notification_area), TRUE);
   gtk_widget_set_visible(GTK_WIDGET(session->gtk.inputbar), FALSE);
 
-  gtk_widget_grab_focus(GTK_WIDGET(session->gtk.view));
+  girara_focus_view(session);
 }
 
 void girara_dialog(girara_session_t* session, const char* dialog, bool invisible,
@@ -617,7 +629,7 @@ bool girara_set_view(girara_session_t* session, GtkWidget* widget) {
 
   gtk_widget_set_visible(widget, true);
   gtk_stack_set_visible_child(GTK_STACK(session->gtk.view), widget);
-  gtk_widget_grab_focus(GTK_WIDGET(session->gtk.view));
+  girara_focus_view(session);
 
   return true;
 }

--- a/girara-gtk/shortcuts.c
+++ b/girara-gtk/shortcuts.c
@@ -142,7 +142,7 @@ bool girara_isc_abort(girara_session_t* session, girara_argument_t* UNUSED(argum
   gtk_editable_delete_text(GTK_EDITABLE(session->gtk.inputbar_entry), 0, -1);
 
   /* grab view */
-  gtk_widget_grab_focus(GTK_WIDGET(session->gtk.view));
+  girara_focus_view(session);
 
   /* hide inputbar */
   gtk_widget_set_visible(GTK_WIDGET(session->gtk.inputbar_dialog), FALSE);


### PR DESCRIPTION
**Problem.** After any `girara_notify()`, every shortcut is dropped until the user clicks back into the view.

**Repro.** Open a PDF, select text with the mouse (notification: "Copied selected text to selection clipboard"), press `Tab`. The index opens, but `j`, `k`, `Return`, `q` do nothing. A single click in the index restores the keys.

**Cause.** The key controller is capture-phase on `session->gtk.view`. Capture only walks to the focused widget. The stack sets `can-focus`, not `focusable`, so `gtk_widget_grab_focus()` on it does not land, and focus ends outside the stack.

**Fix.** Focus the stack's visible child, with the old call as fallback. `girara_isc_abort()` has the same latent problem (it grabs the view, then hides the inputbar), so it uses the same helper.

`girara_session_init()` keeps the bare call: the stack has no child yet at that point.

An alternative is to set `focusable` on the stack at `session.c:283`, but that makes the stack itself take focus. This change keeps focus on the real child.

Verified on 2026.07.18 and develop `614f1ee1`, GTK 4.22.4, Wayland. Traced with a debug build: before the change only the `Tab` keypress reaches `girara_process_view_key()`; after it, `j`, `k`, `Return` and `q` all arrive and the index entry activates.