### PR TITLE
Add window-decoration setting to disable CSD on Wayland

### DIFF
--- a/girara-gtk/session.c
+++ b/girara-gtk/session.c
@@ -418,6 +418,11 @@ bool girara_session_init(girara_session_t* session, const char* sessionname) {
     gtk_window_set_default_size(GTK_WINDOW(session->gtk.window), window_width, window_height);
   }
 
+  /* apply the window-decoration setting (read from the application's config) before showing the window */
+  bool window_decoration = true;
+  girara_setting_get(session, "window-decoration", &window_decoration);
+  gtk_window_set_decorated(GTK_WINDOW(session->gtk.window), window_decoration);
+
   gtk_widget_set_visible(GTK_WIDGET(session->gtk.window), TRUE);
   gtk_widget_set_visible(GTK_WIDGET(session->gtk.notification_area), FALSE);
   gtk_widget_set_visible(GTK_WIDGET(session->gtk.inputbar_dialog), FALSE);

--- a/zathura/config.c
+++ b/zathura/config.c
@@ -489,6 +489,8 @@ void config_load_default(zathura_t* zathura) {
   girara_setting_add(gsession, "word-separator",           " /.-=&#?",           STRING,  TRUE,  NULL, NULL, NULL);
   girara_setting_add(gsession, "window-width",             &window_width,        UINT,    TRUE,  _("Initial window width"), NULL, NULL);
   girara_setting_add(gsession, "window-height",            &window_height,       UINT,    TRUE,  _("Initial window height"), NULL, NULL);
+  bool_value = true;
+  girara_setting_add(gsession, "window-decoration",        &bool_value,          BOOLEAN, TRUE,  _("Show window decorations"), NULL, NULL);
   girara_setting_add(gsession, "statusbar-h-padding",      &statusbar_h_padding, INT,     TRUE,  _("Horizontal padding for the status, input, and notification bars"), NULL, NULL);
   girara_setting_add(gsession, "statusbar-v-padding",      &statusbar_v_padding, INT,     TRUE,  _("Vertical padding for the status, input, and notification bars"), NULL, NULL);
   girara_setting_add(gsession, "n-completion-items",       &n_completion_items,  UINT,    TRUE,  _("Number of completion items"), NULL, NULL);


### PR DESCRIPTION
Closes #1021

Adds a `window-decoration` setting (default `true`) so users can hide the window title bar.

**Changes:**
- `zathura/config.c`: registers the `window-decoration` setting as a boolean that defaults to on, so existing behavior is unchanged for anyone who doesn't change it.
- `girara-gtk/session.c`: reads `window-decoration` during window setup and uses it to either show or hide the title bar before the window appears on screen.

**Use case:** On Wayland, zathura's GTK4 window always renders a client-side title bar that a compositor like COSMIC can't strip. With this option, users who prefer a borderless viewer — similar to mpv/imv — can add this to their config:

```
set window-decoration false
```

to hide the title bar and let the document take up the full window.