### PR TITLE
Fix fractional display scale

### DIFF
--- a/zathura/callbacks.c
+++ b/zathura/callbacks.c
@@ -307,15 +307,18 @@ void cb_monitors_changed(GListModel* UNUSED(model), guint UNUSED(position), guin
   zathura_update_view_ppi(zathura);
 }
 
-void cb_scale_factor(GObject* object, GParamSpec* UNUSED(pspec), gpointer data) {
+void cb_scale_factor(GObject* UNUSED(object), GParamSpec* UNUSED(pspec), gpointer data) {
   zathura_t* zathura = data;
   if (zathura_has_document(zathura) == false) {
     return;
   }
 
-  int new_factor = gtk_widget_get_scale_factor(GTK_WIDGET(object));
-  if (new_factor == 0) {
-    girara_debug("Ignoring new device scale factor = 0");
+  GtkWidget* view     = zathura->ui.session->gtk.view;
+  GtkNative* native   = gtk_widget_get_native(view);
+  GdkSurface* surface = native != NULL ? gtk_native_get_surface(native) : NULL;
+  /* read the exact display scale instead of the rounded whole number */
+  const double new_factor = surface != NULL ? gdk_surface_get_scale(surface) : gtk_widget_get_scale_factor(view);
+  if (new_factor <= 0.0) {
     return;
   }
 
@@ -323,10 +326,27 @@ void cb_scale_factor(GObject* object, GParamSpec* UNUSED(pspec), gpointer data) 
   zathura_device_factors_t current = zathura_document_get_device_factors(document);
   if (fabs(new_factor - current.x) >= DBL_EPSILON || fabs(new_factor - current.y) >= DBL_EPSILON) {
     zathura_document_set_device_factors(document, new_factor, new_factor);
-    girara_debug("New device scale factor: %d", new_factor);
+    girara_debug("New device scale factor: %0.2f", new_factor);
     zathura_update_view_ppi(zathura);
     zathura_document_widget_render_all(zathura->ui.document_widget);
   }
+}
+
+void cb_view_realized(GtkWidget* widget, gpointer data) {
+  zathura_t* zathura = data;
+
+  GtkNative* native = gtk_widget_get_native(widget);
+  if (native == NULL) {
+    return;
+  }
+  GdkSurface* surface = gtk_native_get_surface(native);
+  if (surface == NULL) {
+    return;
+  }
+
+  /* run the scale handler when the display scale changes */
+  g_signal_connect(G_OBJECT(surface), "notify::scale", G_CALLBACK(cb_scale_factor), zathura);
+  cb_scale_factor(NULL, NULL, zathura);
 }
 
 void cb_page_layout_value_changed(girara_session_t* session, const char* name, girara_setting_type_t UNUSED(type),

--- a/zathura/callbacks.h
+++ b/zathura/callbacks.h
@@ -81,16 +81,24 @@ void cb_view_vadjustment_changed(GtkAdjustment* adjustment, gpointer data);
 void cb_refresh_view(GtkWidget* view, gpointer data);
 
 /**
- * This function gets called when the view widget scale factor changes (e.g.
- * when moving from a regular to a HiDPI screen).
+ * This function gets called when the display scale changes.
  *
  * It records the new value and triggers a re-rendering of the document.
  *
- * @param object The view widget
- * @param pspec The GParamSpec for the scale-factor property
- * @param gpointer The zathura instance
+ * @param object Unused
+ * @param pspec Unused
+ * @param data The zathura instance
  */
 void cb_scale_factor(GObject* object, GParamSpec* pspec, gpointer data);
+
+/**
+ * Called when the view is set up on screen. Makes the scale handler run when
+ * the display scale changes.
+ *
+ * @param widget The view widget
+ * @param data The zathura instance
+ */
+void cb_view_realized(GtkWidget* widget, gpointer data);
 
 /**
  * This function gets called when the monitor configuration changes (e.g.

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -217,6 +217,11 @@ static bool init_ui(zathura_t* zathura) {
 
   g_signal_connect(G_OBJECT(zathura->ui.session->gtk.view), "notify::scale-factor", G_CALLBACK(cb_scale_factor),
                    zathura);
+  g_signal_connect(G_OBJECT(zathura->ui.session->gtk.view), "realize", G_CALLBACK(cb_view_realized), zathura);
+  /* the window can already be shown at this point */
+  if (gtk_widget_get_realized(zathura->ui.session->gtk.view) == TRUE) {
+    cb_view_realized(zathura->ui.session->gtk.view, zathura);
+  }
 
   /* update the view PPI whenever the monitor configuration changes */
   GdkDisplay* display = gtk_widget_get_display(zathura->ui.session->gtk.view);
@@ -1063,7 +1068,10 @@ bool document_open(zathura_t* zathura, const char* path, const char* uri, const 
   zathura_document_set_viewport_height(document, view_height);
 
   /* get initial device scale */
-  const int device_factor = gtk_widget_get_scale_factor(zathura->ui.session->gtk.view);
+  GtkNative* native   = gtk_widget_get_native(zathura->ui.session->gtk.view);
+  GdkSurface* surface = native != NULL ? gtk_native_get_surface(native) : NULL;
+  const double device_factor =
+      surface != NULL ? gdk_surface_get_scale(surface) : gtk_widget_get_scale_factor(zathura->ui.session->gtk.view);
   zathura_document_set_device_factors(document, device_factor, device_factor);
 
   /* create blank pages */


### PR DESCRIPTION
addresses #997

The render size used the integer scale factor which rounds a fractional scale like 1.5 up to 2. Pages were rendered larger than the screen and the compositor scaled down every frame down which probably caused the performance regression with fractional scaling on Wayland.