### PR TITLE
minor fixes

### DIFF
--- a/zathura/jumplist.c
+++ b/zathura/jumplist.c
@@ -187,5 +187,6 @@ void zathura_jumplist_free(zathura_t* zathura) {
 
   /* remove jump list */
   zathura_jumplist_clear(zathura);
+  girara_list_free(zathura->jumplist.list);
   zathura->jumplist.list = NULL;
 }

--- a/zathura/zathura.c
+++ b/zathura/zathura.c
@@ -924,7 +924,7 @@ bool document_open(zathura_t* zathura, const char* path, const char* uri, const 
   if (page_number < 0) {
     page_number += number_of_pages;
   }
-  if ((unsigned)page_number > number_of_pages) {
+  if ((unsigned)page_number >= number_of_pages) {
     girara_warning("document info: '%s' has an invalid page number", file_path);
     zathura_document_set_current_page_number(document, 0);
   } else {


### PR DESCRIPTION
Fixes one off-by-one page bound in document_open and a jumplist container leak at shutdown.