### PR TITLE
Add window-decoration setting to disable CSD on Wayland

### DIFF
--- a/girara-gtk/session.c
+++ b/girara-gtk/session.c
@@ -418,6 +418,11 @@ bool girara_session_init(girara_session_t* session, const char* sessionname) {
     gtk_window_set_default_size(GTK_WINDOW(session->gtk.window), window_width, window_height);
   }
 
+  /* apply the window-decoration setting (read from the application's config) before showing the window */
+  bool window_decoration = true;
+  girara_setting_get(session, "window-decoration", &window_decoration);
+  gtk_window_set_decorated(GTK_WINDOW(session->gtk.window), window_decoration);
+
   gtk_widget_set_visible(GTK_WIDGET(session->gtk.window), TRUE);
   gtk_widget_set_visible(GTK_WIDGET(session->gtk.notification_area), FALSE);
   gtk_widget_set_visible(GTK_WIDGET(session->gtk.inputbar_dialog), FALSE);

--- a/zathura/config.c
+++ b/zathura/config.c
@@ -489,6 +489,8 @@ void config_load_default(zathura_t* zathura) {
   girara_setting_add(gsession, "word-separator",           " /.-=&#?",           STRING,  TRUE,  NULL, NULL, NULL);
   girara_setting_add(gsession, "window-width",             &window_width,        UINT,    TRUE,  _("Initial window width"), NULL, NULL);
   girara_setting_add(gsession, "window-height",            &window_height,       UINT,    TRUE,  _("Initial window height"), NULL, NULL);
+  bool_value = true;
+  girara_setting_add(gsession, "window-decoration",        &bool_value,          BOOLEAN, TRUE,  _("Show window decorations"), NULL, NULL);
   girara_setting_add(gsession, "statusbar-h-padding",      &statusbar_h_padding, INT,     TRUE,  _("Horizontal padding for the status, input, and notification bars"), NULL, NULL);
   girara_setting_add(gsession, "statusbar-v-padding",      &statusbar_v_padding, INT,     TRUE,  _("Vertical padding for the status, input, and notification bars"), NULL, NULL);
   girara_setting_add(gsession, "n-completion-items",       &n_completion_items,  UINT,    TRUE,  _("Number of completion items"), NULL, NULL);


### PR DESCRIPTION
Closes #1018

Adds an init-only `window-decoration` boolean setting (default `true`):

- `zathura/config.c`: register the setting (BOOLEAN, init-only, default true)
- `girara-gtk/session.c`: read it and call `gtk_window_set_decorated()` before the window is shown

This lets users run fully borderless under native Wayland (GTK4 renders CSD that a compositor such as COSMIC can't strip):

```
set window-decoration false
```

Default stays `true`, so no behavior change for existing users.