### PR TITLE
feat: implement drag & drop document opening

### DIFF
--- a/zathura/callbacks.c
+++ b/zathura/callbacks.c
@@ -811,6 +811,40 @@ void cb_gesture_zoom_scale_changed(GtkGestureZoom* UNUSED(self), gdouble scale, 
   sc_zoom(zathura->ui.session, &argument, NULL, next_zoom * 100);
 }
 
+gboolean cb_drop_file(GtkDropTarget* UNUSED(self), const GValue* value, double UNUSED(x), double UNUSED(y),
+                      void* data) {
+  zathura_t* zathura = data;
+  if (zathura == NULL || value == NULL) {
+    return FALSE;
+  }
+
+  /* the dropped value holds the list of file GFiles (matched GDK_TYPE_FILE_LIST) */
+  GSList* files = NULL;
+  if (G_VALUE_HOLDS(value, GDK_TYPE_FILE_LIST)) {
+    files = g_value_get_boxed(value);
+  }
+
+  const GSList* file = files;
+  while (file != NULL && g_file_is_native(G_FILE(file->data)) == FALSE) {
+    file = file->next;
+  }
+  if (file == NULL) {
+    return FALSE;
+  }
+
+  g_autofree char* path = g_file_get_path(G_FILE(file->data));
+  if (path == NULL) {
+    return FALSE;
+  }
+
+  if (zathura_has_document(zathura) == true) {
+    document_close(zathura, false);
+  }
+
+  document_open_idle(zathura, path, NULL, ZATHURA_PAGE_NUMBER_UNSPECIFIED, NULL, NULL, NULL, NULL);
+  return TRUE;
+}
+
 void cb_hide_links(GtkWidget* widget, gpointer data) {
   g_return_if_fail(widget != NULL);
   g_return_if_fail(data != NULL);

--- a/zathura/callbacks.h
+++ b/zathura/callbacks.h
@@ -250,6 +250,15 @@ void cb_gesture_zoom_begin(GtkGesture* self, GdkEventSequence* sequence, void* d
 void cb_gesture_zoom_scale_changed(GtkGestureZoom* self, gdouble scale, void* data);
 
 /**
+ * Open the file dropped onto the view
+ *
+ * @param self The GtkDropTarget that received the drop
+ * @param value The dropped data
+ * @param data The zathura instance
+ */
+gboolean cb_drop_file(GtkDropTarget* self, const GValue* value, double x, double y, void* data);
+
+/**
  * Clears all highlighted links when the inputbar gets closed
  *
  * @param GtkWidget* Inputbar widget

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -209,6 +209,11 @@ static bool init_ui(zathura_t* zathura) {
   gtk_event_controller_set_propagation_phase(GTK_EVENT_CONTROLLER(zoom), GTK_PHASE_BUBBLE);
   gtk_widget_add_controller(GTK_WIDGET(zathura->ui.session->gtk.view), GTK_EVENT_CONTROLLER(zoom));
 
+  /* allow dropping a file onto the window to open it */
+  GtkDropTarget* drop_target = gtk_drop_target_new(GDK_TYPE_FILE_LIST, GDK_ACTION_COPY);
+  g_signal_connect(drop_target, "drop", G_CALLBACK(cb_drop_file), zathura);
+  gtk_widget_add_controller(GTK_WIDGET(zathura->ui.session->gtk.view), GTK_EVENT_CONTROLLER(drop_target));
+
   /* zathura signals */
   zathura->signals.refresh_view = g_signal_new("refresh-view", GTK_TYPE_WIDGET, G_SIGNAL_RUN_LAST, 0, NULL, NULL,
                                                g_cclosure_marshal_generic, G_TYPE_NONE, 1, G_TYPE_POINTER);


### PR DESCRIPTION
This PR adds support for dropping a document from a file manager onto a running zathura, to open it in that window.

I registered a `GtkDropTarget` on the main view and on drop I close the current document (like `:open` does) and open the dropped file. When multiple files are dropped only the first one in list is used.

Made this since I'm used to image viewers letting me do this, just quickly switching between files